### PR TITLE
Use latest RenderMap type from renderers-core

### DIFF
--- a/.changeset/clean-dancers-go.md
+++ b/.changeset/clean-dancers-go.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-js': patch
+---
+
+Use latest RenderMap type from renderers-core

--- a/package.json
+++ b/package.json
@@ -50,15 +50,15 @@
         "test:unit": "vitest run"
     },
     "dependencies": {
-        "@codama/errors": "^1.4.0",
-        "@codama/nodes": "^1.4.0",
-        "@codama/renderers-core": "^1.2.4",
-        "@codama/visitors-core": "^1.4.0",
+        "@codama/errors": "^1.4.1",
+        "@codama/nodes": "^1.4.1",
+        "@codama/renderers-core": "^1.3.0",
+        "@codama/visitors-core": "^1.4.1",
         "@solana/codecs-strings": "^5.0.0",
         "prettier": "^3.6.2"
     },
     "devDependencies": {
-        "@codama/nodes-from-anchor": "^1.3.0",
+        "@codama/nodes-from-anchor": "^1.3.3",
         "@changesets/changelog-github": "^0.5.1",
         "@changesets/cli": "^2.29.7",
         "@solana/eslint-config-solana": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,16 +9,16 @@ importers:
   .:
     dependencies:
       '@codama/errors':
-        specifier: ^1.4.0
+        specifier: ^1.4.1
         version: 1.4.1
       '@codama/nodes':
-        specifier: ^1.4.0
+        specifier: ^1.4.1
         version: 1.4.1
       '@codama/renderers-core':
-        specifier: ^1.2.4
-        version: 1.2.5
+        specifier: ^1.3.0
+        version: 1.3.0
       '@codama/visitors-core':
-        specifier: ^1.4.0
+        specifier: ^1.4.1
         version: 1.4.1
       '@solana/codecs-strings':
         specifier: ^5.0.0
@@ -34,8 +34,8 @@ importers:
         specifier: ^2.29.7
         version: 2.29.7(@types/node@24.10.1)
       '@codama/nodes-from-anchor':
-        specifier: ^1.3.0
-        version: 1.3.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+        specifier: ^1.3.3
+        version: 1.3.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/eslint-config-solana':
         specifier: ^5.0.0
         version: 5.0.0(@eslint/js@9.39.1)(@types/eslint__js@8.42.3)(eslint-plugin-jest@29.0.1(@typescript-eslint/eslint-plugin@8.43.0(@typescript-eslint/parser@8.43.0(eslint@9.39.1)(typescript@5.9.3))(eslint@9.39.1)(typescript@5.9.3))(eslint@9.39.1)(jest@30.1.3(@types/node@24.10.1))(typescript@5.9.3))(eslint-plugin-react-hooks@5.2.0(eslint@9.39.1))(eslint-plugin-simple-import-sort@12.1.1(eslint@9.39.1))(eslint-plugin-sort-keys-fix@1.1.2)(eslint-plugin-typescript-sort-keys@3.3.0(@typescript-eslint/parser@8.43.0(eslint@9.39.1)(typescript@5.9.3))(eslint@9.39.1)(typescript@5.9.3))(eslint@9.39.1)(globals@14.0.0)(jest@30.1.3(@types/node@24.10.1))(typescript-eslint@8.43.0(eslint@9.39.1)(typescript@5.9.3))(typescript@5.9.3)
@@ -306,14 +306,14 @@ packages:
   '@codama/node-types@1.4.1':
     resolution: {integrity: sha512-eqPKI1pZR+xaYHytMQUhW+DHmmhLhzVNTN9Cs+VpJV4NArJBrmx3Yht39tjT9Ul7eS9jGmBO1lodFxSCRKV4sQ==}
 
-  '@codama/nodes-from-anchor@1.3.1':
-    resolution: {integrity: sha512-PTpSn6pmAReb1d9uzyzvCC6xjcC/W3KJ2jNIIfJkaMYyx0sE2o6OP0Ql3Du130TzSd7SpPVGj0MS8EyINq+GUA==}
+  '@codama/nodes-from-anchor@1.3.3':
+    resolution: {integrity: sha512-PjnpYddndQABPFoslEyiygGapl0UlFh8Ng5o0HKmb7WvrEaTN0gqTP5Za/fNT3Kf7PUrafF85vKS6UMaYAhLpQ==}
 
   '@codama/nodes@1.4.1':
     resolution: {integrity: sha512-gqr87Neh3g0+0nubVC3j4JNT99xC4flv72Z8Yjplz5vxoU+IncE3Rsv3mr8V1AC0k8fv5/ND21OcSOK44Wbh2g==}
 
-  '@codama/renderers-core@1.2.5':
-    resolution: {integrity: sha512-MJ+PjUSalPuperZFeH9t7vNY/HXUv0QfVjVAIvi+Z4ey51hLPyzSLg4IYq96hYvLpTomMp4socpVecKoyOgzrA==}
+  '@codama/renderers-core@1.3.0':
+    resolution: {integrity: sha512-39ugOM7c6AT5h6azC8lix6YGA17u8wSsCzJbDrShTzRgz+QHWVF1Uci/v4CEcesEHgGQigP6f1jGAnEoTb/gcQ==}
 
   '@codama/visitors-core@1.4.1':
     resolution: {integrity: sha512-1IzVQlr4gxv4QQcZE98NZqTS2QLH3FdXzPvIi3Y9o34zyS9cCgdif5/nGAd1Q35uVQJSTV5UcIJ/a0dWqLNaFg==}
@@ -3543,7 +3543,7 @@ snapshots:
 
   '@codama/node-types@1.4.1': {}
 
-  '@codama/nodes-from-anchor@1.3.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+  '@codama/nodes-from-anchor@1.3.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@codama/errors': 1.4.1
       '@codama/nodes': 1.4.1
@@ -3559,7 +3559,7 @@ snapshots:
       '@codama/errors': 1.4.1
       '@codama/node-types': 1.4.1
 
-  '@codama/renderers-core@1.2.5':
+  '@codama/renderers-core@1.3.0':
     dependencies:
       '@codama/errors': 1.4.1
       '@codama/nodes': 1.4.1

--- a/src/visitors/getRenderMapVisitor.ts
+++ b/src/visitors/getRenderMapVisitor.ts
@@ -82,7 +82,7 @@ export function getRenderMapVisitor(options: GetRenderMapOptions = {}) {
     };
 
     return pipe(
-        staticVisitor(() => createRenderMap(), {
+        staticVisitor(() => createRenderMap<Fragment>(), {
             keys: ['rootNode', 'programNode', 'pdaNode', 'accountNode', 'definedTypeNode', 'instructionNode'],
         }),
         v =>

--- a/test/_setup.ts
+++ b/test/_setup.ts
@@ -5,6 +5,8 @@ import * as typeScriptPlugin from 'prettier/plugins/typescript';
 import { format } from 'prettier/standalone';
 import { expect } from 'vitest';
 
+import type { Fragment } from '../src/utils';
+
 const PRETTIER_OPTIONS: Parameters<typeof format>[1] = {
     arrowParens: 'always',
     parser: 'typescript',
@@ -17,18 +19,22 @@ const PRETTIER_OPTIONS: Parameters<typeof format>[1] = {
     useTabs: false,
 };
 
-export function renderMapContains(renderMap: RenderMap, key: string, expected: (RegExp | string)[] | RegExp | string) {
-    expect(renderMap.has(key), `RenderMap is missing key "${key}".`).toBe(true);
-    return codeContains(getFromRenderMap(renderMap, key), expected);
-}
-
-export function renderMapDoesNotContain(
-    renderMap: RenderMap,
+export function renderMapContains(
+    renderMap: RenderMap<Fragment>,
     key: string,
     expected: (RegExp | string)[] | RegExp | string,
 ) {
     expect(renderMap.has(key), `RenderMap is missing key "${key}".`).toBe(true);
-    return codeDoesNotContain(getFromRenderMap(renderMap, key), expected);
+    return codeContains(getFromRenderMap(renderMap, key).content, expected);
+}
+
+export function renderMapDoesNotContain(
+    renderMap: RenderMap<Fragment>,
+    key: string,
+    expected: (RegExp | string)[] | RegExp | string,
+) {
+    expect(renderMap.has(key), `RenderMap is missing key "${key}".`).toBe(true);
+    return codeDoesNotContain(getFromRenderMap(renderMap, key).content, expected);
 }
 
 export async function codeContains(actual: string, expected: (RegExp | string)[] | RegExp | string) {
@@ -55,18 +61,22 @@ export async function codeDoesNotContain(actual: string, expected: (RegExp | str
     });
 }
 
-export function renderMapContainsImports(renderMap: RenderMap, key: string, expectedImports: Record<string, string[]>) {
-    expect(renderMap.has(key), `RenderMap is missing key "${key}".`).toBe(true);
-    return codeContainsImports(getFromRenderMap(renderMap, key), expectedImports);
-}
-
-export function renderMapDoesNotContainImports(
-    renderMap: RenderMap,
+export function renderMapContainsImports(
+    renderMap: RenderMap<Fragment>,
     key: string,
     expectedImports: Record<string, string[]>,
 ) {
     expect(renderMap.has(key), `RenderMap is missing key "${key}".`).toBe(true);
-    return codeDoesNotContainImports(getFromRenderMap(renderMap, key), expectedImports);
+    return codeContainsImports(getFromRenderMap(renderMap, key).content, expectedImports);
+}
+
+export function renderMapDoesNotContainImports(
+    renderMap: RenderMap<Fragment>,
+    key: string,
+    expectedImports: Record<string, string[]>,
+) {
+    expect(renderMap.has(key), `RenderMap is missing key "${key}".`).toBe(true);
+    return codeDoesNotContainImports(getFromRenderMap(renderMap, key).content, expectedImports);
 }
 
 export async function codeContainsImports(actual: string, expectedImports: Record<string, string[]>) {

--- a/test/instructionsPage.test.ts
+++ b/test/instructionsPage.test.ts
@@ -110,7 +110,7 @@ test('it renders the args variable on the async function only if the extra argum
     const renderMap = visit(node, getRenderMapVisitor({ asyncResolvers: ['myAsyncResolver'] }));
 
     // And split the async and sync functions.
-    const [asyncFunction, syncFunction] = getFromRenderMap(renderMap, 'instructions/create.ts').split(
+    const [asyncFunction, syncFunction] = getFromRenderMap(renderMap, 'instructions/create.ts').content.split(
         /export\s+function\s+getCreateInstruction/,
     );
 
@@ -150,7 +150,7 @@ test('it only renders the args variable on the async function if the extra argum
     const renderMap = visit(node, getRenderMapVisitor({ asyncResolvers: ['myAsyncResolver'] }));
 
     // And split the async and sync functions.
-    const [asyncFunction, syncFunction] = getFromRenderMap(renderMap, 'instructions/create.ts').split(
+    const [asyncFunction, syncFunction] = getFromRenderMap(renderMap, 'instructions/create.ts').content.split(
         /export\s+function\s+getCreateInstruction/,
     );
 


### PR DESCRIPTION
This PR bumps the `renderers-core` package and updates the use of `RenderMaps` to its latest definition.