### PR TITLE
Use programId override from PdaValueNode when set

### DIFF
--- a/.changeset/wicked-onions-camp.md
+++ b/.changeset/wicked-onions-camp.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-js': minor
+---
+
+Use the programId attribute of the PdaValueNode when provided to render default values. This enables PDA derivations to set the program address to another account in the same instruction.

--- a/package.json
+++ b/package.json
@@ -50,15 +50,15 @@
         "test:unit": "vitest run"
     },
     "dependencies": {
-        "@codama/errors": "^1.3.7",
-        "@codama/nodes": "^1.3.7",
-        "@codama/renderers-core": "^1.2.2",
-        "@codama/visitors-core": "^1.3.7",
+        "@codama/errors": "^1.4.0",
+        "@codama/nodes": "^1.4.0",
+        "@codama/renderers-core": "^1.2.4",
+        "@codama/visitors-core": "^1.4.0",
         "@solana/codecs-strings": "^5.0.0",
         "prettier": "^3.6.2"
     },
     "devDependencies": {
-        "@codama/nodes-from-anchor": "^1.2.9",
+        "@codama/nodes-from-anchor": "^1.3.0",
         "@changesets/changelog-github": "^0.5.1",
         "@changesets/cli": "^2.29.7",
         "@solana/eslint-config-solana": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,17 +9,17 @@ importers:
   .:
     dependencies:
       '@codama/errors':
-        specifier: ^1.3.7
-        version: 1.3.8
+        specifier: ^1.4.0
+        version: 1.4.0
       '@codama/nodes':
-        specifier: ^1.3.7
-        version: 1.3.8
+        specifier: ^1.4.0
+        version: 1.4.0
       '@codama/renderers-core':
-        specifier: ^1.2.2
-        version: 1.2.3
+        specifier: ^1.2.4
+        version: 1.2.4
       '@codama/visitors-core':
-        specifier: ^1.3.7
-        version: 1.3.8
+        specifier: ^1.4.0
+        version: 1.4.0
       '@solana/codecs-strings':
         specifier: ^5.0.0
         version: 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -34,8 +34,8 @@ importers:
         specifier: ^2.29.7
         version: 2.29.7(@types/node@24.10.1)
       '@codama/nodes-from-anchor':
-        specifier: ^1.2.9
-        version: 1.2.10(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+        specifier: ^1.3.0
+        version: 1.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/eslint-config-solana':
         specifier: ^5.0.0
         version: 5.0.0(@eslint/js@9.39.1)(@types/eslint__js@8.42.3)(eslint-plugin-jest@29.0.1(@typescript-eslint/eslint-plugin@8.43.0(@typescript-eslint/parser@8.43.0(eslint@9.39.1)(typescript@5.9.3))(eslint@9.39.1)(typescript@5.9.3))(eslint@9.39.1)(jest@30.1.3(@types/node@24.10.1))(typescript@5.9.3))(eslint-plugin-react-hooks@5.2.0(eslint@9.39.1))(eslint-plugin-simple-import-sort@12.1.1(eslint@9.39.1))(eslint-plugin-sort-keys-fix@1.1.2)(eslint-plugin-typescript-sort-keys@3.3.0(@typescript-eslint/parser@8.43.0(eslint@9.39.1)(typescript@5.9.3))(eslint@9.39.1)(typescript@5.9.3))(eslint@9.39.1)(globals@14.0.0)(jest@30.1.3(@types/node@24.10.1))(typescript-eslint@8.43.0(eslint@9.39.1)(typescript@5.9.3))(typescript@5.9.3)
@@ -299,27 +299,27 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@codama/errors@1.3.8':
-    resolution: {integrity: sha512-jI4/ZfERPKkpBNuvv7GOZSXPjSWj2eng5bKv2uE43gJH6LGM7v3h0egNGCt31pMFAddSme0NYVyymwEHgbeZiQ==}
+  '@codama/errors@1.4.0':
+    resolution: {integrity: sha512-w0WUrFJhIZUoYuyMTX1ls+qYaU6e3hrTzyeu/KS818wYY50HvdyLxLXhDAhHR/CF9MdNz6XyZpKAMOZDPmxqOw==}
     hasBin: true
 
-  '@codama/node-types@1.3.8':
-    resolution: {integrity: sha512-seWqt37DUm3bkqI9sZZ3x/Ujyfbjndgg2jtcXRz6vWATQ6ofnWv4UT7BWBO/gEMXAAVisSscA8eRalnkURWZaA==}
+  '@codama/node-types@1.4.0':
+    resolution: {integrity: sha512-h5yNdI6CmSWwjyVQ03b15faI6xC35ytqOzTQQ09uA6GUnsQyESce3nZGbrwGy9Gape12JfFdmsxziVtLB0Ldkg==}
 
-  '@codama/nodes-from-anchor@1.2.10':
-    resolution: {integrity: sha512-M5FfJd2Nlb3xztEcA1aFs/sHp9X+AVcS3bU9k9y8ukdSWJnuApWezzIcuqJVWbE8h+Eax4Qxe0Rrvk26ocLBEw==}
+  '@codama/nodes-from-anchor@1.3.0':
+    resolution: {integrity: sha512-CgHXC4cdhQGectfA3Me5nc1uBQF81p0Wu+ibuGuVDXdU55sbExUaGVkMLO1znnLvV5EutAoDzV1rhnDuhEyWcA==}
 
-  '@codama/nodes@1.3.8':
-    resolution: {integrity: sha512-rEffpMmhxicc4i7jVBhEBslKzw9JTGp8UocCspvYu/vI9NQyxd3e2P1eJd1j4XlYsEnyNv2zZS2/UKsVgLCVEA==}
+  '@codama/nodes@1.4.0':
+    resolution: {integrity: sha512-4v51bD/awhDqKzKjTOf84f4wzkLrs4WodU0HNT33BcsP+gcbC+z+HSHBqVaDofjHpbkP8YlMP+4SRqU8utff8A==}
 
-  '@codama/renderers-core@1.2.3':
-    resolution: {integrity: sha512-xnll2+Ulse9Pa+QfzxuRosu3Ux82fuWxpIMHeoEtXDwkEHOghfbUoSlb7hPqPABWMiAywYLYZuEgWeZPwnRvQw==}
+  '@codama/renderers-core@1.2.4':
+    resolution: {integrity: sha512-mimXkXWRaWB5Uk+pptXtAwD1jfRvY7dK/oCqpV+UW0lbZuRU/OqpRIhYk+opiwpEb9duB7pwPDzZdIuKJbIDvg==}
 
-  '@codama/visitors-core@1.3.8':
-    resolution: {integrity: sha512-JVA3Lf9/M/STgc3t/2HiI3cvUKjyByBhcjlOcOI6RrhaLIX2g418REyGdsJz9aRwKNNSzADzX3dhlDyLq0h6lQ==}
+  '@codama/visitors-core@1.4.0':
+    resolution: {integrity: sha512-971xAqXuBbfGLB5DUNIB2X66MEWE+NF22blkNgoXgOCm1XfKr50MTkvF1nYiFxa4+09AS621rybppqQRmOqPsw==}
 
-  '@codama/visitors@1.3.8':
-    resolution: {integrity: sha512-X+x3vQnkM6zA5dWj4X9KLAKF7+2BstwLBPJUCnOrUfn3k0cEqJov2NxnmtgHi0VQNFYKbVEilWVVP3YTOdTvbA==}
+  '@codama/visitors@1.4.0':
+    resolution: {integrity: sha512-KM/dWSV7a/zet7blGtiyMQHIUmFmJDtbAFY9ISRmaSuCJ9RsfoF4RyjjKjY1ON5GVsG25bGUdXdnqXd1JTFM7g==}
 
   '@emnapi/core@1.7.1':
     resolution: {integrity: sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==}
@@ -832,9 +832,9 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@noble/hashes@1.8.0':
-    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
-    engines: {node: ^14.21.3 || >=16}
+  '@noble/hashes@2.0.1':
+    resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
+    engines: {node: '>= 20.19.0'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -3426,47 +3426,47 @@ snapshots:
       human-id: 4.1.1
       prettier: 2.8.8
 
-  '@codama/errors@1.3.8':
+  '@codama/errors@1.4.0':
     dependencies:
-      '@codama/node-types': 1.3.8
+      '@codama/node-types': 1.4.0
       commander: 14.0.2
       picocolors: 1.1.1
 
-  '@codama/node-types@1.3.8': {}
+  '@codama/node-types@1.4.0': {}
 
-  '@codama/nodes-from-anchor@1.2.10(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+  '@codama/nodes-from-anchor@1.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
-      '@codama/errors': 1.3.8
-      '@codama/nodes': 1.3.8
-      '@codama/visitors': 1.3.8
-      '@noble/hashes': 1.8.0
+      '@codama/errors': 1.4.0
+      '@codama/nodes': 1.4.0
+      '@codama/visitors': 1.4.0
+      '@noble/hashes': 2.0.1
       '@solana/codecs': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - typescript
 
-  '@codama/nodes@1.3.8':
+  '@codama/nodes@1.4.0':
     dependencies:
-      '@codama/errors': 1.3.8
-      '@codama/node-types': 1.3.8
+      '@codama/errors': 1.4.0
+      '@codama/node-types': 1.4.0
 
-  '@codama/renderers-core@1.2.3':
+  '@codama/renderers-core@1.2.4':
     dependencies:
-      '@codama/errors': 1.3.8
-      '@codama/nodes': 1.3.8
-      '@codama/visitors-core': 1.3.8
+      '@codama/errors': 1.4.0
+      '@codama/nodes': 1.4.0
+      '@codama/visitors-core': 1.4.0
 
-  '@codama/visitors-core@1.3.8':
+  '@codama/visitors-core@1.4.0':
     dependencies:
-      '@codama/errors': 1.3.8
-      '@codama/nodes': 1.3.8
+      '@codama/errors': 1.4.0
+      '@codama/nodes': 1.4.0
       json-stable-stringify: 1.3.0
 
-  '@codama/visitors@1.3.8':
+  '@codama/visitors@1.4.0':
     dependencies:
-      '@codama/errors': 1.3.8
-      '@codama/nodes': 1.3.8
-      '@codama/visitors-core': 1.3.8
+      '@codama/errors': 1.4.0
+      '@codama/nodes': 1.4.0
+      '@codama/visitors-core': 1.4.0
 
   '@emnapi/core@1.7.1':
     dependencies:
@@ -3950,7 +3950,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@noble/hashes@1.8.0': {}
+  '@noble/hashes@2.0.1': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:


### PR DESCRIPTION
This PR makes use of the latest `programId` attribute from the `PdaValueNode` when rendering default values in generated instruction helpers.

This enables us to set the program address of a PDA derivation to another account in the same instruction.

See https://github.com/codama-idl/codama/pull/915