### PR TITLE
Fix casing when exporting modules

### DIFF
--- a/.changeset/red-ears-argue.md
+++ b/.changeset/red-ears-argue.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-js': patch
+---
+
+Fix bug that did not camelcase exported modules properly

--- a/src/fragments/indexPage.ts
+++ b/src/fragments/indexPage.ts
@@ -1,12 +1,12 @@
-import { CamelCaseString } from '@codama/nodes';
+import { camelCase } from '@codama/nodes';
 
 import { Fragment, getExportAllFragment, mergeFragments } from '../utils';
 
-export function getIndexPageFragment(items: { name: CamelCaseString }[]): Fragment | undefined {
+export function getIndexPageFragment(items: { name: string }[]): Fragment | undefined {
     if (items.length === 0) return;
 
     const names = items
-        .map(item => item.name)
+        .map(item => camelCase(item.name))
         .sort((a, b) => a.localeCompare(b))
         .map(name => getExportAllFragment(`./${name}`));
 


### PR DESCRIPTION
This PR fixes an issues when generating files that export modules as some of the names may not have been camelcased properly.