### PR TITLE
Resolve Prettier options from packageFolder option

### DIFF
--- a/.changeset/wild-years-visit.md
+++ b/.changeset/wild-years-visit.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-js': patch
+---
+
+Resolve Prettier options from packageFolder option

--- a/src/utils/formatCode.ts
+++ b/src/utils/formatCode.ts
@@ -1,0 +1,47 @@
+import { mapRenderMapContentAsync, RenderMap } from '@codama/renderers-core';
+import { format, Plugin, resolveConfig } from 'prettier';
+import * as estreePlugin from 'prettier/plugins/estree';
+import * as typeScriptPlugin from 'prettier/plugins/typescript';
+
+import { Fragment } from './fragment';
+import { RenderOptions } from './options';
+
+export type PrettierOptions = Parameters<typeof format>[1];
+
+const DEFAULT_PRETTIER_OPTIONS: PrettierOptions = {
+    arrowParens: 'always',
+    parser: 'typescript',
+    plugins: [estreePlugin as Plugin<unknown>, typeScriptPlugin],
+    printWidth: 80,
+    semi: true,
+    singleQuote: true,
+    tabWidth: 2,
+    trailingComma: 'es5',
+    useTabs: false,
+};
+
+export async function formatCode(
+    renderMap: RenderMap<Fragment>,
+    options: Pick<RenderOptions, 'formatCode' | 'packageFolder' | 'prettierOptions'>,
+): Promise<RenderMap<Fragment>> {
+    const shouldFormatCode = options.formatCode ?? true;
+    if (!shouldFormatCode) return renderMap;
+
+    const prettierOptions: PrettierOptions = {
+        ...DEFAULT_PRETTIER_OPTIONS,
+        ...(await resolvePrettierOptions(options.packageFolder)),
+        ...options.prettierOptions,
+    };
+
+    return await mapRenderMapContentAsync(renderMap, code => format(code, prettierOptions));
+}
+
+async function resolvePrettierOptions(packageFolder: string | undefined): Promise<PrettierOptions | null> {
+    if (!__NODEJS__) {
+        // In a non-NodeJS environment, we cannot load config files.
+        return null;
+    }
+
+    if (!packageFolder) return null;
+    return await resolveConfig(packageFolder);
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,7 @@
 export * from './async';
 export * from './codecs';
 export * from './customData';
+export * from './formatCode';
 export * from './fragment';
 export * from './importMap';
 export * from './linkOverrides';

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -1,13 +1,11 @@
 import type { CamelCaseString } from '@codama/nodes';
 import type { LinkableDictionary } from '@codama/visitors-core';
-import type { format } from 'prettier/standalone';
 
 import type { TypeManifestVisitor } from '../visitors';
 import type { CustomDataOptions, ParsedCustomDataOptions } from './customData';
+import { PrettierOptions } from './formatCode';
 import type { GetImportFromFunction, LinkOverrides } from './linkOverrides';
 import type { NameApi, NameTransformers } from './nameTransformers';
-
-type PrettierOptions = Parameters<typeof format>[1];
 
 export type RenderOptions = GetRenderMapOptions & {
     deleteFolderBeforeRendering?: boolean;

--- a/test/e2e/anchor/.prettierrc.json
+++ b/test/e2e/anchor/.prettierrc.json
@@ -1,9 +1,0 @@
-{
-  "semi": true,
-  "singleQuote": true,
-  "trailingComma": "es5",
-  "useTabs": false,
-  "tabWidth": 2,
-  "arrowParens": "always",
-  "printWidth": 80
-}

--- a/test/e2e/anchor/package.json
+++ b/test/e2e/anchor/package.json
@@ -10,6 +10,9 @@
     "lint": "eslint --ext js,ts,tsx src && prettier --check src test",
     "lint:fix": "eslint --fix --ext js,ts,tsx src && prettier --write src test"
   },
+  "dependencies": {
+    "@solana/kit": "^5.0.0"
+  },
   "license": "MIT",
   "ava": {
     "typescript": {
@@ -18,6 +21,5 @@
         "test/": "dist/test/"
       }
     }
-  },
-  "packageManager": "pnpm@9.1.0"
+  }
 }

--- a/test/e2e/anchor/src/generated/accounts/guardV1.ts
+++ b/test/e2e/anchor/src/generated/accounts/guardV1.ts
@@ -7,178 +7,167 @@
  */
 
 import {
-  assertAccountExists,
-  assertAccountsExist,
-  combineCodec,
-  decodeAccount,
-  fetchEncodedAccount,
-  fetchEncodedAccounts,
-  fixDecoderSize,
-  fixEncoderSize,
-  getAddressDecoder,
-  getAddressEncoder,
-  getArrayDecoder,
-  getArrayEncoder,
-  getBytesDecoder,
-  getBytesEncoder,
-  getOptionDecoder,
-  getOptionEncoder,
-  getStructDecoder,
-  getStructEncoder,
-  getU8Decoder,
-  getU8Encoder,
-  transformEncoder,
-  type Account,
-  type Address,
-  type Codec,
-  type Decoder,
-  type EncodedAccount,
-  type Encoder,
-  type FetchAccountConfig,
-  type FetchAccountsConfig,
-  type MaybeAccount,
-  type MaybeEncodedAccount,
-  type Option,
-  type OptionOrNullable,
-  type ReadonlyUint8Array,
+    assertAccountExists,
+    assertAccountsExist,
+    combineCodec,
+    decodeAccount,
+    fetchEncodedAccount,
+    fetchEncodedAccounts,
+    fixDecoderSize,
+    fixEncoderSize,
+    getAddressDecoder,
+    getAddressEncoder,
+    getArrayDecoder,
+    getArrayEncoder,
+    getBytesDecoder,
+    getBytesEncoder,
+    getOptionDecoder,
+    getOptionEncoder,
+    getStructDecoder,
+    getStructEncoder,
+    getU8Decoder,
+    getU8Encoder,
+    transformEncoder,
+    type Account,
+    type Address,
+    type Codec,
+    type Decoder,
+    type EncodedAccount,
+    type Encoder,
+    type FetchAccountConfig,
+    type FetchAccountsConfig,
+    type MaybeAccount,
+    type MaybeEncodedAccount,
+    type Option,
+    type OptionOrNullable,
+    type ReadonlyUint8Array,
 } from '@solana/kit';
 import {
-  getCpiRuleDecoder,
-  getCpiRuleEncoder,
-  getMetadataAdditionalFieldRuleDecoder,
-  getMetadataAdditionalFieldRuleEncoder,
-  getTransferAmountRuleDecoder,
-  getTransferAmountRuleEncoder,
-  type CpiRule,
-  type CpiRuleArgs,
-  type MetadataAdditionalFieldRule,
-  type MetadataAdditionalFieldRuleArgs,
-  type TransferAmountRule,
-  type TransferAmountRuleArgs,
+    getCpiRuleDecoder,
+    getCpiRuleEncoder,
+    getMetadataAdditionalFieldRuleDecoder,
+    getMetadataAdditionalFieldRuleEncoder,
+    getTransferAmountRuleDecoder,
+    getTransferAmountRuleEncoder,
+    type CpiRule,
+    type CpiRuleArgs,
+    type MetadataAdditionalFieldRule,
+    type MetadataAdditionalFieldRuleArgs,
+    type TransferAmountRule,
+    type TransferAmountRuleArgs,
 } from '../types';
 
-export const GUARD_V1_DISCRIMINATOR = new Uint8Array([
-  185, 149, 156, 78, 245, 108, 172, 68,
-]);
+export const GUARD_V1_DISCRIMINATOR = new Uint8Array([185, 149, 156, 78, 245, 108, 172, 68]);
 
 export function getGuardV1DiscriminatorBytes() {
-  return fixEncoderSize(getBytesEncoder(), 8).encode(GUARD_V1_DISCRIMINATOR);
+    return fixEncoderSize(getBytesEncoder(), 8).encode(GUARD_V1_DISCRIMINATOR);
 }
 
 export type GuardV1 = {
-  discriminator: ReadonlyUint8Array;
-  /** Mint token representing the guard, do not confuse with the mint of the token being transferred. */
-  mint: Address;
-  /** Bump seed for the guard account. */
-  bump: number;
-  /** CPI ruleset for the guard. */
-  cpiRule: Option<CpiRule>;
-  /** Transfer amount ruleset for the guard. */
-  transferAmountRule: Option<TransferAmountRule>;
-  /** Additional fields ruleset for the guard. */
-  additionalFieldsRule: Array<MetadataAdditionalFieldRule>;
+    discriminator: ReadonlyUint8Array;
+    /** Mint token representing the guard, do not confuse with the mint of the token being transferred. */
+    mint: Address;
+    /** Bump seed for the guard account. */
+    bump: number;
+    /** CPI ruleset for the guard. */
+    cpiRule: Option<CpiRule>;
+    /** Transfer amount ruleset for the guard. */
+    transferAmountRule: Option<TransferAmountRule>;
+    /** Additional fields ruleset for the guard. */
+    additionalFieldsRule: Array<MetadataAdditionalFieldRule>;
 };
 
 export type GuardV1Args = {
-  /** Mint token representing the guard, do not confuse with the mint of the token being transferred. */
-  mint: Address;
-  /** Bump seed for the guard account. */
-  bump: number;
-  /** CPI ruleset for the guard. */
-  cpiRule: OptionOrNullable<CpiRuleArgs>;
-  /** Transfer amount ruleset for the guard. */
-  transferAmountRule: OptionOrNullable<TransferAmountRuleArgs>;
-  /** Additional fields ruleset for the guard. */
-  additionalFieldsRule: Array<MetadataAdditionalFieldRuleArgs>;
+    /** Mint token representing the guard, do not confuse with the mint of the token being transferred. */
+    mint: Address;
+    /** Bump seed for the guard account. */
+    bump: number;
+    /** CPI ruleset for the guard. */
+    cpiRule: OptionOrNullable<CpiRuleArgs>;
+    /** Transfer amount ruleset for the guard. */
+    transferAmountRule: OptionOrNullable<TransferAmountRuleArgs>;
+    /** Additional fields ruleset for the guard. */
+    additionalFieldsRule: Array<MetadataAdditionalFieldRuleArgs>;
 };
 
 /** Gets the encoder for {@link GuardV1Args} account data. */
 export function getGuardV1Encoder(): Encoder<GuardV1Args> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', fixEncoderSize(getBytesEncoder(), 8)],
-      ['mint', getAddressEncoder()],
-      ['bump', getU8Encoder()],
-      ['cpiRule', getOptionEncoder(getCpiRuleEncoder())],
-      ['transferAmountRule', getOptionEncoder(getTransferAmountRuleEncoder())],
-      [
-        'additionalFieldsRule',
-        getArrayEncoder(getMetadataAdditionalFieldRuleEncoder()),
-      ],
-    ]),
-    (value) => ({ ...value, discriminator: GUARD_V1_DISCRIMINATOR })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', fixEncoderSize(getBytesEncoder(), 8)],
+            ['mint', getAddressEncoder()],
+            ['bump', getU8Encoder()],
+            ['cpiRule', getOptionEncoder(getCpiRuleEncoder())],
+            ['transferAmountRule', getOptionEncoder(getTransferAmountRuleEncoder())],
+            ['additionalFieldsRule', getArrayEncoder(getMetadataAdditionalFieldRuleEncoder())],
+        ]),
+        value => ({ ...value, discriminator: GUARD_V1_DISCRIMINATOR })
+    );
 }
 
 /** Gets the decoder for {@link GuardV1} account data. */
 export function getGuardV1Decoder(): Decoder<GuardV1> {
-  return getStructDecoder([
-    ['discriminator', fixDecoderSize(getBytesDecoder(), 8)],
-    ['mint', getAddressDecoder()],
-    ['bump', getU8Decoder()],
-    ['cpiRule', getOptionDecoder(getCpiRuleDecoder())],
-    ['transferAmountRule', getOptionDecoder(getTransferAmountRuleDecoder())],
-    [
-      'additionalFieldsRule',
-      getArrayDecoder(getMetadataAdditionalFieldRuleDecoder()),
-    ],
-  ]);
+    return getStructDecoder([
+        ['discriminator', fixDecoderSize(getBytesDecoder(), 8)],
+        ['mint', getAddressDecoder()],
+        ['bump', getU8Decoder()],
+        ['cpiRule', getOptionDecoder(getCpiRuleDecoder())],
+        ['transferAmountRule', getOptionDecoder(getTransferAmountRuleDecoder())],
+        ['additionalFieldsRule', getArrayDecoder(getMetadataAdditionalFieldRuleDecoder())],
+    ]);
 }
 
 /** Gets the codec for {@link GuardV1} account data. */
 export function getGuardV1Codec(): Codec<GuardV1Args, GuardV1> {
-  return combineCodec(getGuardV1Encoder(), getGuardV1Decoder());
+    return combineCodec(getGuardV1Encoder(), getGuardV1Decoder());
 }
 
 export function decodeGuardV1<TAddress extends string = string>(
-  encodedAccount: EncodedAccount<TAddress>
+    encodedAccount: EncodedAccount<TAddress>
 ): Account<GuardV1, TAddress>;
 export function decodeGuardV1<TAddress extends string = string>(
-  encodedAccount: MaybeEncodedAccount<TAddress>
+    encodedAccount: MaybeEncodedAccount<TAddress>
 ): MaybeAccount<GuardV1, TAddress>;
 export function decodeGuardV1<TAddress extends string = string>(
-  encodedAccount: EncodedAccount<TAddress> | MaybeEncodedAccount<TAddress>
+    encodedAccount: EncodedAccount<TAddress> | MaybeEncodedAccount<TAddress>
 ): Account<GuardV1, TAddress> | MaybeAccount<GuardV1, TAddress> {
-  return decodeAccount(
-    encodedAccount as MaybeEncodedAccount<TAddress>,
-    getGuardV1Decoder()
-  );
+    return decodeAccount(encodedAccount as MaybeEncodedAccount<TAddress>, getGuardV1Decoder());
 }
 
 export async function fetchGuardV1<TAddress extends string = string>(
-  rpc: Parameters<typeof fetchEncodedAccount>[0],
-  address: Address<TAddress>,
-  config?: FetchAccountConfig
+    rpc: Parameters<typeof fetchEncodedAccount>[0],
+    address: Address<TAddress>,
+    config?: FetchAccountConfig
 ): Promise<Account<GuardV1, TAddress>> {
-  const maybeAccount = await fetchMaybeGuardV1(rpc, address, config);
-  assertAccountExists(maybeAccount);
-  return maybeAccount;
+    const maybeAccount = await fetchMaybeGuardV1(rpc, address, config);
+    assertAccountExists(maybeAccount);
+    return maybeAccount;
 }
 
 export async function fetchMaybeGuardV1<TAddress extends string = string>(
-  rpc: Parameters<typeof fetchEncodedAccount>[0],
-  address: Address<TAddress>,
-  config?: FetchAccountConfig
+    rpc: Parameters<typeof fetchEncodedAccount>[0],
+    address: Address<TAddress>,
+    config?: FetchAccountConfig
 ): Promise<MaybeAccount<GuardV1, TAddress>> {
-  const maybeAccount = await fetchEncodedAccount(rpc, address, config);
-  return decodeGuardV1(maybeAccount);
+    const maybeAccount = await fetchEncodedAccount(rpc, address, config);
+    return decodeGuardV1(maybeAccount);
 }
 
 export async function fetchAllGuardV1(
-  rpc: Parameters<typeof fetchEncodedAccounts>[0],
-  addresses: Array<Address>,
-  config?: FetchAccountsConfig
+    rpc: Parameters<typeof fetchEncodedAccounts>[0],
+    addresses: Array<Address>,
+    config?: FetchAccountsConfig
 ): Promise<Account<GuardV1>[]> {
-  const maybeAccounts = await fetchAllMaybeGuardV1(rpc, addresses, config);
-  assertAccountsExist(maybeAccounts);
-  return maybeAccounts;
+    const maybeAccounts = await fetchAllMaybeGuardV1(rpc, addresses, config);
+    assertAccountsExist(maybeAccounts);
+    return maybeAccounts;
 }
 
 export async function fetchAllMaybeGuardV1(
-  rpc: Parameters<typeof fetchEncodedAccounts>[0],
-  addresses: Array<Address>,
-  config?: FetchAccountsConfig
+    rpc: Parameters<typeof fetchEncodedAccounts>[0],
+    addresses: Array<Address>,
+    config?: FetchAccountsConfig
 ): Promise<MaybeAccount<GuardV1>[]> {
-  const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
-  return maybeAccounts.map((maybeAccount) => decodeGuardV1(maybeAccount));
+    const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
+    return maybeAccounts.map(maybeAccount => decodeGuardV1(maybeAccount));
 }

--- a/test/e2e/anchor/src/generated/errors/wenTransferGuard.ts
+++ b/test/e2e/anchor/src/generated/errors/wenTransferGuard.ts
@@ -7,10 +7,10 @@
  */
 
 import {
-  isProgramError,
-  type Address,
-  type SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM,
-  type SolanaError,
+    isProgramError,
+    type Address,
+    type SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM,
+    type SolanaError,
 } from '@solana/kit';
 import { WEN_TRANSFER_GUARD_PROGRAM_ADDRESS } from '../programs';
 
@@ -32,57 +32,42 @@ export const WEN_TRANSFER_GUARD_ERROR__MUST_BE_INITIALIZED_BY_TRANSFER_HOOK_AUTH
 export const WEN_TRANSFER_GUARD_ERROR__MINT_ASSIGNED_TRANSFER_HOOK_PROGRAM_IS_NOT_THIS_ONE = 0x1777; // 6007
 
 export type WenTransferGuardError =
-  | typeof WEN_TRANSFER_GUARD_ERROR__CPI_RULE_ENFORCEMENT_FAILED
-  | typeof WEN_TRANSFER_GUARD_ERROR__GUARD_TOKEN_AMOUNT_SHOULD_BE_AT_LEAST_ONE
-  | typeof WEN_TRANSFER_GUARD_ERROR__METADATA_FIELD_DOES_NOT_EXIST
-  | typeof WEN_TRANSFER_GUARD_ERROR__METADATA_FIELD_DOES_NOT_PASS
-  | typeof WEN_TRANSFER_GUARD_ERROR__MINT_ASSIGNED_TRANSFER_HOOK_PROGRAM_IS_NOT_THIS_ONE
-  | typeof WEN_TRANSFER_GUARD_ERROR__MUST_BE_INITIALIZED_BY_TRANSFER_HOOK_AUTHORITY
-  | typeof WEN_TRANSFER_GUARD_ERROR__NOT_OWNED_BY_TOKEN2022_PROGRAM
-  | typeof WEN_TRANSFER_GUARD_ERROR__TRANSFER_AMOUNT_RULE_ENFORCE_FAILED;
+    | typeof WEN_TRANSFER_GUARD_ERROR__CPI_RULE_ENFORCEMENT_FAILED
+    | typeof WEN_TRANSFER_GUARD_ERROR__GUARD_TOKEN_AMOUNT_SHOULD_BE_AT_LEAST_ONE
+    | typeof WEN_TRANSFER_GUARD_ERROR__METADATA_FIELD_DOES_NOT_EXIST
+    | typeof WEN_TRANSFER_GUARD_ERROR__METADATA_FIELD_DOES_NOT_PASS
+    | typeof WEN_TRANSFER_GUARD_ERROR__MINT_ASSIGNED_TRANSFER_HOOK_PROGRAM_IS_NOT_THIS_ONE
+    | typeof WEN_TRANSFER_GUARD_ERROR__MUST_BE_INITIALIZED_BY_TRANSFER_HOOK_AUTHORITY
+    | typeof WEN_TRANSFER_GUARD_ERROR__NOT_OWNED_BY_TOKEN2022_PROGRAM
+    | typeof WEN_TRANSFER_GUARD_ERROR__TRANSFER_AMOUNT_RULE_ENFORCE_FAILED;
 
-let wenTransferGuardErrorMessages:
-  | Record<WenTransferGuardError, string>
-  | undefined;
+let wenTransferGuardErrorMessages: Record<WenTransferGuardError, string> | undefined;
 if (process.env.NODE_ENV !== 'production') {
-  wenTransferGuardErrorMessages = {
-    [WEN_TRANSFER_GUARD_ERROR__CPI_RULE_ENFORCEMENT_FAILED]: `Cpi Rule Enforcement Failed`,
-    [WEN_TRANSFER_GUARD_ERROR__GUARD_TOKEN_AMOUNT_SHOULD_BE_AT_LEAST_ONE]: `Guard token amount should be at least 1`,
-    [WEN_TRANSFER_GUARD_ERROR__METADATA_FIELD_DOES_NOT_EXIST]: `Metadata Field Does Not Exist`,
-    [WEN_TRANSFER_GUARD_ERROR__METADATA_FIELD_DOES_NOT_PASS]: `Metadata Field Does Not Pass`,
-    [WEN_TRANSFER_GUARD_ERROR__MINT_ASSIGNED_TRANSFER_HOOK_PROGRAM_IS_NOT_THIS_ONE]: `Mint's assigned Transfer Hook Program is not this one`,
-    [WEN_TRANSFER_GUARD_ERROR__MUST_BE_INITIALIZED_BY_TRANSFER_HOOK_AUTHORITY]: `Must be initialized by Transfer Hook Authority`,
-    [WEN_TRANSFER_GUARD_ERROR__NOT_OWNED_BY_TOKEN2022_PROGRAM]: `Not owned by token 2022 program`,
-    [WEN_TRANSFER_GUARD_ERROR__TRANSFER_AMOUNT_RULE_ENFORCE_FAILED]: `Transfer Amount Rule Enforce Failed`,
-  };
+    wenTransferGuardErrorMessages = {
+        [WEN_TRANSFER_GUARD_ERROR__CPI_RULE_ENFORCEMENT_FAILED]: `Cpi Rule Enforcement Failed`,
+        [WEN_TRANSFER_GUARD_ERROR__GUARD_TOKEN_AMOUNT_SHOULD_BE_AT_LEAST_ONE]: `Guard token amount should be at least 1`,
+        [WEN_TRANSFER_GUARD_ERROR__METADATA_FIELD_DOES_NOT_EXIST]: `Metadata Field Does Not Exist`,
+        [WEN_TRANSFER_GUARD_ERROR__METADATA_FIELD_DOES_NOT_PASS]: `Metadata Field Does Not Pass`,
+        [WEN_TRANSFER_GUARD_ERROR__MINT_ASSIGNED_TRANSFER_HOOK_PROGRAM_IS_NOT_THIS_ONE]: `Mint's assigned Transfer Hook Program is not this one`,
+        [WEN_TRANSFER_GUARD_ERROR__MUST_BE_INITIALIZED_BY_TRANSFER_HOOK_AUTHORITY]: `Must be initialized by Transfer Hook Authority`,
+        [WEN_TRANSFER_GUARD_ERROR__NOT_OWNED_BY_TOKEN2022_PROGRAM]: `Not owned by token 2022 program`,
+        [WEN_TRANSFER_GUARD_ERROR__TRANSFER_AMOUNT_RULE_ENFORCE_FAILED]: `Transfer Amount Rule Enforce Failed`,
+    };
 }
 
-export function getWenTransferGuardErrorMessage(
-  code: WenTransferGuardError
-): string {
-  if (process.env.NODE_ENV !== 'production') {
-    return (
-      wenTransferGuardErrorMessages as Record<WenTransferGuardError, string>
-    )[code];
-  }
+export function getWenTransferGuardErrorMessage(code: WenTransferGuardError): string {
+    if (process.env.NODE_ENV !== 'production') {
+        return (wenTransferGuardErrorMessages as Record<WenTransferGuardError, string>)[code];
+    }
 
-  return 'Error message not available in production bundles.';
+    return 'Error message not available in production bundles.';
 }
 
-export function isWenTransferGuardError<
-  TProgramErrorCode extends WenTransferGuardError,
->(
-  error: unknown,
-  transactionMessage: {
-    instructions: Record<number, { programAddress: Address }>;
-  },
-  code?: TProgramErrorCode
+export function isWenTransferGuardError<TProgramErrorCode extends WenTransferGuardError>(
+    error: unknown,
+    transactionMessage: { instructions: Record<number, { programAddress: Address }> },
+    code?: TProgramErrorCode
 ): error is SolanaError<typeof SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM> &
-  Readonly<{ context: Readonly<{ code: TProgramErrorCode }> }> {
-  return isProgramError<TProgramErrorCode>(
-    error,
-    transactionMessage,
-    WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
-    code
-  );
+    Readonly<{ context: Readonly<{ code: TProgramErrorCode }> }> {
+    return isProgramError<TProgramErrorCode>(error, transactionMessage, WEN_TRANSFER_GUARD_PROGRAM_ADDRESS, code);
 }

--- a/test/e2e/anchor/src/generated/instructions/createGuard.ts
+++ b/test/e2e/anchor/src/generated/instructions/createGuard.ts
@@ -7,467 +7,354 @@
  */
 
 import {
-  addDecoderSizePrefix,
-  addEncoderSizePrefix,
-  combineCodec,
-  fixDecoderSize,
-  fixEncoderSize,
-  getAddressEncoder,
-  getArrayDecoder,
-  getArrayEncoder,
-  getBytesDecoder,
-  getBytesEncoder,
-  getOptionDecoder,
-  getOptionEncoder,
-  getProgramDerivedAddress,
-  getStructDecoder,
-  getStructEncoder,
-  getU32Decoder,
-  getU32Encoder,
-  getUtf8Decoder,
-  getUtf8Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type Codec,
-  type Decoder,
-  type Encoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type Option,
-  type OptionOrNullable,
-  type ReadonlyAccount,
-  type ReadonlySignerAccount,
-  type ReadonlyUint8Array,
-  type TransactionSigner,
-  type WritableAccount,
-  type WritableSignerAccount,
+    addDecoderSizePrefix,
+    addEncoderSizePrefix,
+    combineCodec,
+    fixDecoderSize,
+    fixEncoderSize,
+    getAddressEncoder,
+    getArrayDecoder,
+    getArrayEncoder,
+    getBytesDecoder,
+    getBytesEncoder,
+    getOptionDecoder,
+    getOptionEncoder,
+    getProgramDerivedAddress,
+    getStructDecoder,
+    getStructEncoder,
+    getU32Decoder,
+    getU32Encoder,
+    getUtf8Decoder,
+    getUtf8Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type Codec,
+    type Decoder,
+    type Encoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type Option,
+    type OptionOrNullable,
+    type ReadonlyAccount,
+    type ReadonlySignerAccount,
+    type ReadonlyUint8Array,
+    type TransactionSigner,
+    type WritableAccount,
+    type WritableSignerAccount,
 } from '@solana/kit';
 import { WEN_TRANSFER_GUARD_PROGRAM_ADDRESS } from '../programs';
+import { expectAddress, getAccountMetaFactory, type ResolvedAccount } from '../shared';
 import {
-  expectAddress,
-  getAccountMetaFactory,
-  type ResolvedAccount,
-} from '../shared';
-import {
-  getCpiRuleDecoder,
-  getCpiRuleEncoder,
-  getMetadataAdditionalFieldRuleDecoder,
-  getMetadataAdditionalFieldRuleEncoder,
-  getTransferAmountRuleDecoder,
-  getTransferAmountRuleEncoder,
-  type CpiRule,
-  type CpiRuleArgs,
-  type MetadataAdditionalFieldRule,
-  type MetadataAdditionalFieldRuleArgs,
-  type TransferAmountRule,
-  type TransferAmountRuleArgs,
+    getCpiRuleDecoder,
+    getCpiRuleEncoder,
+    getMetadataAdditionalFieldRuleDecoder,
+    getMetadataAdditionalFieldRuleEncoder,
+    getTransferAmountRuleDecoder,
+    getTransferAmountRuleEncoder,
+    type CpiRule,
+    type CpiRuleArgs,
+    type MetadataAdditionalFieldRule,
+    type MetadataAdditionalFieldRuleArgs,
+    type TransferAmountRule,
+    type TransferAmountRuleArgs,
 } from '../types';
 
-export const CREATE_GUARD_DISCRIMINATOR = new Uint8Array([
-  251, 254, 17, 198, 219, 218, 154, 99,
-]);
+export const CREATE_GUARD_DISCRIMINATOR = new Uint8Array([251, 254, 17, 198, 219, 218, 154, 99]);
 
 export function getCreateGuardDiscriminatorBytes() {
-  return fixEncoderSize(getBytesEncoder(), 8).encode(
-    CREATE_GUARD_DISCRIMINATOR
-  );
+    return fixEncoderSize(getBytesEncoder(), 8).encode(CREATE_GUARD_DISCRIMINATOR);
 }
 
 export type CreateGuardInstruction<
-  TProgram extends string = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
-  TAccountGuard extends string | AccountMeta<string> = string,
-  TAccountMint extends string | AccountMeta<string> = string,
-  TAccountMintTokenAccount extends string | AccountMeta<string> = string,
-  TAccountGuardAuthority extends string | AccountMeta<string> = string,
-  TAccountPayer extends string | AccountMeta<string> = string,
-  TAccountAssociatedTokenProgram extends string | AccountMeta<string> =
-    'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL',
-  TAccountTokenProgram extends string | AccountMeta<string> =
-    'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
-  TAccountSystemProgram extends string | AccountMeta<string> =
-    '11111111111111111111111111111111',
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+    TAccountGuard extends string | AccountMeta<string> = string,
+    TAccountMint extends string | AccountMeta<string> = string,
+    TAccountMintTokenAccount extends string | AccountMeta<string> = string,
+    TAccountGuardAuthority extends string | AccountMeta<string> = string,
+    TAccountPayer extends string | AccountMeta<string> = string,
+    TAccountAssociatedTokenProgram extends string | AccountMeta<string> =
+        'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL',
+    TAccountTokenProgram extends string | AccountMeta<string> = 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+    TAccountSystemProgram extends string | AccountMeta<string> = '11111111111111111111111111111111',
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountGuard extends string
-        ? WritableAccount<TAccountGuard>
-        : TAccountGuard,
-      TAccountMint extends string
-        ? WritableSignerAccount<TAccountMint> & AccountSignerMeta<TAccountMint>
-        : TAccountMint,
-      TAccountMintTokenAccount extends string
-        ? WritableAccount<TAccountMintTokenAccount>
-        : TAccountMintTokenAccount,
-      TAccountGuardAuthority extends string
-        ? ReadonlySignerAccount<TAccountGuardAuthority> &
-            AccountSignerMeta<TAccountGuardAuthority>
-        : TAccountGuardAuthority,
-      TAccountPayer extends string
-        ? WritableSignerAccount<TAccountPayer> &
-            AccountSignerMeta<TAccountPayer>
-        : TAccountPayer,
-      TAccountAssociatedTokenProgram extends string
-        ? ReadonlyAccount<TAccountAssociatedTokenProgram>
-        : TAccountAssociatedTokenProgram,
-      TAccountTokenProgram extends string
-        ? ReadonlyAccount<TAccountTokenProgram>
-        : TAccountTokenProgram,
-      TAccountSystemProgram extends string
-        ? ReadonlyAccount<TAccountSystemProgram>
-        : TAccountSystemProgram,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountGuard extends string ? WritableAccount<TAccountGuard> : TAccountGuard,
+            TAccountMint extends string
+                ? WritableSignerAccount<TAccountMint> & AccountSignerMeta<TAccountMint>
+                : TAccountMint,
+            TAccountMintTokenAccount extends string
+                ? WritableAccount<TAccountMintTokenAccount>
+                : TAccountMintTokenAccount,
+            TAccountGuardAuthority extends string
+                ? ReadonlySignerAccount<TAccountGuardAuthority> & AccountSignerMeta<TAccountGuardAuthority>
+                : TAccountGuardAuthority,
+            TAccountPayer extends string
+                ? WritableSignerAccount<TAccountPayer> & AccountSignerMeta<TAccountPayer>
+                : TAccountPayer,
+            TAccountAssociatedTokenProgram extends string
+                ? ReadonlyAccount<TAccountAssociatedTokenProgram>
+                : TAccountAssociatedTokenProgram,
+            TAccountTokenProgram extends string ? ReadonlyAccount<TAccountTokenProgram> : TAccountTokenProgram,
+            TAccountSystemProgram extends string ? ReadonlyAccount<TAccountSystemProgram> : TAccountSystemProgram,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type CreateGuardInstructionData = {
-  discriminator: ReadonlyUint8Array;
-  name: string;
-  symbol: string;
-  uri: string;
-  cpiRule: Option<CpiRule>;
-  transferAmountRule: Option<TransferAmountRule>;
-  additionalFieldsRule: Array<MetadataAdditionalFieldRule>;
+    discriminator: ReadonlyUint8Array;
+    name: string;
+    symbol: string;
+    uri: string;
+    cpiRule: Option<CpiRule>;
+    transferAmountRule: Option<TransferAmountRule>;
+    additionalFieldsRule: Array<MetadataAdditionalFieldRule>;
 };
 
 export type CreateGuardInstructionDataArgs = {
-  name: string;
-  symbol: string;
-  uri: string;
-  cpiRule: OptionOrNullable<CpiRuleArgs>;
-  transferAmountRule: OptionOrNullable<TransferAmountRuleArgs>;
-  additionalFieldsRule: Array<MetadataAdditionalFieldRuleArgs>;
+    name: string;
+    symbol: string;
+    uri: string;
+    cpiRule: OptionOrNullable<CpiRuleArgs>;
+    transferAmountRule: OptionOrNullable<TransferAmountRuleArgs>;
+    additionalFieldsRule: Array<MetadataAdditionalFieldRuleArgs>;
 };
 
 export function getCreateGuardInstructionDataEncoder(): Encoder<CreateGuardInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', fixEncoderSize(getBytesEncoder(), 8)],
-      ['name', addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
-      ['symbol', addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
-      ['uri', addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
-      ['cpiRule', getOptionEncoder(getCpiRuleEncoder())],
-      ['transferAmountRule', getOptionEncoder(getTransferAmountRuleEncoder())],
-      [
-        'additionalFieldsRule',
-        getArrayEncoder(getMetadataAdditionalFieldRuleEncoder()),
-      ],
-    ]),
-    (value) => ({ ...value, discriminator: CREATE_GUARD_DISCRIMINATOR })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', fixEncoderSize(getBytesEncoder(), 8)],
+            ['name', addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
+            ['symbol', addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
+            ['uri', addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
+            ['cpiRule', getOptionEncoder(getCpiRuleEncoder())],
+            ['transferAmountRule', getOptionEncoder(getTransferAmountRuleEncoder())],
+            ['additionalFieldsRule', getArrayEncoder(getMetadataAdditionalFieldRuleEncoder())],
+        ]),
+        value => ({ ...value, discriminator: CREATE_GUARD_DISCRIMINATOR })
+    );
 }
 
 export function getCreateGuardInstructionDataDecoder(): Decoder<CreateGuardInstructionData> {
-  return getStructDecoder([
-    ['discriminator', fixDecoderSize(getBytesDecoder(), 8)],
-    ['name', addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())],
-    ['symbol', addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())],
-    ['uri', addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())],
-    ['cpiRule', getOptionDecoder(getCpiRuleDecoder())],
-    ['transferAmountRule', getOptionDecoder(getTransferAmountRuleDecoder())],
-    [
-      'additionalFieldsRule',
-      getArrayDecoder(getMetadataAdditionalFieldRuleDecoder()),
-    ],
-  ]);
+    return getStructDecoder([
+        ['discriminator', fixDecoderSize(getBytesDecoder(), 8)],
+        ['name', addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())],
+        ['symbol', addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())],
+        ['uri', addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())],
+        ['cpiRule', getOptionDecoder(getCpiRuleDecoder())],
+        ['transferAmountRule', getOptionDecoder(getTransferAmountRuleDecoder())],
+        ['additionalFieldsRule', getArrayDecoder(getMetadataAdditionalFieldRuleDecoder())],
+    ]);
 }
 
 export function getCreateGuardInstructionDataCodec(): Codec<
-  CreateGuardInstructionDataArgs,
-  CreateGuardInstructionData
+    CreateGuardInstructionDataArgs,
+    CreateGuardInstructionData
 > {
-  return combineCodec(
-    getCreateGuardInstructionDataEncoder(),
-    getCreateGuardInstructionDataDecoder()
-  );
+    return combineCodec(getCreateGuardInstructionDataEncoder(), getCreateGuardInstructionDataDecoder());
 }
 
 export type CreateGuardAsyncInput<
-  TAccountGuard extends string = string,
-  TAccountMint extends string = string,
-  TAccountMintTokenAccount extends string = string,
-  TAccountGuardAuthority extends string = string,
-  TAccountPayer extends string = string,
-  TAccountAssociatedTokenProgram extends string = string,
-  TAccountTokenProgram extends string = string,
-  TAccountSystemProgram extends string = string,
+    TAccountGuard extends string = string,
+    TAccountMint extends string = string,
+    TAccountMintTokenAccount extends string = string,
+    TAccountGuardAuthority extends string = string,
+    TAccountPayer extends string = string,
+    TAccountAssociatedTokenProgram extends string = string,
+    TAccountTokenProgram extends string = string,
+    TAccountSystemProgram extends string = string,
 > = {
-  guard?: Address<TAccountGuard>;
-  mint: TransactionSigner<TAccountMint>;
-  mintTokenAccount?: Address<TAccountMintTokenAccount>;
-  guardAuthority: TransactionSigner<TAccountGuardAuthority>;
-  payer: TransactionSigner<TAccountPayer>;
-  associatedTokenProgram?: Address<TAccountAssociatedTokenProgram>;
-  tokenProgram?: Address<TAccountTokenProgram>;
-  systemProgram?: Address<TAccountSystemProgram>;
-  name: CreateGuardInstructionDataArgs['name'];
-  symbol: CreateGuardInstructionDataArgs['symbol'];
-  uri: CreateGuardInstructionDataArgs['uri'];
-  cpiRule: CreateGuardInstructionDataArgs['cpiRule'];
-  transferAmountRule: CreateGuardInstructionDataArgs['transferAmountRule'];
-  additionalFieldsRule: CreateGuardInstructionDataArgs['additionalFieldsRule'];
+    guard?: Address<TAccountGuard>;
+    mint: TransactionSigner<TAccountMint>;
+    mintTokenAccount?: Address<TAccountMintTokenAccount>;
+    guardAuthority: TransactionSigner<TAccountGuardAuthority>;
+    payer: TransactionSigner<TAccountPayer>;
+    associatedTokenProgram?: Address<TAccountAssociatedTokenProgram>;
+    tokenProgram?: Address<TAccountTokenProgram>;
+    systemProgram?: Address<TAccountSystemProgram>;
+    name: CreateGuardInstructionDataArgs['name'];
+    symbol: CreateGuardInstructionDataArgs['symbol'];
+    uri: CreateGuardInstructionDataArgs['uri'];
+    cpiRule: CreateGuardInstructionDataArgs['cpiRule'];
+    transferAmountRule: CreateGuardInstructionDataArgs['transferAmountRule'];
+    additionalFieldsRule: CreateGuardInstructionDataArgs['additionalFieldsRule'];
 };
 
 export async function getCreateGuardInstructionAsync<
-  TAccountGuard extends string,
-  TAccountMint extends string,
-  TAccountMintTokenAccount extends string,
-  TAccountGuardAuthority extends string,
-  TAccountPayer extends string,
-  TAccountAssociatedTokenProgram extends string,
-  TAccountTokenProgram extends string,
-  TAccountSystemProgram extends string,
-  TProgramAddress extends Address = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+    TAccountGuard extends string,
+    TAccountMint extends string,
+    TAccountMintTokenAccount extends string,
+    TAccountGuardAuthority extends string,
+    TAccountPayer extends string,
+    TAccountAssociatedTokenProgram extends string,
+    TAccountTokenProgram extends string,
+    TAccountSystemProgram extends string,
+    TProgramAddress extends Address = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
 >(
-  input: CreateGuardAsyncInput<
-    TAccountGuard,
-    TAccountMint,
-    TAccountMintTokenAccount,
-    TAccountGuardAuthority,
-    TAccountPayer,
-    TAccountAssociatedTokenProgram,
-    TAccountTokenProgram,
-    TAccountSystemProgram
-  >,
-  config?: { programAddress?: TProgramAddress }
+    input: CreateGuardAsyncInput<
+        TAccountGuard,
+        TAccountMint,
+        TAccountMintTokenAccount,
+        TAccountGuardAuthority,
+        TAccountPayer,
+        TAccountAssociatedTokenProgram,
+        TAccountTokenProgram,
+        TAccountSystemProgram
+    >,
+    config?: { programAddress?: TProgramAddress }
 ): Promise<
-  CreateGuardInstruction<
-    TProgramAddress,
-    TAccountGuard,
-    TAccountMint,
-    TAccountMintTokenAccount,
-    TAccountGuardAuthority,
-    TAccountPayer,
-    TAccountAssociatedTokenProgram,
-    TAccountTokenProgram,
-    TAccountSystemProgram
-  >
+    CreateGuardInstruction<
+        TProgramAddress,
+        TAccountGuard,
+        TAccountMint,
+        TAccountMintTokenAccount,
+        TAccountGuardAuthority,
+        TAccountPayer,
+        TAccountAssociatedTokenProgram,
+        TAccountTokenProgram,
+        TAccountSystemProgram
+    >
 > {
-  // Program address.
-  const programAddress =
-    config?.programAddress ?? WEN_TRANSFER_GUARD_PROGRAM_ADDRESS;
+    // Program address.
+    const programAddress = config?.programAddress ?? WEN_TRANSFER_GUARD_PROGRAM_ADDRESS;
 
-  // Original accounts.
-  const originalAccounts = {
-    guard: { value: input.guard ?? null, isWritable: true },
-    mint: { value: input.mint ?? null, isWritable: true },
-    mintTokenAccount: {
-      value: input.mintTokenAccount ?? null,
-      isWritable: true,
-    },
-    guardAuthority: { value: input.guardAuthority ?? null, isWritable: false },
-    payer: { value: input.payer ?? null, isWritable: true },
-    associatedTokenProgram: {
-      value: input.associatedTokenProgram ?? null,
-      isWritable: false,
-    },
-    tokenProgram: { value: input.tokenProgram ?? null, isWritable: false },
-    systemProgram: { value: input.systemProgram ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
+    // Original accounts.
+    const originalAccounts = {
+        guard: { value: input.guard ?? null, isWritable: true },
+        mint: { value: input.mint ?? null, isWritable: true },
+        mintTokenAccount: { value: input.mintTokenAccount ?? null, isWritable: true },
+        guardAuthority: { value: input.guardAuthority ?? null, isWritable: false },
+        payer: { value: input.payer ?? null, isWritable: true },
+        associatedTokenProgram: { value: input.associatedTokenProgram ?? null, isWritable: false },
+        tokenProgram: { value: input.tokenProgram ?? null, isWritable: false },
+        systemProgram: { value: input.systemProgram ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
 
-  // Original args.
-  const args = { ...input };
+    // Original args.
+    const args = { ...input };
 
-  // Resolve default values.
-  if (!accounts.guard.value) {
-    accounts.guard.value = await getProgramDerivedAddress({
-      programAddress,
-      seeds: [
-        getBytesEncoder().encode(
-          new Uint8Array([
-            119, 101, 110, 95, 116, 111, 107, 101, 110, 95, 116, 114, 97, 110,
-            115, 102, 101, 114, 95, 103, 117, 97, 114, 100,
-          ])
-        ),
-        getBytesEncoder().encode(
-          new Uint8Array([103, 117, 97, 114, 100, 95, 118, 49])
-        ),
-        getAddressEncoder().encode(expectAddress(accounts.mint.value)),
-      ],
-    });
-  }
-  if (!accounts.tokenProgram.value) {
-    accounts.tokenProgram.value =
-      'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb' as Address<'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb'>;
-  }
-  if (!accounts.mintTokenAccount.value) {
-    accounts.mintTokenAccount.value = await getProgramDerivedAddress({
-      programAddress:
-        'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL' as Address<'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL'>,
-      seeds: [
-        getAddressEncoder().encode(
-          expectAddress(accounts.guardAuthority.value)
-        ),
-        getAddressEncoder().encode(expectAddress(accounts.tokenProgram.value)),
-        getAddressEncoder().encode(expectAddress(accounts.mint.value)),
-      ],
-    });
-  }
-  if (!accounts.associatedTokenProgram.value) {
-    accounts.associatedTokenProgram.value =
-      'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL' as Address<'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL'>;
-  }
-  if (!accounts.systemProgram.value) {
-    accounts.systemProgram.value =
-      '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
-  }
+    // Resolve default values.
+    if (!accounts.guard.value) {
+        accounts.guard.value = await getProgramDerivedAddress({
+            programAddress,
+            seeds: [
+                getBytesEncoder().encode(
+                    new Uint8Array([
+                        119, 101, 110, 95, 116, 111, 107, 101, 110, 95, 116, 114, 97, 110, 115, 102, 101, 114, 95, 103,
+                        117, 97, 114, 100,
+                    ])
+                ),
+                getBytesEncoder().encode(new Uint8Array([103, 117, 97, 114, 100, 95, 118, 49])),
+                getAddressEncoder().encode(expectAddress(accounts.mint.value)),
+            ],
+        });
+    }
+    if (!accounts.tokenProgram.value) {
+        accounts.tokenProgram.value =
+            'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb' as Address<'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb'>;
+    }
+    if (!accounts.mintTokenAccount.value) {
+        accounts.mintTokenAccount.value = await getProgramDerivedAddress({
+            programAddress:
+                'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL' as Address<'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL'>,
+            seeds: [
+                getAddressEncoder().encode(expectAddress(accounts.guardAuthority.value)),
+                getAddressEncoder().encode(expectAddress(accounts.tokenProgram.value)),
+                getAddressEncoder().encode(expectAddress(accounts.mint.value)),
+            ],
+        });
+    }
+    if (!accounts.associatedTokenProgram.value) {
+        accounts.associatedTokenProgram.value =
+            'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL' as Address<'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL'>;
+    }
+    if (!accounts.systemProgram.value) {
+        accounts.systemProgram.value =
+            '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
+    }
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.guard),
-      getAccountMeta(accounts.mint),
-      getAccountMeta(accounts.mintTokenAccount),
-      getAccountMeta(accounts.guardAuthority),
-      getAccountMeta(accounts.payer),
-      getAccountMeta(accounts.associatedTokenProgram),
-      getAccountMeta(accounts.tokenProgram),
-      getAccountMeta(accounts.systemProgram),
-    ],
-    data: getCreateGuardInstructionDataEncoder().encode(
-      args as CreateGuardInstructionDataArgs
-    ),
-    programAddress,
-  } as CreateGuardInstruction<
-    TProgramAddress,
-    TAccountGuard,
-    TAccountMint,
-    TAccountMintTokenAccount,
-    TAccountGuardAuthority,
-    TAccountPayer,
-    TAccountAssociatedTokenProgram,
-    TAccountTokenProgram,
-    TAccountSystemProgram
-  >);
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [
+            getAccountMeta(accounts.guard),
+            getAccountMeta(accounts.mint),
+            getAccountMeta(accounts.mintTokenAccount),
+            getAccountMeta(accounts.guardAuthority),
+            getAccountMeta(accounts.payer),
+            getAccountMeta(accounts.associatedTokenProgram),
+            getAccountMeta(accounts.tokenProgram),
+            getAccountMeta(accounts.systemProgram),
+        ],
+        data: getCreateGuardInstructionDataEncoder().encode(args as CreateGuardInstructionDataArgs),
+        programAddress,
+    } as CreateGuardInstruction<
+        TProgramAddress,
+        TAccountGuard,
+        TAccountMint,
+        TAccountMintTokenAccount,
+        TAccountGuardAuthority,
+        TAccountPayer,
+        TAccountAssociatedTokenProgram,
+        TAccountTokenProgram,
+        TAccountSystemProgram
+    >);
 }
 
 export type CreateGuardInput<
-  TAccountGuard extends string = string,
-  TAccountMint extends string = string,
-  TAccountMintTokenAccount extends string = string,
-  TAccountGuardAuthority extends string = string,
-  TAccountPayer extends string = string,
-  TAccountAssociatedTokenProgram extends string = string,
-  TAccountTokenProgram extends string = string,
-  TAccountSystemProgram extends string = string,
+    TAccountGuard extends string = string,
+    TAccountMint extends string = string,
+    TAccountMintTokenAccount extends string = string,
+    TAccountGuardAuthority extends string = string,
+    TAccountPayer extends string = string,
+    TAccountAssociatedTokenProgram extends string = string,
+    TAccountTokenProgram extends string = string,
+    TAccountSystemProgram extends string = string,
 > = {
-  guard: Address<TAccountGuard>;
-  mint: TransactionSigner<TAccountMint>;
-  mintTokenAccount: Address<TAccountMintTokenAccount>;
-  guardAuthority: TransactionSigner<TAccountGuardAuthority>;
-  payer: TransactionSigner<TAccountPayer>;
-  associatedTokenProgram?: Address<TAccountAssociatedTokenProgram>;
-  tokenProgram?: Address<TAccountTokenProgram>;
-  systemProgram?: Address<TAccountSystemProgram>;
-  name: CreateGuardInstructionDataArgs['name'];
-  symbol: CreateGuardInstructionDataArgs['symbol'];
-  uri: CreateGuardInstructionDataArgs['uri'];
-  cpiRule: CreateGuardInstructionDataArgs['cpiRule'];
-  transferAmountRule: CreateGuardInstructionDataArgs['transferAmountRule'];
-  additionalFieldsRule: CreateGuardInstructionDataArgs['additionalFieldsRule'];
+    guard: Address<TAccountGuard>;
+    mint: TransactionSigner<TAccountMint>;
+    mintTokenAccount: Address<TAccountMintTokenAccount>;
+    guardAuthority: TransactionSigner<TAccountGuardAuthority>;
+    payer: TransactionSigner<TAccountPayer>;
+    associatedTokenProgram?: Address<TAccountAssociatedTokenProgram>;
+    tokenProgram?: Address<TAccountTokenProgram>;
+    systemProgram?: Address<TAccountSystemProgram>;
+    name: CreateGuardInstructionDataArgs['name'];
+    symbol: CreateGuardInstructionDataArgs['symbol'];
+    uri: CreateGuardInstructionDataArgs['uri'];
+    cpiRule: CreateGuardInstructionDataArgs['cpiRule'];
+    transferAmountRule: CreateGuardInstructionDataArgs['transferAmountRule'];
+    additionalFieldsRule: CreateGuardInstructionDataArgs['additionalFieldsRule'];
 };
 
 export function getCreateGuardInstruction<
-  TAccountGuard extends string,
-  TAccountMint extends string,
-  TAccountMintTokenAccount extends string,
-  TAccountGuardAuthority extends string,
-  TAccountPayer extends string,
-  TAccountAssociatedTokenProgram extends string,
-  TAccountTokenProgram extends string,
-  TAccountSystemProgram extends string,
-  TProgramAddress extends Address = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+    TAccountGuard extends string,
+    TAccountMint extends string,
+    TAccountMintTokenAccount extends string,
+    TAccountGuardAuthority extends string,
+    TAccountPayer extends string,
+    TAccountAssociatedTokenProgram extends string,
+    TAccountTokenProgram extends string,
+    TAccountSystemProgram extends string,
+    TProgramAddress extends Address = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
 >(
-  input: CreateGuardInput<
-    TAccountGuard,
-    TAccountMint,
-    TAccountMintTokenAccount,
-    TAccountGuardAuthority,
-    TAccountPayer,
-    TAccountAssociatedTokenProgram,
-    TAccountTokenProgram,
-    TAccountSystemProgram
-  >,
-  config?: { programAddress?: TProgramAddress }
+    input: CreateGuardInput<
+        TAccountGuard,
+        TAccountMint,
+        TAccountMintTokenAccount,
+        TAccountGuardAuthority,
+        TAccountPayer,
+        TAccountAssociatedTokenProgram,
+        TAccountTokenProgram,
+        TAccountSystemProgram
+    >,
+    config?: { programAddress?: TProgramAddress }
 ): CreateGuardInstruction<
-  TProgramAddress,
-  TAccountGuard,
-  TAccountMint,
-  TAccountMintTokenAccount,
-  TAccountGuardAuthority,
-  TAccountPayer,
-  TAccountAssociatedTokenProgram,
-  TAccountTokenProgram,
-  TAccountSystemProgram
-> {
-  // Program address.
-  const programAddress =
-    config?.programAddress ?? WEN_TRANSFER_GUARD_PROGRAM_ADDRESS;
-
-  // Original accounts.
-  const originalAccounts = {
-    guard: { value: input.guard ?? null, isWritable: true },
-    mint: { value: input.mint ?? null, isWritable: true },
-    mintTokenAccount: {
-      value: input.mintTokenAccount ?? null,
-      isWritable: true,
-    },
-    guardAuthority: { value: input.guardAuthority ?? null, isWritable: false },
-    payer: { value: input.payer ?? null, isWritable: true },
-    associatedTokenProgram: {
-      value: input.associatedTokenProgram ?? null,
-      isWritable: false,
-    },
-    tokenProgram: { value: input.tokenProgram ?? null, isWritable: false },
-    systemProgram: { value: input.systemProgram ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
-
-  // Original args.
-  const args = { ...input };
-
-  // Resolve default values.
-  if (!accounts.tokenProgram.value) {
-    accounts.tokenProgram.value =
-      'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb' as Address<'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb'>;
-  }
-  if (!accounts.associatedTokenProgram.value) {
-    accounts.associatedTokenProgram.value =
-      'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL' as Address<'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL'>;
-  }
-  if (!accounts.systemProgram.value) {
-    accounts.systemProgram.value =
-      '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
-  }
-
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.guard),
-      getAccountMeta(accounts.mint),
-      getAccountMeta(accounts.mintTokenAccount),
-      getAccountMeta(accounts.guardAuthority),
-      getAccountMeta(accounts.payer),
-      getAccountMeta(accounts.associatedTokenProgram),
-      getAccountMeta(accounts.tokenProgram),
-      getAccountMeta(accounts.systemProgram),
-    ],
-    data: getCreateGuardInstructionDataEncoder().encode(
-      args as CreateGuardInstructionDataArgs
-    ),
-    programAddress,
-  } as CreateGuardInstruction<
     TProgramAddress,
     TAccountGuard,
     TAccountMint,
@@ -477,57 +364,112 @@ export function getCreateGuardInstruction<
     TAccountAssociatedTokenProgram,
     TAccountTokenProgram,
     TAccountSystemProgram
-  >);
+> {
+    // Program address.
+    const programAddress = config?.programAddress ?? WEN_TRANSFER_GUARD_PROGRAM_ADDRESS;
+
+    // Original accounts.
+    const originalAccounts = {
+        guard: { value: input.guard ?? null, isWritable: true },
+        mint: { value: input.mint ?? null, isWritable: true },
+        mintTokenAccount: { value: input.mintTokenAccount ?? null, isWritable: true },
+        guardAuthority: { value: input.guardAuthority ?? null, isWritable: false },
+        payer: { value: input.payer ?? null, isWritable: true },
+        associatedTokenProgram: { value: input.associatedTokenProgram ?? null, isWritable: false },
+        tokenProgram: { value: input.tokenProgram ?? null, isWritable: false },
+        systemProgram: { value: input.systemProgram ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
+
+    // Original args.
+    const args = { ...input };
+
+    // Resolve default values.
+    if (!accounts.tokenProgram.value) {
+        accounts.tokenProgram.value =
+            'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb' as Address<'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb'>;
+    }
+    if (!accounts.associatedTokenProgram.value) {
+        accounts.associatedTokenProgram.value =
+            'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL' as Address<'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL'>;
+    }
+    if (!accounts.systemProgram.value) {
+        accounts.systemProgram.value =
+            '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
+    }
+
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [
+            getAccountMeta(accounts.guard),
+            getAccountMeta(accounts.mint),
+            getAccountMeta(accounts.mintTokenAccount),
+            getAccountMeta(accounts.guardAuthority),
+            getAccountMeta(accounts.payer),
+            getAccountMeta(accounts.associatedTokenProgram),
+            getAccountMeta(accounts.tokenProgram),
+            getAccountMeta(accounts.systemProgram),
+        ],
+        data: getCreateGuardInstructionDataEncoder().encode(args as CreateGuardInstructionDataArgs),
+        programAddress,
+    } as CreateGuardInstruction<
+        TProgramAddress,
+        TAccountGuard,
+        TAccountMint,
+        TAccountMintTokenAccount,
+        TAccountGuardAuthority,
+        TAccountPayer,
+        TAccountAssociatedTokenProgram,
+        TAccountTokenProgram,
+        TAccountSystemProgram
+    >);
 }
 
 export type ParsedCreateGuardInstruction<
-  TProgram extends string = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    guard: TAccountMetas[0];
-    mint: TAccountMetas[1];
-    mintTokenAccount: TAccountMetas[2];
-    guardAuthority: TAccountMetas[3];
-    payer: TAccountMetas[4];
-    associatedTokenProgram: TAccountMetas[5];
-    tokenProgram: TAccountMetas[6];
-    systemProgram: TAccountMetas[7];
-  };
-  data: CreateGuardInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        guard: TAccountMetas[0];
+        mint: TAccountMetas[1];
+        mintTokenAccount: TAccountMetas[2];
+        guardAuthority: TAccountMetas[3];
+        payer: TAccountMetas[4];
+        associatedTokenProgram: TAccountMetas[5];
+        tokenProgram: TAccountMetas[6];
+        systemProgram: TAccountMetas[7];
+    };
+    data: CreateGuardInstructionData;
 };
 
-export function parseCreateGuardInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
->(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+export function parseCreateGuardInstruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedCreateGuardInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 8) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: {
-      guard: getNextAccount(),
-      mint: getNextAccount(),
-      mintTokenAccount: getNextAccount(),
-      guardAuthority: getNextAccount(),
-      payer: getNextAccount(),
-      associatedTokenProgram: getNextAccount(),
-      tokenProgram: getNextAccount(),
-      systemProgram: getNextAccount(),
-    },
-    data: getCreateGuardInstructionDataDecoder().decode(instruction.data),
-  };
+    if (instruction.accounts.length < 8) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: {
+            guard: getNextAccount(),
+            mint: getNextAccount(),
+            mintTokenAccount: getNextAccount(),
+            guardAuthority: getNextAccount(),
+            payer: getNextAccount(),
+            associatedTokenProgram: getNextAccount(),
+            tokenProgram: getNextAccount(),
+            systemProgram: getNextAccount(),
+        },
+        data: getCreateGuardInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/anchor/src/generated/instructions/execute.ts
+++ b/test/e2e/anchor/src/generated/instructions/execute.ts
@@ -7,349 +7,248 @@
  */
 
 import {
-  combineCodec,
-  fixDecoderSize,
-  fixEncoderSize,
-  getAddressEncoder,
-  getBytesDecoder,
-  getBytesEncoder,
-  getProgramDerivedAddress,
-  getStructDecoder,
-  getStructEncoder,
-  getU64Decoder,
-  getU64Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyAccount,
-  type ReadonlyUint8Array,
+    combineCodec,
+    fixDecoderSize,
+    fixEncoderSize,
+    getAddressEncoder,
+    getBytesDecoder,
+    getBytesEncoder,
+    getProgramDerivedAddress,
+    getStructDecoder,
+    getStructEncoder,
+    getU64Decoder,
+    getU64Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyAccount,
+    type ReadonlyUint8Array,
 } from '@solana/kit';
 import { WEN_TRANSFER_GUARD_PROGRAM_ADDRESS } from '../programs';
-import {
-  expectAddress,
-  getAccountMetaFactory,
-  type ResolvedAccount,
-} from '../shared';
+import { expectAddress, getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
-export const EXECUTE_DISCRIMINATOR = new Uint8Array([
-  105, 37, 101, 197, 75, 251, 102, 26,
-]);
+export const EXECUTE_DISCRIMINATOR = new Uint8Array([105, 37, 101, 197, 75, 251, 102, 26]);
 
 export function getExecuteDiscriminatorBytes() {
-  return fixEncoderSize(getBytesEncoder(), 8).encode(EXECUTE_DISCRIMINATOR);
+    return fixEncoderSize(getBytesEncoder(), 8).encode(EXECUTE_DISCRIMINATOR);
 }
 
 export type ExecuteInstruction<
-  TProgram extends string = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
-  TAccountSourceAccount extends string | AccountMeta<string> = string,
-  TAccountMint extends string | AccountMeta<string> = string,
-  TAccountDestinationAccount extends string | AccountMeta<string> = string,
-  TAccountOwnerDelegate extends string | AccountMeta<string> = string,
-  TAccountExtraMetasAccount extends string | AccountMeta<string> = string,
-  TAccountGuard extends string | AccountMeta<string> = string,
-  TAccountInstructionSysvarAccount extends string | AccountMeta<string> =
-    'Sysvar1nstructions1111111111111111111111111',
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+    TAccountSourceAccount extends string | AccountMeta<string> = string,
+    TAccountMint extends string | AccountMeta<string> = string,
+    TAccountDestinationAccount extends string | AccountMeta<string> = string,
+    TAccountOwnerDelegate extends string | AccountMeta<string> = string,
+    TAccountExtraMetasAccount extends string | AccountMeta<string> = string,
+    TAccountGuard extends string | AccountMeta<string> = string,
+    TAccountInstructionSysvarAccount extends string | AccountMeta<string> =
+        'Sysvar1nstructions1111111111111111111111111',
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountSourceAccount extends string
-        ? ReadonlyAccount<TAccountSourceAccount>
-        : TAccountSourceAccount,
-      TAccountMint extends string
-        ? ReadonlyAccount<TAccountMint>
-        : TAccountMint,
-      TAccountDestinationAccount extends string
-        ? ReadonlyAccount<TAccountDestinationAccount>
-        : TAccountDestinationAccount,
-      TAccountOwnerDelegate extends string
-        ? ReadonlyAccount<TAccountOwnerDelegate>
-        : TAccountOwnerDelegate,
-      TAccountExtraMetasAccount extends string
-        ? ReadonlyAccount<TAccountExtraMetasAccount>
-        : TAccountExtraMetasAccount,
-      TAccountGuard extends string
-        ? ReadonlyAccount<TAccountGuard>
-        : TAccountGuard,
-      TAccountInstructionSysvarAccount extends string
-        ? ReadonlyAccount<TAccountInstructionSysvarAccount>
-        : TAccountInstructionSysvarAccount,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountSourceAccount extends string ? ReadonlyAccount<TAccountSourceAccount> : TAccountSourceAccount,
+            TAccountMint extends string ? ReadonlyAccount<TAccountMint> : TAccountMint,
+            TAccountDestinationAccount extends string
+                ? ReadonlyAccount<TAccountDestinationAccount>
+                : TAccountDestinationAccount,
+            TAccountOwnerDelegate extends string ? ReadonlyAccount<TAccountOwnerDelegate> : TAccountOwnerDelegate,
+            TAccountExtraMetasAccount extends string
+                ? ReadonlyAccount<TAccountExtraMetasAccount>
+                : TAccountExtraMetasAccount,
+            TAccountGuard extends string ? ReadonlyAccount<TAccountGuard> : TAccountGuard,
+            TAccountInstructionSysvarAccount extends string
+                ? ReadonlyAccount<TAccountInstructionSysvarAccount>
+                : TAccountInstructionSysvarAccount,
+            ...TRemainingAccounts,
+        ]
+    >;
 
-export type ExecuteInstructionData = {
-  discriminator: ReadonlyUint8Array;
-  amount: bigint;
-};
+export type ExecuteInstructionData = { discriminator: ReadonlyUint8Array; amount: bigint };
 
 export type ExecuteInstructionDataArgs = { amount: number | bigint };
 
 export function getExecuteInstructionDataEncoder(): FixedSizeEncoder<ExecuteInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', fixEncoderSize(getBytesEncoder(), 8)],
-      ['amount', getU64Encoder()],
-    ]),
-    (value) => ({ ...value, discriminator: EXECUTE_DISCRIMINATOR })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', fixEncoderSize(getBytesEncoder(), 8)],
+            ['amount', getU64Encoder()],
+        ]),
+        value => ({ ...value, discriminator: EXECUTE_DISCRIMINATOR })
+    );
 }
 
 export function getExecuteInstructionDataDecoder(): FixedSizeDecoder<ExecuteInstructionData> {
-  return getStructDecoder([
-    ['discriminator', fixDecoderSize(getBytesDecoder(), 8)],
-    ['amount', getU64Decoder()],
-  ]);
+    return getStructDecoder([
+        ['discriminator', fixDecoderSize(getBytesDecoder(), 8)],
+        ['amount', getU64Decoder()],
+    ]);
 }
 
-export function getExecuteInstructionDataCodec(): FixedSizeCodec<
-  ExecuteInstructionDataArgs,
-  ExecuteInstructionData
-> {
-  return combineCodec(
-    getExecuteInstructionDataEncoder(),
-    getExecuteInstructionDataDecoder()
-  );
+export function getExecuteInstructionDataCodec(): FixedSizeCodec<ExecuteInstructionDataArgs, ExecuteInstructionData> {
+    return combineCodec(getExecuteInstructionDataEncoder(), getExecuteInstructionDataDecoder());
 }
 
 export type ExecuteAsyncInput<
-  TAccountSourceAccount extends string = string,
-  TAccountMint extends string = string,
-  TAccountDestinationAccount extends string = string,
-  TAccountOwnerDelegate extends string = string,
-  TAccountExtraMetasAccount extends string = string,
-  TAccountGuard extends string = string,
-  TAccountInstructionSysvarAccount extends string = string,
+    TAccountSourceAccount extends string = string,
+    TAccountMint extends string = string,
+    TAccountDestinationAccount extends string = string,
+    TAccountOwnerDelegate extends string = string,
+    TAccountExtraMetasAccount extends string = string,
+    TAccountGuard extends string = string,
+    TAccountInstructionSysvarAccount extends string = string,
 > = {
-  sourceAccount: Address<TAccountSourceAccount>;
-  mint: Address<TAccountMint>;
-  destinationAccount: Address<TAccountDestinationAccount>;
-  ownerDelegate: Address<TAccountOwnerDelegate>;
-  extraMetasAccount?: Address<TAccountExtraMetasAccount>;
-  guard: Address<TAccountGuard>;
-  instructionSysvarAccount?: Address<TAccountInstructionSysvarAccount>;
-  amount: ExecuteInstructionDataArgs['amount'];
+    sourceAccount: Address<TAccountSourceAccount>;
+    mint: Address<TAccountMint>;
+    destinationAccount: Address<TAccountDestinationAccount>;
+    ownerDelegate: Address<TAccountOwnerDelegate>;
+    extraMetasAccount?: Address<TAccountExtraMetasAccount>;
+    guard: Address<TAccountGuard>;
+    instructionSysvarAccount?: Address<TAccountInstructionSysvarAccount>;
+    amount: ExecuteInstructionDataArgs['amount'];
 };
 
 export async function getExecuteInstructionAsync<
-  TAccountSourceAccount extends string,
-  TAccountMint extends string,
-  TAccountDestinationAccount extends string,
-  TAccountOwnerDelegate extends string,
-  TAccountExtraMetasAccount extends string,
-  TAccountGuard extends string,
-  TAccountInstructionSysvarAccount extends string,
-  TProgramAddress extends Address = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+    TAccountSourceAccount extends string,
+    TAccountMint extends string,
+    TAccountDestinationAccount extends string,
+    TAccountOwnerDelegate extends string,
+    TAccountExtraMetasAccount extends string,
+    TAccountGuard extends string,
+    TAccountInstructionSysvarAccount extends string,
+    TProgramAddress extends Address = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
 >(
-  input: ExecuteAsyncInput<
-    TAccountSourceAccount,
-    TAccountMint,
-    TAccountDestinationAccount,
-    TAccountOwnerDelegate,
-    TAccountExtraMetasAccount,
-    TAccountGuard,
-    TAccountInstructionSysvarAccount
-  >,
-  config?: { programAddress?: TProgramAddress }
+    input: ExecuteAsyncInput<
+        TAccountSourceAccount,
+        TAccountMint,
+        TAccountDestinationAccount,
+        TAccountOwnerDelegate,
+        TAccountExtraMetasAccount,
+        TAccountGuard,
+        TAccountInstructionSysvarAccount
+    >,
+    config?: { programAddress?: TProgramAddress }
 ): Promise<
-  ExecuteInstruction<
-    TProgramAddress,
-    TAccountSourceAccount,
-    TAccountMint,
-    TAccountDestinationAccount,
-    TAccountOwnerDelegate,
-    TAccountExtraMetasAccount,
-    TAccountGuard,
-    TAccountInstructionSysvarAccount
-  >
+    ExecuteInstruction<
+        TProgramAddress,
+        TAccountSourceAccount,
+        TAccountMint,
+        TAccountDestinationAccount,
+        TAccountOwnerDelegate,
+        TAccountExtraMetasAccount,
+        TAccountGuard,
+        TAccountInstructionSysvarAccount
+    >
 > {
-  // Program address.
-  const programAddress =
-    config?.programAddress ?? WEN_TRANSFER_GUARD_PROGRAM_ADDRESS;
+    // Program address.
+    const programAddress = config?.programAddress ?? WEN_TRANSFER_GUARD_PROGRAM_ADDRESS;
 
-  // Original accounts.
-  const originalAccounts = {
-    sourceAccount: { value: input.sourceAccount ?? null, isWritable: false },
-    mint: { value: input.mint ?? null, isWritable: false },
-    destinationAccount: {
-      value: input.destinationAccount ?? null,
-      isWritable: false,
-    },
-    ownerDelegate: { value: input.ownerDelegate ?? null, isWritable: false },
-    extraMetasAccount: {
-      value: input.extraMetasAccount ?? null,
-      isWritable: false,
-    },
-    guard: { value: input.guard ?? null, isWritable: false },
-    instructionSysvarAccount: {
-      value: input.instructionSysvarAccount ?? null,
-      isWritable: false,
-    },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
+    // Original accounts.
+    const originalAccounts = {
+        sourceAccount: { value: input.sourceAccount ?? null, isWritable: false },
+        mint: { value: input.mint ?? null, isWritable: false },
+        destinationAccount: { value: input.destinationAccount ?? null, isWritable: false },
+        ownerDelegate: { value: input.ownerDelegate ?? null, isWritable: false },
+        extraMetasAccount: { value: input.extraMetasAccount ?? null, isWritable: false },
+        guard: { value: input.guard ?? null, isWritable: false },
+        instructionSysvarAccount: { value: input.instructionSysvarAccount ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
 
-  // Original args.
-  const args = { ...input };
+    // Original args.
+    const args = { ...input };
 
-  // Resolve default values.
-  if (!accounts.extraMetasAccount.value) {
-    accounts.extraMetasAccount.value = await getProgramDerivedAddress({
-      programAddress,
-      seeds: [
-        getBytesEncoder().encode(
-          new Uint8Array([
-            101, 120, 116, 114, 97, 45, 97, 99, 99, 111, 117, 110, 116, 45, 109,
-            101, 116, 97, 115,
-          ])
-        ),
-        getAddressEncoder().encode(expectAddress(accounts.mint.value)),
-      ],
-    });
-  }
-  if (!accounts.instructionSysvarAccount.value) {
-    accounts.instructionSysvarAccount.value =
-      'Sysvar1nstructions1111111111111111111111111' as Address<'Sysvar1nstructions1111111111111111111111111'>;
-  }
+    // Resolve default values.
+    if (!accounts.extraMetasAccount.value) {
+        accounts.extraMetasAccount.value = await getProgramDerivedAddress({
+            programAddress,
+            seeds: [
+                getBytesEncoder().encode(
+                    new Uint8Array([
+                        101, 120, 116, 114, 97, 45, 97, 99, 99, 111, 117, 110, 116, 45, 109, 101, 116, 97, 115,
+                    ])
+                ),
+                getAddressEncoder().encode(expectAddress(accounts.mint.value)),
+            ],
+        });
+    }
+    if (!accounts.instructionSysvarAccount.value) {
+        accounts.instructionSysvarAccount.value =
+            'Sysvar1nstructions1111111111111111111111111' as Address<'Sysvar1nstructions1111111111111111111111111'>;
+    }
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.sourceAccount),
-      getAccountMeta(accounts.mint),
-      getAccountMeta(accounts.destinationAccount),
-      getAccountMeta(accounts.ownerDelegate),
-      getAccountMeta(accounts.extraMetasAccount),
-      getAccountMeta(accounts.guard),
-      getAccountMeta(accounts.instructionSysvarAccount),
-    ],
-    data: getExecuteInstructionDataEncoder().encode(
-      args as ExecuteInstructionDataArgs
-    ),
-    programAddress,
-  } as ExecuteInstruction<
-    TProgramAddress,
-    TAccountSourceAccount,
-    TAccountMint,
-    TAccountDestinationAccount,
-    TAccountOwnerDelegate,
-    TAccountExtraMetasAccount,
-    TAccountGuard,
-    TAccountInstructionSysvarAccount
-  >);
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [
+            getAccountMeta(accounts.sourceAccount),
+            getAccountMeta(accounts.mint),
+            getAccountMeta(accounts.destinationAccount),
+            getAccountMeta(accounts.ownerDelegate),
+            getAccountMeta(accounts.extraMetasAccount),
+            getAccountMeta(accounts.guard),
+            getAccountMeta(accounts.instructionSysvarAccount),
+        ],
+        data: getExecuteInstructionDataEncoder().encode(args as ExecuteInstructionDataArgs),
+        programAddress,
+    } as ExecuteInstruction<
+        TProgramAddress,
+        TAccountSourceAccount,
+        TAccountMint,
+        TAccountDestinationAccount,
+        TAccountOwnerDelegate,
+        TAccountExtraMetasAccount,
+        TAccountGuard,
+        TAccountInstructionSysvarAccount
+    >);
 }
 
 export type ExecuteInput<
-  TAccountSourceAccount extends string = string,
-  TAccountMint extends string = string,
-  TAccountDestinationAccount extends string = string,
-  TAccountOwnerDelegate extends string = string,
-  TAccountExtraMetasAccount extends string = string,
-  TAccountGuard extends string = string,
-  TAccountInstructionSysvarAccount extends string = string,
+    TAccountSourceAccount extends string = string,
+    TAccountMint extends string = string,
+    TAccountDestinationAccount extends string = string,
+    TAccountOwnerDelegate extends string = string,
+    TAccountExtraMetasAccount extends string = string,
+    TAccountGuard extends string = string,
+    TAccountInstructionSysvarAccount extends string = string,
 > = {
-  sourceAccount: Address<TAccountSourceAccount>;
-  mint: Address<TAccountMint>;
-  destinationAccount: Address<TAccountDestinationAccount>;
-  ownerDelegate: Address<TAccountOwnerDelegate>;
-  extraMetasAccount: Address<TAccountExtraMetasAccount>;
-  guard: Address<TAccountGuard>;
-  instructionSysvarAccount?: Address<TAccountInstructionSysvarAccount>;
-  amount: ExecuteInstructionDataArgs['amount'];
+    sourceAccount: Address<TAccountSourceAccount>;
+    mint: Address<TAccountMint>;
+    destinationAccount: Address<TAccountDestinationAccount>;
+    ownerDelegate: Address<TAccountOwnerDelegate>;
+    extraMetasAccount: Address<TAccountExtraMetasAccount>;
+    guard: Address<TAccountGuard>;
+    instructionSysvarAccount?: Address<TAccountInstructionSysvarAccount>;
+    amount: ExecuteInstructionDataArgs['amount'];
 };
 
 export function getExecuteInstruction<
-  TAccountSourceAccount extends string,
-  TAccountMint extends string,
-  TAccountDestinationAccount extends string,
-  TAccountOwnerDelegate extends string,
-  TAccountExtraMetasAccount extends string,
-  TAccountGuard extends string,
-  TAccountInstructionSysvarAccount extends string,
-  TProgramAddress extends Address = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+    TAccountSourceAccount extends string,
+    TAccountMint extends string,
+    TAccountDestinationAccount extends string,
+    TAccountOwnerDelegate extends string,
+    TAccountExtraMetasAccount extends string,
+    TAccountGuard extends string,
+    TAccountInstructionSysvarAccount extends string,
+    TProgramAddress extends Address = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
 >(
-  input: ExecuteInput<
-    TAccountSourceAccount,
-    TAccountMint,
-    TAccountDestinationAccount,
-    TAccountOwnerDelegate,
-    TAccountExtraMetasAccount,
-    TAccountGuard,
-    TAccountInstructionSysvarAccount
-  >,
-  config?: { programAddress?: TProgramAddress }
+    input: ExecuteInput<
+        TAccountSourceAccount,
+        TAccountMint,
+        TAccountDestinationAccount,
+        TAccountOwnerDelegate,
+        TAccountExtraMetasAccount,
+        TAccountGuard,
+        TAccountInstructionSysvarAccount
+    >,
+    config?: { programAddress?: TProgramAddress }
 ): ExecuteInstruction<
-  TProgramAddress,
-  TAccountSourceAccount,
-  TAccountMint,
-  TAccountDestinationAccount,
-  TAccountOwnerDelegate,
-  TAccountExtraMetasAccount,
-  TAccountGuard,
-  TAccountInstructionSysvarAccount
-> {
-  // Program address.
-  const programAddress =
-    config?.programAddress ?? WEN_TRANSFER_GUARD_PROGRAM_ADDRESS;
-
-  // Original accounts.
-  const originalAccounts = {
-    sourceAccount: { value: input.sourceAccount ?? null, isWritable: false },
-    mint: { value: input.mint ?? null, isWritable: false },
-    destinationAccount: {
-      value: input.destinationAccount ?? null,
-      isWritable: false,
-    },
-    ownerDelegate: { value: input.ownerDelegate ?? null, isWritable: false },
-    extraMetasAccount: {
-      value: input.extraMetasAccount ?? null,
-      isWritable: false,
-    },
-    guard: { value: input.guard ?? null, isWritable: false },
-    instructionSysvarAccount: {
-      value: input.instructionSysvarAccount ?? null,
-      isWritable: false,
-    },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
-
-  // Original args.
-  const args = { ...input };
-
-  // Resolve default values.
-  if (!accounts.instructionSysvarAccount.value) {
-    accounts.instructionSysvarAccount.value =
-      'Sysvar1nstructions1111111111111111111111111' as Address<'Sysvar1nstructions1111111111111111111111111'>;
-  }
-
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.sourceAccount),
-      getAccountMeta(accounts.mint),
-      getAccountMeta(accounts.destinationAccount),
-      getAccountMeta(accounts.ownerDelegate),
-      getAccountMeta(accounts.extraMetasAccount),
-      getAccountMeta(accounts.guard),
-      getAccountMeta(accounts.instructionSysvarAccount),
-    ],
-    data: getExecuteInstructionDataEncoder().encode(
-      args as ExecuteInstructionDataArgs
-    ),
-    programAddress,
-  } as ExecuteInstruction<
     TProgramAddress,
     TAccountSourceAccount,
     TAccountMint,
@@ -358,55 +257,99 @@ export function getExecuteInstruction<
     TAccountExtraMetasAccount,
     TAccountGuard,
     TAccountInstructionSysvarAccount
-  >);
+> {
+    // Program address.
+    const programAddress = config?.programAddress ?? WEN_TRANSFER_GUARD_PROGRAM_ADDRESS;
+
+    // Original accounts.
+    const originalAccounts = {
+        sourceAccount: { value: input.sourceAccount ?? null, isWritable: false },
+        mint: { value: input.mint ?? null, isWritable: false },
+        destinationAccount: { value: input.destinationAccount ?? null, isWritable: false },
+        ownerDelegate: { value: input.ownerDelegate ?? null, isWritable: false },
+        extraMetasAccount: { value: input.extraMetasAccount ?? null, isWritable: false },
+        guard: { value: input.guard ?? null, isWritable: false },
+        instructionSysvarAccount: { value: input.instructionSysvarAccount ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
+
+    // Original args.
+    const args = { ...input };
+
+    // Resolve default values.
+    if (!accounts.instructionSysvarAccount.value) {
+        accounts.instructionSysvarAccount.value =
+            'Sysvar1nstructions1111111111111111111111111' as Address<'Sysvar1nstructions1111111111111111111111111'>;
+    }
+
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [
+            getAccountMeta(accounts.sourceAccount),
+            getAccountMeta(accounts.mint),
+            getAccountMeta(accounts.destinationAccount),
+            getAccountMeta(accounts.ownerDelegate),
+            getAccountMeta(accounts.extraMetasAccount),
+            getAccountMeta(accounts.guard),
+            getAccountMeta(accounts.instructionSysvarAccount),
+        ],
+        data: getExecuteInstructionDataEncoder().encode(args as ExecuteInstructionDataArgs),
+        programAddress,
+    } as ExecuteInstruction<
+        TProgramAddress,
+        TAccountSourceAccount,
+        TAccountMint,
+        TAccountDestinationAccount,
+        TAccountOwnerDelegate,
+        TAccountExtraMetasAccount,
+        TAccountGuard,
+        TAccountInstructionSysvarAccount
+    >);
 }
 
 export type ParsedExecuteInstruction<
-  TProgram extends string = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    sourceAccount: TAccountMetas[0];
-    mint: TAccountMetas[1];
-    destinationAccount: TAccountMetas[2];
-    ownerDelegate: TAccountMetas[3];
-    extraMetasAccount: TAccountMetas[4];
-    guard: TAccountMetas[5];
-    instructionSysvarAccount: TAccountMetas[6];
-  };
-  data: ExecuteInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        sourceAccount: TAccountMetas[0];
+        mint: TAccountMetas[1];
+        destinationAccount: TAccountMetas[2];
+        ownerDelegate: TAccountMetas[3];
+        extraMetasAccount: TAccountMetas[4];
+        guard: TAccountMetas[5];
+        instructionSysvarAccount: TAccountMetas[6];
+    };
+    data: ExecuteInstructionData;
 };
 
-export function parseExecuteInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
->(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+export function parseExecuteInstruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedExecuteInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 7) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: {
-      sourceAccount: getNextAccount(),
-      mint: getNextAccount(),
-      destinationAccount: getNextAccount(),
-      ownerDelegate: getNextAccount(),
-      extraMetasAccount: getNextAccount(),
-      guard: getNextAccount(),
-      instructionSysvarAccount: getNextAccount(),
-    },
-    data: getExecuteInstructionDataDecoder().decode(instruction.data),
-  };
+    if (instruction.accounts.length < 7) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: {
+            sourceAccount: getNextAccount(),
+            mint: getNextAccount(),
+            destinationAccount: getNextAccount(),
+            ownerDelegate: getNextAccount(),
+            extraMetasAccount: getNextAccount(),
+            guard: getNextAccount(),
+            instructionSysvarAccount: getNextAccount(),
+        },
+        data: getExecuteInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/anchor/src/generated/instructions/initialize.ts
+++ b/test/e2e/anchor/src/generated/instructions/initialize.ts
@@ -7,309 +7,228 @@
  */
 
 import {
-  combineCodec,
-  fixDecoderSize,
-  fixEncoderSize,
-  getAddressEncoder,
-  getBytesDecoder,
-  getBytesEncoder,
-  getProgramDerivedAddress,
-  getStructDecoder,
-  getStructEncoder,
-  transformEncoder,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyAccount,
-  type ReadonlyUint8Array,
-  type TransactionSigner,
-  type WritableAccount,
-  type WritableSignerAccount,
+    combineCodec,
+    fixDecoderSize,
+    fixEncoderSize,
+    getAddressEncoder,
+    getBytesDecoder,
+    getBytesEncoder,
+    getProgramDerivedAddress,
+    getStructDecoder,
+    getStructEncoder,
+    transformEncoder,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyAccount,
+    type ReadonlyUint8Array,
+    type TransactionSigner,
+    type WritableAccount,
+    type WritableSignerAccount,
 } from '@solana/kit';
 import { WEN_TRANSFER_GUARD_PROGRAM_ADDRESS } from '../programs';
-import {
-  expectAddress,
-  getAccountMetaFactory,
-  type ResolvedAccount,
-} from '../shared';
+import { expectAddress, getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
-export const INITIALIZE_DISCRIMINATOR = new Uint8Array([
-  43, 34, 13, 49, 167, 88, 235, 235,
-]);
+export const INITIALIZE_DISCRIMINATOR = new Uint8Array([43, 34, 13, 49, 167, 88, 235, 235]);
 
 export function getInitializeDiscriminatorBytes() {
-  return fixEncoderSize(getBytesEncoder(), 8).encode(INITIALIZE_DISCRIMINATOR);
+    return fixEncoderSize(getBytesEncoder(), 8).encode(INITIALIZE_DISCRIMINATOR);
 }
 
 export type InitializeInstruction<
-  TProgram extends string = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
-  TAccountExtraMetasAccount extends string | AccountMeta<string> = string,
-  TAccountGuard extends string | AccountMeta<string> = string,
-  TAccountMint extends string | AccountMeta<string> = string,
-  TAccountTransferHookAuthority extends string | AccountMeta<string> = string,
-  TAccountSystemProgram extends string | AccountMeta<string> =
-    '11111111111111111111111111111111',
-  TAccountPayer extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+    TAccountExtraMetasAccount extends string | AccountMeta<string> = string,
+    TAccountGuard extends string | AccountMeta<string> = string,
+    TAccountMint extends string | AccountMeta<string> = string,
+    TAccountTransferHookAuthority extends string | AccountMeta<string> = string,
+    TAccountSystemProgram extends string | AccountMeta<string> = '11111111111111111111111111111111',
+    TAccountPayer extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountExtraMetasAccount extends string
-        ? WritableAccount<TAccountExtraMetasAccount>
-        : TAccountExtraMetasAccount,
-      TAccountGuard extends string
-        ? ReadonlyAccount<TAccountGuard>
-        : TAccountGuard,
-      TAccountMint extends string
-        ? ReadonlyAccount<TAccountMint>
-        : TAccountMint,
-      TAccountTransferHookAuthority extends string
-        ? WritableSignerAccount<TAccountTransferHookAuthority> &
-            AccountSignerMeta<TAccountTransferHookAuthority>
-        : TAccountTransferHookAuthority,
-      TAccountSystemProgram extends string
-        ? ReadonlyAccount<TAccountSystemProgram>
-        : TAccountSystemProgram,
-      TAccountPayer extends string
-        ? WritableSignerAccount<TAccountPayer> &
-            AccountSignerMeta<TAccountPayer>
-        : TAccountPayer,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountExtraMetasAccount extends string
+                ? WritableAccount<TAccountExtraMetasAccount>
+                : TAccountExtraMetasAccount,
+            TAccountGuard extends string ? ReadonlyAccount<TAccountGuard> : TAccountGuard,
+            TAccountMint extends string ? ReadonlyAccount<TAccountMint> : TAccountMint,
+            TAccountTransferHookAuthority extends string
+                ? WritableSignerAccount<TAccountTransferHookAuthority> &
+                      AccountSignerMeta<TAccountTransferHookAuthority>
+                : TAccountTransferHookAuthority,
+            TAccountSystemProgram extends string ? ReadonlyAccount<TAccountSystemProgram> : TAccountSystemProgram,
+            TAccountPayer extends string
+                ? WritableSignerAccount<TAccountPayer> & AccountSignerMeta<TAccountPayer>
+                : TAccountPayer,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type InitializeInstructionData = { discriminator: ReadonlyUint8Array };
 
 export type InitializeInstructionDataArgs = {};
 
 export function getInitializeInstructionDataEncoder(): FixedSizeEncoder<InitializeInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([['discriminator', fixEncoderSize(getBytesEncoder(), 8)]]),
-    (value) => ({ ...value, discriminator: INITIALIZE_DISCRIMINATOR })
-  );
+    return transformEncoder(getStructEncoder([['discriminator', fixEncoderSize(getBytesEncoder(), 8)]]), value => ({
+        ...value,
+        discriminator: INITIALIZE_DISCRIMINATOR,
+    }));
 }
 
 export function getInitializeInstructionDataDecoder(): FixedSizeDecoder<InitializeInstructionData> {
-  return getStructDecoder([
-    ['discriminator', fixDecoderSize(getBytesDecoder(), 8)],
-  ]);
+    return getStructDecoder([['discriminator', fixDecoderSize(getBytesDecoder(), 8)]]);
 }
 
 export function getInitializeInstructionDataCodec(): FixedSizeCodec<
-  InitializeInstructionDataArgs,
-  InitializeInstructionData
+    InitializeInstructionDataArgs,
+    InitializeInstructionData
 > {
-  return combineCodec(
-    getInitializeInstructionDataEncoder(),
-    getInitializeInstructionDataDecoder()
-  );
+    return combineCodec(getInitializeInstructionDataEncoder(), getInitializeInstructionDataDecoder());
 }
 
 export type InitializeAsyncInput<
-  TAccountExtraMetasAccount extends string = string,
-  TAccountGuard extends string = string,
-  TAccountMint extends string = string,
-  TAccountTransferHookAuthority extends string = string,
-  TAccountSystemProgram extends string = string,
-  TAccountPayer extends string = string,
+    TAccountExtraMetasAccount extends string = string,
+    TAccountGuard extends string = string,
+    TAccountMint extends string = string,
+    TAccountTransferHookAuthority extends string = string,
+    TAccountSystemProgram extends string = string,
+    TAccountPayer extends string = string,
 > = {
-  extraMetasAccount?: Address<TAccountExtraMetasAccount>;
-  guard: Address<TAccountGuard>;
-  mint: Address<TAccountMint>;
-  transferHookAuthority: TransactionSigner<TAccountTransferHookAuthority>;
-  systemProgram?: Address<TAccountSystemProgram>;
-  payer: TransactionSigner<TAccountPayer>;
+    extraMetasAccount?: Address<TAccountExtraMetasAccount>;
+    guard: Address<TAccountGuard>;
+    mint: Address<TAccountMint>;
+    transferHookAuthority: TransactionSigner<TAccountTransferHookAuthority>;
+    systemProgram?: Address<TAccountSystemProgram>;
+    payer: TransactionSigner<TAccountPayer>;
 };
 
 export async function getInitializeInstructionAsync<
-  TAccountExtraMetasAccount extends string,
-  TAccountGuard extends string,
-  TAccountMint extends string,
-  TAccountTransferHookAuthority extends string,
-  TAccountSystemProgram extends string,
-  TAccountPayer extends string,
-  TProgramAddress extends Address = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+    TAccountExtraMetasAccount extends string,
+    TAccountGuard extends string,
+    TAccountMint extends string,
+    TAccountTransferHookAuthority extends string,
+    TAccountSystemProgram extends string,
+    TAccountPayer extends string,
+    TProgramAddress extends Address = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
 >(
-  input: InitializeAsyncInput<
-    TAccountExtraMetasAccount,
-    TAccountGuard,
-    TAccountMint,
-    TAccountTransferHookAuthority,
-    TAccountSystemProgram,
-    TAccountPayer
-  >,
-  config?: { programAddress?: TProgramAddress }
+    input: InitializeAsyncInput<
+        TAccountExtraMetasAccount,
+        TAccountGuard,
+        TAccountMint,
+        TAccountTransferHookAuthority,
+        TAccountSystemProgram,
+        TAccountPayer
+    >,
+    config?: { programAddress?: TProgramAddress }
 ): Promise<
-  InitializeInstruction<
-    TProgramAddress,
-    TAccountExtraMetasAccount,
-    TAccountGuard,
-    TAccountMint,
-    TAccountTransferHookAuthority,
-    TAccountSystemProgram,
-    TAccountPayer
-  >
+    InitializeInstruction<
+        TProgramAddress,
+        TAccountExtraMetasAccount,
+        TAccountGuard,
+        TAccountMint,
+        TAccountTransferHookAuthority,
+        TAccountSystemProgram,
+        TAccountPayer
+    >
 > {
-  // Program address.
-  const programAddress =
-    config?.programAddress ?? WEN_TRANSFER_GUARD_PROGRAM_ADDRESS;
+    // Program address.
+    const programAddress = config?.programAddress ?? WEN_TRANSFER_GUARD_PROGRAM_ADDRESS;
 
-  // Original accounts.
-  const originalAccounts = {
-    extraMetasAccount: {
-      value: input.extraMetasAccount ?? null,
-      isWritable: true,
-    },
-    guard: { value: input.guard ?? null, isWritable: false },
-    mint: { value: input.mint ?? null, isWritable: false },
-    transferHookAuthority: {
-      value: input.transferHookAuthority ?? null,
-      isWritable: true,
-    },
-    systemProgram: { value: input.systemProgram ?? null, isWritable: false },
-    payer: { value: input.payer ?? null, isWritable: true },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
+    // Original accounts.
+    const originalAccounts = {
+        extraMetasAccount: { value: input.extraMetasAccount ?? null, isWritable: true },
+        guard: { value: input.guard ?? null, isWritable: false },
+        mint: { value: input.mint ?? null, isWritable: false },
+        transferHookAuthority: { value: input.transferHookAuthority ?? null, isWritable: true },
+        systemProgram: { value: input.systemProgram ?? null, isWritable: false },
+        payer: { value: input.payer ?? null, isWritable: true },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
 
-  // Resolve default values.
-  if (!accounts.extraMetasAccount.value) {
-    accounts.extraMetasAccount.value = await getProgramDerivedAddress({
-      programAddress,
-      seeds: [
-        getBytesEncoder().encode(
-          new Uint8Array([
-            101, 120, 116, 114, 97, 45, 97, 99, 99, 111, 117, 110, 116, 45, 109,
-            101, 116, 97, 115,
-          ])
-        ),
-        getAddressEncoder().encode(expectAddress(accounts.mint.value)),
-      ],
-    });
-  }
-  if (!accounts.systemProgram.value) {
-    accounts.systemProgram.value =
-      '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
-  }
+    // Resolve default values.
+    if (!accounts.extraMetasAccount.value) {
+        accounts.extraMetasAccount.value = await getProgramDerivedAddress({
+            programAddress,
+            seeds: [
+                getBytesEncoder().encode(
+                    new Uint8Array([
+                        101, 120, 116, 114, 97, 45, 97, 99, 99, 111, 117, 110, 116, 45, 109, 101, 116, 97, 115,
+                    ])
+                ),
+                getAddressEncoder().encode(expectAddress(accounts.mint.value)),
+            ],
+        });
+    }
+    if (!accounts.systemProgram.value) {
+        accounts.systemProgram.value =
+            '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
+    }
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.extraMetasAccount),
-      getAccountMeta(accounts.guard),
-      getAccountMeta(accounts.mint),
-      getAccountMeta(accounts.transferHookAuthority),
-      getAccountMeta(accounts.systemProgram),
-      getAccountMeta(accounts.payer),
-    ],
-    data: getInitializeInstructionDataEncoder().encode({}),
-    programAddress,
-  } as InitializeInstruction<
-    TProgramAddress,
-    TAccountExtraMetasAccount,
-    TAccountGuard,
-    TAccountMint,
-    TAccountTransferHookAuthority,
-    TAccountSystemProgram,
-    TAccountPayer
-  >);
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [
+            getAccountMeta(accounts.extraMetasAccount),
+            getAccountMeta(accounts.guard),
+            getAccountMeta(accounts.mint),
+            getAccountMeta(accounts.transferHookAuthority),
+            getAccountMeta(accounts.systemProgram),
+            getAccountMeta(accounts.payer),
+        ],
+        data: getInitializeInstructionDataEncoder().encode({}),
+        programAddress,
+    } as InitializeInstruction<
+        TProgramAddress,
+        TAccountExtraMetasAccount,
+        TAccountGuard,
+        TAccountMint,
+        TAccountTransferHookAuthority,
+        TAccountSystemProgram,
+        TAccountPayer
+    >);
 }
 
 export type InitializeInput<
-  TAccountExtraMetasAccount extends string = string,
-  TAccountGuard extends string = string,
-  TAccountMint extends string = string,
-  TAccountTransferHookAuthority extends string = string,
-  TAccountSystemProgram extends string = string,
-  TAccountPayer extends string = string,
+    TAccountExtraMetasAccount extends string = string,
+    TAccountGuard extends string = string,
+    TAccountMint extends string = string,
+    TAccountTransferHookAuthority extends string = string,
+    TAccountSystemProgram extends string = string,
+    TAccountPayer extends string = string,
 > = {
-  extraMetasAccount: Address<TAccountExtraMetasAccount>;
-  guard: Address<TAccountGuard>;
-  mint: Address<TAccountMint>;
-  transferHookAuthority: TransactionSigner<TAccountTransferHookAuthority>;
-  systemProgram?: Address<TAccountSystemProgram>;
-  payer: TransactionSigner<TAccountPayer>;
+    extraMetasAccount: Address<TAccountExtraMetasAccount>;
+    guard: Address<TAccountGuard>;
+    mint: Address<TAccountMint>;
+    transferHookAuthority: TransactionSigner<TAccountTransferHookAuthority>;
+    systemProgram?: Address<TAccountSystemProgram>;
+    payer: TransactionSigner<TAccountPayer>;
 };
 
 export function getInitializeInstruction<
-  TAccountExtraMetasAccount extends string,
-  TAccountGuard extends string,
-  TAccountMint extends string,
-  TAccountTransferHookAuthority extends string,
-  TAccountSystemProgram extends string,
-  TAccountPayer extends string,
-  TProgramAddress extends Address = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+    TAccountExtraMetasAccount extends string,
+    TAccountGuard extends string,
+    TAccountMint extends string,
+    TAccountTransferHookAuthority extends string,
+    TAccountSystemProgram extends string,
+    TAccountPayer extends string,
+    TProgramAddress extends Address = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
 >(
-  input: InitializeInput<
-    TAccountExtraMetasAccount,
-    TAccountGuard,
-    TAccountMint,
-    TAccountTransferHookAuthority,
-    TAccountSystemProgram,
-    TAccountPayer
-  >,
-  config?: { programAddress?: TProgramAddress }
+    input: InitializeInput<
+        TAccountExtraMetasAccount,
+        TAccountGuard,
+        TAccountMint,
+        TAccountTransferHookAuthority,
+        TAccountSystemProgram,
+        TAccountPayer
+    >,
+    config?: { programAddress?: TProgramAddress }
 ): InitializeInstruction<
-  TProgramAddress,
-  TAccountExtraMetasAccount,
-  TAccountGuard,
-  TAccountMint,
-  TAccountTransferHookAuthority,
-  TAccountSystemProgram,
-  TAccountPayer
-> {
-  // Program address.
-  const programAddress =
-    config?.programAddress ?? WEN_TRANSFER_GUARD_PROGRAM_ADDRESS;
-
-  // Original accounts.
-  const originalAccounts = {
-    extraMetasAccount: {
-      value: input.extraMetasAccount ?? null,
-      isWritable: true,
-    },
-    guard: { value: input.guard ?? null, isWritable: false },
-    mint: { value: input.mint ?? null, isWritable: false },
-    transferHookAuthority: {
-      value: input.transferHookAuthority ?? null,
-      isWritable: true,
-    },
-    systemProgram: { value: input.systemProgram ?? null, isWritable: false },
-    payer: { value: input.payer ?? null, isWritable: true },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
-
-  // Resolve default values.
-  if (!accounts.systemProgram.value) {
-    accounts.systemProgram.value =
-      '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
-  }
-
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.extraMetasAccount),
-      getAccountMeta(accounts.guard),
-      getAccountMeta(accounts.mint),
-      getAccountMeta(accounts.transferHookAuthority),
-      getAccountMeta(accounts.systemProgram),
-      getAccountMeta(accounts.payer),
-    ],
-    data: getInitializeInstructionDataEncoder().encode({}),
-    programAddress,
-  } as InitializeInstruction<
     TProgramAddress,
     TAccountExtraMetasAccount,
     TAccountGuard,
@@ -317,53 +236,91 @@ export function getInitializeInstruction<
     TAccountTransferHookAuthority,
     TAccountSystemProgram,
     TAccountPayer
-  >);
+> {
+    // Program address.
+    const programAddress = config?.programAddress ?? WEN_TRANSFER_GUARD_PROGRAM_ADDRESS;
+
+    // Original accounts.
+    const originalAccounts = {
+        extraMetasAccount: { value: input.extraMetasAccount ?? null, isWritable: true },
+        guard: { value: input.guard ?? null, isWritable: false },
+        mint: { value: input.mint ?? null, isWritable: false },
+        transferHookAuthority: { value: input.transferHookAuthority ?? null, isWritable: true },
+        systemProgram: { value: input.systemProgram ?? null, isWritable: false },
+        payer: { value: input.payer ?? null, isWritable: true },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
+
+    // Resolve default values.
+    if (!accounts.systemProgram.value) {
+        accounts.systemProgram.value =
+            '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
+    }
+
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [
+            getAccountMeta(accounts.extraMetasAccount),
+            getAccountMeta(accounts.guard),
+            getAccountMeta(accounts.mint),
+            getAccountMeta(accounts.transferHookAuthority),
+            getAccountMeta(accounts.systemProgram),
+            getAccountMeta(accounts.payer),
+        ],
+        data: getInitializeInstructionDataEncoder().encode({}),
+        programAddress,
+    } as InitializeInstruction<
+        TProgramAddress,
+        TAccountExtraMetasAccount,
+        TAccountGuard,
+        TAccountMint,
+        TAccountTransferHookAuthority,
+        TAccountSystemProgram,
+        TAccountPayer
+    >);
 }
 
 export type ParsedInitializeInstruction<
-  TProgram extends string = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    extraMetasAccount: TAccountMetas[0];
-    guard: TAccountMetas[1];
-    mint: TAccountMetas[2];
-    transferHookAuthority: TAccountMetas[3];
-    systemProgram: TAccountMetas[4];
-    payer: TAccountMetas[5];
-  };
-  data: InitializeInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        extraMetasAccount: TAccountMetas[0];
+        guard: TAccountMetas[1];
+        mint: TAccountMetas[2];
+        transferHookAuthority: TAccountMetas[3];
+        systemProgram: TAccountMetas[4];
+        payer: TAccountMetas[5];
+    };
+    data: InitializeInstructionData;
 };
 
-export function parseInitializeInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
->(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+export function parseInitializeInstruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedInitializeInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 6) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: {
-      extraMetasAccount: getNextAccount(),
-      guard: getNextAccount(),
-      mint: getNextAccount(),
-      transferHookAuthority: getNextAccount(),
-      systemProgram: getNextAccount(),
-      payer: getNextAccount(),
-    },
-    data: getInitializeInstructionDataDecoder().decode(instruction.data),
-  };
+    if (instruction.accounts.length < 6) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: {
+            extraMetasAccount: getNextAccount(),
+            guard: getNextAccount(),
+            mint: getNextAccount(),
+            transferHookAuthority: getNextAccount(),
+            systemProgram: getNextAccount(),
+            payer: getNextAccount(),
+        },
+        data: getInitializeInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/anchor/src/generated/instructions/updateGuard.ts
+++ b/test/e2e/anchor/src/generated/instructions/updateGuard.ts
@@ -7,382 +7,288 @@
  */
 
 import {
-  combineCodec,
-  fixDecoderSize,
-  fixEncoderSize,
-  getAddressEncoder,
-  getArrayDecoder,
-  getArrayEncoder,
-  getBytesDecoder,
-  getBytesEncoder,
-  getOptionDecoder,
-  getOptionEncoder,
-  getProgramDerivedAddress,
-  getStructDecoder,
-  getStructEncoder,
-  transformEncoder,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type Codec,
-  type Decoder,
-  type Encoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type Option,
-  type OptionOrNullable,
-  type ReadonlyAccount,
-  type ReadonlySignerAccount,
-  type ReadonlyUint8Array,
-  type TransactionSigner,
-  type WritableAccount,
+    combineCodec,
+    fixDecoderSize,
+    fixEncoderSize,
+    getAddressEncoder,
+    getArrayDecoder,
+    getArrayEncoder,
+    getBytesDecoder,
+    getBytesEncoder,
+    getOptionDecoder,
+    getOptionEncoder,
+    getProgramDerivedAddress,
+    getStructDecoder,
+    getStructEncoder,
+    transformEncoder,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type Codec,
+    type Decoder,
+    type Encoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type Option,
+    type OptionOrNullable,
+    type ReadonlyAccount,
+    type ReadonlySignerAccount,
+    type ReadonlyUint8Array,
+    type TransactionSigner,
+    type WritableAccount,
 } from '@solana/kit';
 import { WEN_TRANSFER_GUARD_PROGRAM_ADDRESS } from '../programs';
+import { expectAddress, getAccountMetaFactory, type ResolvedAccount } from '../shared';
 import {
-  expectAddress,
-  getAccountMetaFactory,
-  type ResolvedAccount,
-} from '../shared';
-import {
-  getCpiRuleDecoder,
-  getCpiRuleEncoder,
-  getMetadataAdditionalFieldRuleDecoder,
-  getMetadataAdditionalFieldRuleEncoder,
-  getTransferAmountRuleDecoder,
-  getTransferAmountRuleEncoder,
-  type CpiRule,
-  type CpiRuleArgs,
-  type MetadataAdditionalFieldRule,
-  type MetadataAdditionalFieldRuleArgs,
-  type TransferAmountRule,
-  type TransferAmountRuleArgs,
+    getCpiRuleDecoder,
+    getCpiRuleEncoder,
+    getMetadataAdditionalFieldRuleDecoder,
+    getMetadataAdditionalFieldRuleEncoder,
+    getTransferAmountRuleDecoder,
+    getTransferAmountRuleEncoder,
+    type CpiRule,
+    type CpiRuleArgs,
+    type MetadataAdditionalFieldRule,
+    type MetadataAdditionalFieldRuleArgs,
+    type TransferAmountRule,
+    type TransferAmountRuleArgs,
 } from '../types';
 
-export const UPDATE_GUARD_DISCRIMINATOR = new Uint8Array([
-  51, 38, 175, 180, 25, 249, 39, 24,
-]);
+export const UPDATE_GUARD_DISCRIMINATOR = new Uint8Array([51, 38, 175, 180, 25, 249, 39, 24]);
 
 export function getUpdateGuardDiscriminatorBytes() {
-  return fixEncoderSize(getBytesEncoder(), 8).encode(
-    UPDATE_GUARD_DISCRIMINATOR
-  );
+    return fixEncoderSize(getBytesEncoder(), 8).encode(UPDATE_GUARD_DISCRIMINATOR);
 }
 
 export type UpdateGuardInstruction<
-  TProgram extends string = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
-  TAccountGuard extends string | AccountMeta<string> = string,
-  TAccountMint extends string | AccountMeta<string> = string,
-  TAccountTokenAccount extends string | AccountMeta<string> = string,
-  TAccountGuardAuthority extends string | AccountMeta<string> = string,
-  TAccountTokenProgram extends string | AccountMeta<string> =
-    'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
-  TAccountSystemProgram extends string | AccountMeta<string> =
-    '11111111111111111111111111111111',
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+    TAccountGuard extends string | AccountMeta<string> = string,
+    TAccountMint extends string | AccountMeta<string> = string,
+    TAccountTokenAccount extends string | AccountMeta<string> = string,
+    TAccountGuardAuthority extends string | AccountMeta<string> = string,
+    TAccountTokenProgram extends string | AccountMeta<string> = 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+    TAccountSystemProgram extends string | AccountMeta<string> = '11111111111111111111111111111111',
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountGuard extends string
-        ? WritableAccount<TAccountGuard>
-        : TAccountGuard,
-      TAccountMint extends string
-        ? ReadonlyAccount<TAccountMint>
-        : TAccountMint,
-      TAccountTokenAccount extends string
-        ? ReadonlyAccount<TAccountTokenAccount>
-        : TAccountTokenAccount,
-      TAccountGuardAuthority extends string
-        ? ReadonlySignerAccount<TAccountGuardAuthority> &
-            AccountSignerMeta<TAccountGuardAuthority>
-        : TAccountGuardAuthority,
-      TAccountTokenProgram extends string
-        ? ReadonlyAccount<TAccountTokenProgram>
-        : TAccountTokenProgram,
-      TAccountSystemProgram extends string
-        ? ReadonlyAccount<TAccountSystemProgram>
-        : TAccountSystemProgram,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountGuard extends string ? WritableAccount<TAccountGuard> : TAccountGuard,
+            TAccountMint extends string ? ReadonlyAccount<TAccountMint> : TAccountMint,
+            TAccountTokenAccount extends string ? ReadonlyAccount<TAccountTokenAccount> : TAccountTokenAccount,
+            TAccountGuardAuthority extends string
+                ? ReadonlySignerAccount<TAccountGuardAuthority> & AccountSignerMeta<TAccountGuardAuthority>
+                : TAccountGuardAuthority,
+            TAccountTokenProgram extends string ? ReadonlyAccount<TAccountTokenProgram> : TAccountTokenProgram,
+            TAccountSystemProgram extends string ? ReadonlyAccount<TAccountSystemProgram> : TAccountSystemProgram,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type UpdateGuardInstructionData = {
-  discriminator: ReadonlyUint8Array;
-  cpiRule: Option<CpiRule>;
-  transferAmountRule: Option<TransferAmountRule>;
-  additionalFieldsRule: Array<MetadataAdditionalFieldRule>;
+    discriminator: ReadonlyUint8Array;
+    cpiRule: Option<CpiRule>;
+    transferAmountRule: Option<TransferAmountRule>;
+    additionalFieldsRule: Array<MetadataAdditionalFieldRule>;
 };
 
 export type UpdateGuardInstructionDataArgs = {
-  cpiRule: OptionOrNullable<CpiRuleArgs>;
-  transferAmountRule: OptionOrNullable<TransferAmountRuleArgs>;
-  additionalFieldsRule: Array<MetadataAdditionalFieldRuleArgs>;
+    cpiRule: OptionOrNullable<CpiRuleArgs>;
+    transferAmountRule: OptionOrNullable<TransferAmountRuleArgs>;
+    additionalFieldsRule: Array<MetadataAdditionalFieldRuleArgs>;
 };
 
 export function getUpdateGuardInstructionDataEncoder(): Encoder<UpdateGuardInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', fixEncoderSize(getBytesEncoder(), 8)],
-      ['cpiRule', getOptionEncoder(getCpiRuleEncoder())],
-      ['transferAmountRule', getOptionEncoder(getTransferAmountRuleEncoder())],
-      [
-        'additionalFieldsRule',
-        getArrayEncoder(getMetadataAdditionalFieldRuleEncoder()),
-      ],
-    ]),
-    (value) => ({ ...value, discriminator: UPDATE_GUARD_DISCRIMINATOR })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', fixEncoderSize(getBytesEncoder(), 8)],
+            ['cpiRule', getOptionEncoder(getCpiRuleEncoder())],
+            ['transferAmountRule', getOptionEncoder(getTransferAmountRuleEncoder())],
+            ['additionalFieldsRule', getArrayEncoder(getMetadataAdditionalFieldRuleEncoder())],
+        ]),
+        value => ({ ...value, discriminator: UPDATE_GUARD_DISCRIMINATOR })
+    );
 }
 
 export function getUpdateGuardInstructionDataDecoder(): Decoder<UpdateGuardInstructionData> {
-  return getStructDecoder([
-    ['discriminator', fixDecoderSize(getBytesDecoder(), 8)],
-    ['cpiRule', getOptionDecoder(getCpiRuleDecoder())],
-    ['transferAmountRule', getOptionDecoder(getTransferAmountRuleDecoder())],
-    [
-      'additionalFieldsRule',
-      getArrayDecoder(getMetadataAdditionalFieldRuleDecoder()),
-    ],
-  ]);
+    return getStructDecoder([
+        ['discriminator', fixDecoderSize(getBytesDecoder(), 8)],
+        ['cpiRule', getOptionDecoder(getCpiRuleDecoder())],
+        ['transferAmountRule', getOptionDecoder(getTransferAmountRuleDecoder())],
+        ['additionalFieldsRule', getArrayDecoder(getMetadataAdditionalFieldRuleDecoder())],
+    ]);
 }
 
 export function getUpdateGuardInstructionDataCodec(): Codec<
-  UpdateGuardInstructionDataArgs,
-  UpdateGuardInstructionData
+    UpdateGuardInstructionDataArgs,
+    UpdateGuardInstructionData
 > {
-  return combineCodec(
-    getUpdateGuardInstructionDataEncoder(),
-    getUpdateGuardInstructionDataDecoder()
-  );
+    return combineCodec(getUpdateGuardInstructionDataEncoder(), getUpdateGuardInstructionDataDecoder());
 }
 
 export type UpdateGuardAsyncInput<
-  TAccountGuard extends string = string,
-  TAccountMint extends string = string,
-  TAccountTokenAccount extends string = string,
-  TAccountGuardAuthority extends string = string,
-  TAccountTokenProgram extends string = string,
-  TAccountSystemProgram extends string = string,
+    TAccountGuard extends string = string,
+    TAccountMint extends string = string,
+    TAccountTokenAccount extends string = string,
+    TAccountGuardAuthority extends string = string,
+    TAccountTokenProgram extends string = string,
+    TAccountSystemProgram extends string = string,
 > = {
-  guard?: Address<TAccountGuard>;
-  mint: Address<TAccountMint>;
-  tokenAccount?: Address<TAccountTokenAccount>;
-  guardAuthority: TransactionSigner<TAccountGuardAuthority>;
-  tokenProgram?: Address<TAccountTokenProgram>;
-  systemProgram?: Address<TAccountSystemProgram>;
-  cpiRule: UpdateGuardInstructionDataArgs['cpiRule'];
-  transferAmountRule: UpdateGuardInstructionDataArgs['transferAmountRule'];
-  additionalFieldsRule: UpdateGuardInstructionDataArgs['additionalFieldsRule'];
+    guard?: Address<TAccountGuard>;
+    mint: Address<TAccountMint>;
+    tokenAccount?: Address<TAccountTokenAccount>;
+    guardAuthority: TransactionSigner<TAccountGuardAuthority>;
+    tokenProgram?: Address<TAccountTokenProgram>;
+    systemProgram?: Address<TAccountSystemProgram>;
+    cpiRule: UpdateGuardInstructionDataArgs['cpiRule'];
+    transferAmountRule: UpdateGuardInstructionDataArgs['transferAmountRule'];
+    additionalFieldsRule: UpdateGuardInstructionDataArgs['additionalFieldsRule'];
 };
 
 export async function getUpdateGuardInstructionAsync<
-  TAccountGuard extends string,
-  TAccountMint extends string,
-  TAccountTokenAccount extends string,
-  TAccountGuardAuthority extends string,
-  TAccountTokenProgram extends string,
-  TAccountSystemProgram extends string,
-  TProgramAddress extends Address = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+    TAccountGuard extends string,
+    TAccountMint extends string,
+    TAccountTokenAccount extends string,
+    TAccountGuardAuthority extends string,
+    TAccountTokenProgram extends string,
+    TAccountSystemProgram extends string,
+    TProgramAddress extends Address = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
 >(
-  input: UpdateGuardAsyncInput<
-    TAccountGuard,
-    TAccountMint,
-    TAccountTokenAccount,
-    TAccountGuardAuthority,
-    TAccountTokenProgram,
-    TAccountSystemProgram
-  >,
-  config?: { programAddress?: TProgramAddress }
+    input: UpdateGuardAsyncInput<
+        TAccountGuard,
+        TAccountMint,
+        TAccountTokenAccount,
+        TAccountGuardAuthority,
+        TAccountTokenProgram,
+        TAccountSystemProgram
+    >,
+    config?: { programAddress?: TProgramAddress }
 ): Promise<
-  UpdateGuardInstruction<
-    TProgramAddress,
-    TAccountGuard,
-    TAccountMint,
-    TAccountTokenAccount,
-    TAccountGuardAuthority,
-    TAccountTokenProgram,
-    TAccountSystemProgram
-  >
+    UpdateGuardInstruction<
+        TProgramAddress,
+        TAccountGuard,
+        TAccountMint,
+        TAccountTokenAccount,
+        TAccountGuardAuthority,
+        TAccountTokenProgram,
+        TAccountSystemProgram
+    >
 > {
-  // Program address.
-  const programAddress =
-    config?.programAddress ?? WEN_TRANSFER_GUARD_PROGRAM_ADDRESS;
+    // Program address.
+    const programAddress = config?.programAddress ?? WEN_TRANSFER_GUARD_PROGRAM_ADDRESS;
 
-  // Original accounts.
-  const originalAccounts = {
-    guard: { value: input.guard ?? null, isWritable: true },
-    mint: { value: input.mint ?? null, isWritable: false },
-    tokenAccount: { value: input.tokenAccount ?? null, isWritable: false },
-    guardAuthority: { value: input.guardAuthority ?? null, isWritable: false },
-    tokenProgram: { value: input.tokenProgram ?? null, isWritable: false },
-    systemProgram: { value: input.systemProgram ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
+    // Original accounts.
+    const originalAccounts = {
+        guard: { value: input.guard ?? null, isWritable: true },
+        mint: { value: input.mint ?? null, isWritable: false },
+        tokenAccount: { value: input.tokenAccount ?? null, isWritable: false },
+        guardAuthority: { value: input.guardAuthority ?? null, isWritable: false },
+        tokenProgram: { value: input.tokenProgram ?? null, isWritable: false },
+        systemProgram: { value: input.systemProgram ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
 
-  // Original args.
-  const args = { ...input };
+    // Original args.
+    const args = { ...input };
 
-  // Resolve default values.
-  if (!accounts.guard.value) {
-    accounts.guard.value = await getProgramDerivedAddress({
-      programAddress,
-      seeds: [
-        getBytesEncoder().encode(
-          new Uint8Array([
-            119, 101, 110, 95, 116, 111, 107, 101, 110, 95, 116, 114, 97, 110,
-            115, 102, 101, 114, 95, 103, 117, 97, 114, 100,
-          ])
-        ),
-        getBytesEncoder().encode(
-          new Uint8Array([103, 117, 97, 114, 100, 95, 118, 49])
-        ),
-        getAddressEncoder().encode(expectAddress(accounts.mint.value)),
-      ],
-    });
-  }
-  if (!accounts.tokenProgram.value) {
-    accounts.tokenProgram.value =
-      'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb' as Address<'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb'>;
-  }
-  if (!accounts.tokenAccount.value) {
-    accounts.tokenAccount.value = await getProgramDerivedAddress({
-      programAddress:
-        'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL' as Address<'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL'>,
-      seeds: [
-        getAddressEncoder().encode(
-          expectAddress(accounts.guardAuthority.value)
-        ),
-        getAddressEncoder().encode(expectAddress(accounts.tokenProgram.value)),
-        getAddressEncoder().encode(expectAddress(accounts.mint.value)),
-      ],
-    });
-  }
-  if (!accounts.systemProgram.value) {
-    accounts.systemProgram.value =
-      '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
-  }
+    // Resolve default values.
+    if (!accounts.guard.value) {
+        accounts.guard.value = await getProgramDerivedAddress({
+            programAddress,
+            seeds: [
+                getBytesEncoder().encode(
+                    new Uint8Array([
+                        119, 101, 110, 95, 116, 111, 107, 101, 110, 95, 116, 114, 97, 110, 115, 102, 101, 114, 95, 103,
+                        117, 97, 114, 100,
+                    ])
+                ),
+                getBytesEncoder().encode(new Uint8Array([103, 117, 97, 114, 100, 95, 118, 49])),
+                getAddressEncoder().encode(expectAddress(accounts.mint.value)),
+            ],
+        });
+    }
+    if (!accounts.tokenProgram.value) {
+        accounts.tokenProgram.value =
+            'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb' as Address<'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb'>;
+    }
+    if (!accounts.tokenAccount.value) {
+        accounts.tokenAccount.value = await getProgramDerivedAddress({
+            programAddress:
+                'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL' as Address<'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL'>,
+            seeds: [
+                getAddressEncoder().encode(expectAddress(accounts.guardAuthority.value)),
+                getAddressEncoder().encode(expectAddress(accounts.tokenProgram.value)),
+                getAddressEncoder().encode(expectAddress(accounts.mint.value)),
+            ],
+        });
+    }
+    if (!accounts.systemProgram.value) {
+        accounts.systemProgram.value =
+            '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
+    }
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.guard),
-      getAccountMeta(accounts.mint),
-      getAccountMeta(accounts.tokenAccount),
-      getAccountMeta(accounts.guardAuthority),
-      getAccountMeta(accounts.tokenProgram),
-      getAccountMeta(accounts.systemProgram),
-    ],
-    data: getUpdateGuardInstructionDataEncoder().encode(
-      args as UpdateGuardInstructionDataArgs
-    ),
-    programAddress,
-  } as UpdateGuardInstruction<
-    TProgramAddress,
-    TAccountGuard,
-    TAccountMint,
-    TAccountTokenAccount,
-    TAccountGuardAuthority,
-    TAccountTokenProgram,
-    TAccountSystemProgram
-  >);
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [
+            getAccountMeta(accounts.guard),
+            getAccountMeta(accounts.mint),
+            getAccountMeta(accounts.tokenAccount),
+            getAccountMeta(accounts.guardAuthority),
+            getAccountMeta(accounts.tokenProgram),
+            getAccountMeta(accounts.systemProgram),
+        ],
+        data: getUpdateGuardInstructionDataEncoder().encode(args as UpdateGuardInstructionDataArgs),
+        programAddress,
+    } as UpdateGuardInstruction<
+        TProgramAddress,
+        TAccountGuard,
+        TAccountMint,
+        TAccountTokenAccount,
+        TAccountGuardAuthority,
+        TAccountTokenProgram,
+        TAccountSystemProgram
+    >);
 }
 
 export type UpdateGuardInput<
-  TAccountGuard extends string = string,
-  TAccountMint extends string = string,
-  TAccountTokenAccount extends string = string,
-  TAccountGuardAuthority extends string = string,
-  TAccountTokenProgram extends string = string,
-  TAccountSystemProgram extends string = string,
+    TAccountGuard extends string = string,
+    TAccountMint extends string = string,
+    TAccountTokenAccount extends string = string,
+    TAccountGuardAuthority extends string = string,
+    TAccountTokenProgram extends string = string,
+    TAccountSystemProgram extends string = string,
 > = {
-  guard: Address<TAccountGuard>;
-  mint: Address<TAccountMint>;
-  tokenAccount: Address<TAccountTokenAccount>;
-  guardAuthority: TransactionSigner<TAccountGuardAuthority>;
-  tokenProgram?: Address<TAccountTokenProgram>;
-  systemProgram?: Address<TAccountSystemProgram>;
-  cpiRule: UpdateGuardInstructionDataArgs['cpiRule'];
-  transferAmountRule: UpdateGuardInstructionDataArgs['transferAmountRule'];
-  additionalFieldsRule: UpdateGuardInstructionDataArgs['additionalFieldsRule'];
+    guard: Address<TAccountGuard>;
+    mint: Address<TAccountMint>;
+    tokenAccount: Address<TAccountTokenAccount>;
+    guardAuthority: TransactionSigner<TAccountGuardAuthority>;
+    tokenProgram?: Address<TAccountTokenProgram>;
+    systemProgram?: Address<TAccountSystemProgram>;
+    cpiRule: UpdateGuardInstructionDataArgs['cpiRule'];
+    transferAmountRule: UpdateGuardInstructionDataArgs['transferAmountRule'];
+    additionalFieldsRule: UpdateGuardInstructionDataArgs['additionalFieldsRule'];
 };
 
 export function getUpdateGuardInstruction<
-  TAccountGuard extends string,
-  TAccountMint extends string,
-  TAccountTokenAccount extends string,
-  TAccountGuardAuthority extends string,
-  TAccountTokenProgram extends string,
-  TAccountSystemProgram extends string,
-  TProgramAddress extends Address = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+    TAccountGuard extends string,
+    TAccountMint extends string,
+    TAccountTokenAccount extends string,
+    TAccountGuardAuthority extends string,
+    TAccountTokenProgram extends string,
+    TAccountSystemProgram extends string,
+    TProgramAddress extends Address = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
 >(
-  input: UpdateGuardInput<
-    TAccountGuard,
-    TAccountMint,
-    TAccountTokenAccount,
-    TAccountGuardAuthority,
-    TAccountTokenProgram,
-    TAccountSystemProgram
-  >,
-  config?: { programAddress?: TProgramAddress }
+    input: UpdateGuardInput<
+        TAccountGuard,
+        TAccountMint,
+        TAccountTokenAccount,
+        TAccountGuardAuthority,
+        TAccountTokenProgram,
+        TAccountSystemProgram
+    >,
+    config?: { programAddress?: TProgramAddress }
 ): UpdateGuardInstruction<
-  TProgramAddress,
-  TAccountGuard,
-  TAccountMint,
-  TAccountTokenAccount,
-  TAccountGuardAuthority,
-  TAccountTokenProgram,
-  TAccountSystemProgram
-> {
-  // Program address.
-  const programAddress =
-    config?.programAddress ?? WEN_TRANSFER_GUARD_PROGRAM_ADDRESS;
-
-  // Original accounts.
-  const originalAccounts = {
-    guard: { value: input.guard ?? null, isWritable: true },
-    mint: { value: input.mint ?? null, isWritable: false },
-    tokenAccount: { value: input.tokenAccount ?? null, isWritable: false },
-    guardAuthority: { value: input.guardAuthority ?? null, isWritable: false },
-    tokenProgram: { value: input.tokenProgram ?? null, isWritable: false },
-    systemProgram: { value: input.systemProgram ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
-
-  // Original args.
-  const args = { ...input };
-
-  // Resolve default values.
-  if (!accounts.tokenProgram.value) {
-    accounts.tokenProgram.value =
-      'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb' as Address<'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb'>;
-  }
-  if (!accounts.systemProgram.value) {
-    accounts.systemProgram.value =
-      '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
-  }
-
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.guard),
-      getAccountMeta(accounts.mint),
-      getAccountMeta(accounts.tokenAccount),
-      getAccountMeta(accounts.guardAuthority),
-      getAccountMeta(accounts.tokenProgram),
-      getAccountMeta(accounts.systemProgram),
-    ],
-    data: getUpdateGuardInstructionDataEncoder().encode(
-      args as UpdateGuardInstructionDataArgs
-    ),
-    programAddress,
-  } as UpdateGuardInstruction<
     TProgramAddress,
     TAccountGuard,
     TAccountMint,
@@ -390,53 +296,98 @@ export function getUpdateGuardInstruction<
     TAccountGuardAuthority,
     TAccountTokenProgram,
     TAccountSystemProgram
-  >);
+> {
+    // Program address.
+    const programAddress = config?.programAddress ?? WEN_TRANSFER_GUARD_PROGRAM_ADDRESS;
+
+    // Original accounts.
+    const originalAccounts = {
+        guard: { value: input.guard ?? null, isWritable: true },
+        mint: { value: input.mint ?? null, isWritable: false },
+        tokenAccount: { value: input.tokenAccount ?? null, isWritable: false },
+        guardAuthority: { value: input.guardAuthority ?? null, isWritable: false },
+        tokenProgram: { value: input.tokenProgram ?? null, isWritable: false },
+        systemProgram: { value: input.systemProgram ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
+
+    // Original args.
+    const args = { ...input };
+
+    // Resolve default values.
+    if (!accounts.tokenProgram.value) {
+        accounts.tokenProgram.value =
+            'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb' as Address<'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb'>;
+    }
+    if (!accounts.systemProgram.value) {
+        accounts.systemProgram.value =
+            '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
+    }
+
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [
+            getAccountMeta(accounts.guard),
+            getAccountMeta(accounts.mint),
+            getAccountMeta(accounts.tokenAccount),
+            getAccountMeta(accounts.guardAuthority),
+            getAccountMeta(accounts.tokenProgram),
+            getAccountMeta(accounts.systemProgram),
+        ],
+        data: getUpdateGuardInstructionDataEncoder().encode(args as UpdateGuardInstructionDataArgs),
+        programAddress,
+    } as UpdateGuardInstruction<
+        TProgramAddress,
+        TAccountGuard,
+        TAccountMint,
+        TAccountTokenAccount,
+        TAccountGuardAuthority,
+        TAccountTokenProgram,
+        TAccountSystemProgram
+    >);
 }
 
 export type ParsedUpdateGuardInstruction<
-  TProgram extends string = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    guard: TAccountMetas[0];
-    mint: TAccountMetas[1];
-    tokenAccount: TAccountMetas[2];
-    guardAuthority: TAccountMetas[3];
-    tokenProgram: TAccountMetas[4];
-    systemProgram: TAccountMetas[5];
-  };
-  data: UpdateGuardInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        guard: TAccountMetas[0];
+        mint: TAccountMetas[1];
+        tokenAccount: TAccountMetas[2];
+        guardAuthority: TAccountMetas[3];
+        tokenProgram: TAccountMetas[4];
+        systemProgram: TAccountMetas[5];
+    };
+    data: UpdateGuardInstructionData;
 };
 
-export function parseUpdateGuardInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
->(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+export function parseUpdateGuardInstruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedUpdateGuardInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 6) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: {
-      guard: getNextAccount(),
-      mint: getNextAccount(),
-      tokenAccount: getNextAccount(),
-      guardAuthority: getNextAccount(),
-      tokenProgram: getNextAccount(),
-      systemProgram: getNextAccount(),
-    },
-    data: getUpdateGuardInstructionDataDecoder().decode(instruction.data),
-  };
+    if (instruction.accounts.length < 6) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: {
+            guard: getNextAccount(),
+            mint: getNextAccount(),
+            tokenAccount: getNextAccount(),
+            guardAuthority: getNextAccount(),
+            tokenProgram: getNextAccount(),
+            systemProgram: getNextAccount(),
+        },
+        data: getUpdateGuardInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/anchor/src/generated/programs/wenTransferGuard.ts
+++ b/test/e2e/anchor/src/generated/programs/wenTransferGuard.ts
@@ -6,119 +6,89 @@
  * @see https://github.com/codama-idl/codama
  */
 
+import { containsBytes, fixEncoderSize, getBytesEncoder, type Address, type ReadonlyUint8Array } from '@solana/kit';
 import {
-  containsBytes,
-  fixEncoderSize,
-  getBytesEncoder,
-  type Address,
-  type ReadonlyUint8Array,
-} from '@solana/kit';
-import {
-  type ParsedCreateGuardInstruction,
-  type ParsedExecuteInstruction,
-  type ParsedInitializeInstruction,
-  type ParsedUpdateGuardInstruction,
+    type ParsedCreateGuardInstruction,
+    type ParsedExecuteInstruction,
+    type ParsedInitializeInstruction,
+    type ParsedUpdateGuardInstruction,
 } from '../instructions';
 
 export const WEN_TRANSFER_GUARD_PROGRAM_ADDRESS =
-  'LockdqYQ9X2kwtWB99ioSbxubAmEi8o9jqYwbXgrrRw' as Address<'LockdqYQ9X2kwtWB99ioSbxubAmEi8o9jqYwbXgrrRw'>;
+    'LockdqYQ9X2kwtWB99ioSbxubAmEi8o9jqYwbXgrrRw' as Address<'LockdqYQ9X2kwtWB99ioSbxubAmEi8o9jqYwbXgrrRw'>;
 
 export enum WenTransferGuardAccount {
-  GuardV1,
+    GuardV1,
 }
 
 export function identifyWenTransferGuardAccount(
-  account: { data: ReadonlyUint8Array } | ReadonlyUint8Array
+    account: { data: ReadonlyUint8Array } | ReadonlyUint8Array
 ): WenTransferGuardAccount {
-  const data = 'data' in account ? account.data : account;
-  if (
-    containsBytes(
-      data,
-      fixEncoderSize(getBytesEncoder(), 8).encode(
-        new Uint8Array([185, 149, 156, 78, 245, 108, 172, 68])
-      ),
-      0
-    )
-  ) {
-    return WenTransferGuardAccount.GuardV1;
-  }
-  throw new Error(
-    'The provided account could not be identified as a wenTransferGuard account.'
-  );
+    const data = 'data' in account ? account.data : account;
+    if (
+        containsBytes(
+            data,
+            fixEncoderSize(getBytesEncoder(), 8).encode(new Uint8Array([185, 149, 156, 78, 245, 108, 172, 68])),
+            0
+        )
+    ) {
+        return WenTransferGuardAccount.GuardV1;
+    }
+    throw new Error('The provided account could not be identified as a wenTransferGuard account.');
 }
 
 export enum WenTransferGuardInstruction {
-  CreateGuard,
-  Execute,
-  Initialize,
-  UpdateGuard,
+    CreateGuard,
+    Execute,
+    Initialize,
+    UpdateGuard,
 }
 
 export function identifyWenTransferGuardInstruction(
-  instruction: { data: ReadonlyUint8Array } | ReadonlyUint8Array
+    instruction: { data: ReadonlyUint8Array } | ReadonlyUint8Array
 ): WenTransferGuardInstruction {
-  const data = 'data' in instruction ? instruction.data : instruction;
-  if (
-    containsBytes(
-      data,
-      fixEncoderSize(getBytesEncoder(), 8).encode(
-        new Uint8Array([251, 254, 17, 198, 219, 218, 154, 99])
-      ),
-      0
-    )
-  ) {
-    return WenTransferGuardInstruction.CreateGuard;
-  }
-  if (
-    containsBytes(
-      data,
-      fixEncoderSize(getBytesEncoder(), 8).encode(
-        new Uint8Array([105, 37, 101, 197, 75, 251, 102, 26])
-      ),
-      0
-    )
-  ) {
-    return WenTransferGuardInstruction.Execute;
-  }
-  if (
-    containsBytes(
-      data,
-      fixEncoderSize(getBytesEncoder(), 8).encode(
-        new Uint8Array([43, 34, 13, 49, 167, 88, 235, 235])
-      ),
-      0
-    )
-  ) {
-    return WenTransferGuardInstruction.Initialize;
-  }
-  if (
-    containsBytes(
-      data,
-      fixEncoderSize(getBytesEncoder(), 8).encode(
-        new Uint8Array([51, 38, 175, 180, 25, 249, 39, 24])
-      ),
-      0
-    )
-  ) {
-    return WenTransferGuardInstruction.UpdateGuard;
-  }
-  throw new Error(
-    'The provided instruction could not be identified as a wenTransferGuard instruction.'
-  );
+    const data = 'data' in instruction ? instruction.data : instruction;
+    if (
+        containsBytes(
+            data,
+            fixEncoderSize(getBytesEncoder(), 8).encode(new Uint8Array([251, 254, 17, 198, 219, 218, 154, 99])),
+            0
+        )
+    ) {
+        return WenTransferGuardInstruction.CreateGuard;
+    }
+    if (
+        containsBytes(
+            data,
+            fixEncoderSize(getBytesEncoder(), 8).encode(new Uint8Array([105, 37, 101, 197, 75, 251, 102, 26])),
+            0
+        )
+    ) {
+        return WenTransferGuardInstruction.Execute;
+    }
+    if (
+        containsBytes(
+            data,
+            fixEncoderSize(getBytesEncoder(), 8).encode(new Uint8Array([43, 34, 13, 49, 167, 88, 235, 235])),
+            0
+        )
+    ) {
+        return WenTransferGuardInstruction.Initialize;
+    }
+    if (
+        containsBytes(
+            data,
+            fixEncoderSize(getBytesEncoder(), 8).encode(new Uint8Array([51, 38, 175, 180, 25, 249, 39, 24])),
+            0
+        )
+    ) {
+        return WenTransferGuardInstruction.UpdateGuard;
+    }
+    throw new Error('The provided instruction could not be identified as a wenTransferGuard instruction.');
 }
 
-export type ParsedWenTransferGuardInstruction<
-  TProgram extends string = 'LockdqYQ9X2kwtWB99ioSbxubAmEi8o9jqYwbXgrrRw',
-> =
-  | ({
-      instructionType: WenTransferGuardInstruction.CreateGuard;
-    } & ParsedCreateGuardInstruction<TProgram>)
-  | ({
-      instructionType: WenTransferGuardInstruction.Execute;
-    } & ParsedExecuteInstruction<TProgram>)
-  | ({
-      instructionType: WenTransferGuardInstruction.Initialize;
-    } & ParsedInitializeInstruction<TProgram>)
-  | ({
-      instructionType: WenTransferGuardInstruction.UpdateGuard;
-    } & ParsedUpdateGuardInstruction<TProgram>);
+export type ParsedWenTransferGuardInstruction<TProgram extends string = 'LockdqYQ9X2kwtWB99ioSbxubAmEi8o9jqYwbXgrrRw'> =
+    | ({ instructionType: WenTransferGuardInstruction.CreateGuard } & ParsedCreateGuardInstruction<TProgram>)
+    | ({ instructionType: WenTransferGuardInstruction.Execute } & ParsedExecuteInstruction<TProgram>)
+    | ({ instructionType: WenTransferGuardInstruction.Initialize } & ParsedInitializeInstruction<TProgram>)
+    | ({ instructionType: WenTransferGuardInstruction.UpdateGuard } & ParsedUpdateGuardInstruction<TProgram>);

--- a/test/e2e/anchor/src/generated/shared/index.ts
+++ b/test/e2e/anchor/src/generated/shared/index.ts
@@ -7,15 +7,15 @@
  */
 
 import {
-  AccountRole,
-  isProgramDerivedAddress,
-  isTransactionSigner as kitIsTransactionSigner,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type ProgramDerivedAddress,
-  type TransactionSigner,
-  upgradeRoleToSigner,
+    AccountRole,
+    isProgramDerivedAddress,
+    isTransactionSigner as kitIsTransactionSigner,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type ProgramDerivedAddress,
+    type TransactionSigner,
+    upgradeRoleToSigner,
 } from '@solana/kit';
 
 /**
@@ -23,10 +23,10 @@ import {
  * @internal
  */
 export function expectSome<T>(value: T | null | undefined): T {
-  if (value === null || value === undefined) {
-    throw new Error('Expected a value but received null or undefined.');
-  }
-  return value;
+    if (value === null || value === undefined) {
+        throw new Error('Expected a value but received null or undefined.');
+    }
+    return value;
 }
 
 /**
@@ -34,23 +34,18 @@ export function expectSome<T>(value: T | null | undefined): T {
  * @internal
  */
 export function expectAddress<T extends string = string>(
-  value:
-    | Address<T>
-    | ProgramDerivedAddress<T>
-    | TransactionSigner<T>
-    | null
-    | undefined
+    value: Address<T> | ProgramDerivedAddress<T> | TransactionSigner<T> | null | undefined
 ): Address<T> {
-  if (!value) {
-    throw new Error('Expected a Address.');
-  }
-  if (typeof value === 'object' && 'address' in value) {
-    return value.address;
-  }
-  if (Array.isArray(value)) {
-    return value[0] as Address<T>;
-  }
-  return value as Address<T>;
+    if (!value) {
+        throw new Error('Expected a Address.');
+    }
+    if (typeof value === 'object' && 'address' in value) {
+        return value.address;
+    }
+    if (Array.isArray(value)) {
+        return value[0] as Address<T>;
+    }
+    return value as Address<T>;
 }
 
 /**
@@ -58,17 +53,12 @@ export function expectAddress<T extends string = string>(
  * @internal
  */
 export function expectProgramDerivedAddress<T extends string = string>(
-  value:
-    | Address<T>
-    | ProgramDerivedAddress<T>
-    | TransactionSigner<T>
-    | null
-    | undefined
+    value: Address<T> | ProgramDerivedAddress<T> | TransactionSigner<T> | null | undefined
 ): ProgramDerivedAddress<T> {
-  if (!value || !Array.isArray(value) || !isProgramDerivedAddress(value)) {
-    throw new Error('Expected a ProgramDerivedAddress.');
-  }
-  return value;
+    if (!value || !Array.isArray(value) || !isProgramDerivedAddress(value)) {
+        throw new Error('Expected a ProgramDerivedAddress.');
+    }
+    return value;
 }
 
 /**
@@ -76,17 +66,12 @@ export function expectProgramDerivedAddress<T extends string = string>(
  * @internal
  */
 export function expectTransactionSigner<T extends string = string>(
-  value:
-    | Address<T>
-    | ProgramDerivedAddress<T>
-    | TransactionSigner<T>
-    | null
-    | undefined
+    value: Address<T> | ProgramDerivedAddress<T> | TransactionSigner<T> | null | undefined
 ): TransactionSigner<T> {
-  if (!value || !isTransactionSigner(value)) {
-    throw new Error('Expected a TransactionSigner.');
-  }
-  return value;
+    if (!value || !isTransactionSigner(value)) {
+        throw new Error('Expected a TransactionSigner.');
+    }
+    return value;
 }
 
 /**
@@ -94,19 +79,15 @@ export function expectTransactionSigner<T extends string = string>(
  * @internal
  */
 export type ResolvedAccount<
-  T extends string = string,
-  U extends
-    | Address<T>
-    | ProgramDerivedAddress<T>
-    | TransactionSigner<T>
-    | null =
-    | Address<T>
-    | ProgramDerivedAddress<T>
-    | TransactionSigner<T>
-    | null,
+    T extends string = string,
+    U extends Address<T> | ProgramDerivedAddress<T> | TransactionSigner<T> | null =
+        | Address<T>
+        | ProgramDerivedAddress<T>
+        | TransactionSigner<T>
+        | null,
 > = {
-  isWritable: boolean;
-  value: U;
+    isWritable: boolean;
+    value: U;
 };
 
 /**
@@ -114,51 +95,31 @@ export type ResolvedAccount<
  * @internal
  */
 export type InstructionWithByteDelta = {
-  byteDelta: number;
+    byteDelta: number;
 };
 
 /**
  * Get account metas and signers from resolved accounts.
  * @internal
  */
-export function getAccountMetaFactory(
-  programAddress: Address,
-  optionalAccountStrategy: 'omitted' | 'programId'
-) {
-  return (
-    account: ResolvedAccount
-  ): AccountMeta | AccountSignerMeta | undefined => {
-    if (!account.value) {
-      if (optionalAccountStrategy === 'omitted') return;
-      return Object.freeze({
-        address: programAddress,
-        role: AccountRole.READONLY,
-      });
-    }
+export function getAccountMetaFactory(programAddress: Address, optionalAccountStrategy: 'omitted' | 'programId') {
+    return (account: ResolvedAccount): AccountMeta | AccountSignerMeta | undefined => {
+        if (!account.value) {
+            if (optionalAccountStrategy === 'omitted') return;
+            return Object.freeze({ address: programAddress, role: AccountRole.READONLY });
+        }
 
-    const writableRole = account.isWritable
-      ? AccountRole.WRITABLE
-      : AccountRole.READONLY;
-    return Object.freeze({
-      address: expectAddress(account.value),
-      role: isTransactionSigner(account.value)
-        ? upgradeRoleToSigner(writableRole)
-        : writableRole,
-      ...(isTransactionSigner(account.value) ? { signer: account.value } : {}),
-    });
-  };
+        const writableRole = account.isWritable ? AccountRole.WRITABLE : AccountRole.READONLY;
+        return Object.freeze({
+            address: expectAddress(account.value),
+            role: isTransactionSigner(account.value) ? upgradeRoleToSigner(writableRole) : writableRole,
+            ...(isTransactionSigner(account.value) ? { signer: account.value } : {}),
+        });
+    };
 }
 
 export function isTransactionSigner<TAddress extends string = string>(
-  value:
-    | Address<TAddress>
-    | ProgramDerivedAddress<TAddress>
-    | TransactionSigner<TAddress>
+    value: Address<TAddress> | ProgramDerivedAddress<TAddress> | TransactionSigner<TAddress>
 ): value is TransactionSigner<TAddress> {
-  return (
-    !!value &&
-    typeof value === 'object' &&
-    'address' in value &&
-    kitIsTransactionSigner(value)
-  );
+    return !!value && typeof value === 'object' && 'address' in value && kitIsTransactionSigner(value);
 }

--- a/test/e2e/anchor/src/generated/types/cpiRule.ts
+++ b/test/e2e/anchor/src/generated/types/cpiRule.ts
@@ -7,23 +7,23 @@
  */
 
 import {
-  combineCodec,
-  getAddressDecoder,
-  getAddressEncoder,
-  getArrayDecoder,
-  getArrayEncoder,
-  getDiscriminatedUnionDecoder,
-  getDiscriminatedUnionEncoder,
-  getStructDecoder,
-  getStructEncoder,
-  getTupleDecoder,
-  getTupleEncoder,
-  type Address,
-  type Codec,
-  type Decoder,
-  type Encoder,
-  type GetDiscriminatedUnionVariant,
-  type GetDiscriminatedUnionVariantContent,
+    combineCodec,
+    getAddressDecoder,
+    getAddressEncoder,
+    getArrayDecoder,
+    getArrayEncoder,
+    getDiscriminatedUnionDecoder,
+    getDiscriminatedUnionEncoder,
+    getStructDecoder,
+    getStructEncoder,
+    getTupleDecoder,
+    getTupleEncoder,
+    type Address,
+    type Codec,
+    type Decoder,
+    type Encoder,
+    type GetDiscriminatedUnionVariant,
+    type GetDiscriminatedUnionVariantContent,
 } from '@solana/kit';
 
 /**
@@ -31,78 +31,42 @@ import {
  * enforcing Allow and Deny lists.
  */
 export type CpiRule =
-  | { __kind: 'Allow'; fields: readonly [Array<Address>] }
-  | { __kind: 'Deny'; fields: readonly [Array<Address>] };
+    | { __kind: 'Allow'; fields: readonly [Array<Address>] }
+    | { __kind: 'Deny'; fields: readonly [Array<Address>] };
 
 export type CpiRuleArgs = CpiRule;
 
 export function getCpiRuleEncoder(): Encoder<CpiRuleArgs> {
-  return getDiscriminatedUnionEncoder([
-    [
-      'Allow',
-      getStructEncoder([
-        ['fields', getTupleEncoder([getArrayEncoder(getAddressEncoder())])],
-      ]),
-    ],
-    [
-      'Deny',
-      getStructEncoder([
-        ['fields', getTupleEncoder([getArrayEncoder(getAddressEncoder())])],
-      ]),
-    ],
-  ]);
+    return getDiscriminatedUnionEncoder([
+        ['Allow', getStructEncoder([['fields', getTupleEncoder([getArrayEncoder(getAddressEncoder())])]])],
+        ['Deny', getStructEncoder([['fields', getTupleEncoder([getArrayEncoder(getAddressEncoder())])]])],
+    ]);
 }
 
 export function getCpiRuleDecoder(): Decoder<CpiRule> {
-  return getDiscriminatedUnionDecoder([
-    [
-      'Allow',
-      getStructDecoder([
-        ['fields', getTupleDecoder([getArrayDecoder(getAddressDecoder())])],
-      ]),
-    ],
-    [
-      'Deny',
-      getStructDecoder([
-        ['fields', getTupleDecoder([getArrayDecoder(getAddressDecoder())])],
-      ]),
-    ],
-  ]);
+    return getDiscriminatedUnionDecoder([
+        ['Allow', getStructDecoder([['fields', getTupleDecoder([getArrayDecoder(getAddressDecoder())])]])],
+        ['Deny', getStructDecoder([['fields', getTupleDecoder([getArrayDecoder(getAddressDecoder())])]])],
+    ]);
 }
 
 export function getCpiRuleCodec(): Codec<CpiRuleArgs, CpiRule> {
-  return combineCodec(getCpiRuleEncoder(), getCpiRuleDecoder());
+    return combineCodec(getCpiRuleEncoder(), getCpiRuleDecoder());
 }
 
 // Data Enum Helpers.
 export function cpiRule(
-  kind: 'Allow',
-  data: GetDiscriminatedUnionVariantContent<
-    CpiRuleArgs,
-    '__kind',
-    'Allow'
-  >['fields']
+    kind: 'Allow',
+    data: GetDiscriminatedUnionVariantContent<CpiRuleArgs, '__kind', 'Allow'>['fields']
 ): GetDiscriminatedUnionVariant<CpiRuleArgs, '__kind', 'Allow'>;
 export function cpiRule(
-  kind: 'Deny',
-  data: GetDiscriminatedUnionVariantContent<
-    CpiRuleArgs,
-    '__kind',
-    'Deny'
-  >['fields']
+    kind: 'Deny',
+    data: GetDiscriminatedUnionVariantContent<CpiRuleArgs, '__kind', 'Deny'>['fields']
 ): GetDiscriminatedUnionVariant<CpiRuleArgs, '__kind', 'Deny'>;
-export function cpiRule<K extends CpiRuleArgs['__kind'], Data>(
-  kind: K,
-  data?: Data
-) {
-  return Array.isArray(data)
-    ? { __kind: kind, fields: data }
-    : { __kind: kind, ...(data ?? {}) };
+export function cpiRule<K extends CpiRuleArgs['__kind'], Data>(kind: K, data?: Data) {
+    return Array.isArray(data) ? { __kind: kind, fields: data } : { __kind: kind, ...(data ?? {}) };
 }
 
-export function isCpiRule<K extends CpiRule['__kind']>(
-  kind: K,
-  value: CpiRule
-): value is CpiRule & { __kind: K } {
-  return value.__kind === kind;
+export function isCpiRule<K extends CpiRule['__kind']>(kind: K, value: CpiRule): value is CpiRule & { __kind: K } {
+    return value.__kind === kind;
 }

--- a/test/e2e/anchor/src/generated/types/metadataAdditionalFieldRestriction.ts
+++ b/test/e2e/anchor/src/generated/types/metadataAdditionalFieldRestriction.ts
@@ -7,26 +7,26 @@
  */
 
 import {
-  addDecoderSizePrefix,
-  addEncoderSizePrefix,
-  combineCodec,
-  getArrayDecoder,
-  getArrayEncoder,
-  getDiscriminatedUnionDecoder,
-  getDiscriminatedUnionEncoder,
-  getStructDecoder,
-  getStructEncoder,
-  getTupleDecoder,
-  getTupleEncoder,
-  getU32Decoder,
-  getU32Encoder,
-  getUtf8Decoder,
-  getUtf8Encoder,
-  type Codec,
-  type Decoder,
-  type Encoder,
-  type GetDiscriminatedUnionVariant,
-  type GetDiscriminatedUnionVariantContent,
+    addDecoderSizePrefix,
+    addEncoderSizePrefix,
+    combineCodec,
+    getArrayDecoder,
+    getArrayEncoder,
+    getDiscriminatedUnionDecoder,
+    getDiscriminatedUnionEncoder,
+    getStructDecoder,
+    getStructEncoder,
+    getTupleDecoder,
+    getTupleEncoder,
+    getU32Decoder,
+    getU32Encoder,
+    getUtf8Decoder,
+    getUtf8Encoder,
+    type Codec,
+    type Decoder,
+    type Encoder,
+    type GetDiscriminatedUnionVariant,
+    type GetDiscriminatedUnionVariantContent,
 } from '@solana/kit';
 
 /**
@@ -35,123 +35,71 @@ import {
  * * Excludes - The field must not include any of the values in the vector.
  */
 export type MetadataAdditionalFieldRestriction =
-  | { __kind: 'Includes'; fields: readonly [Array<string>] }
-  | { __kind: 'Excludes'; fields: readonly [Array<string>] };
+    | { __kind: 'Includes'; fields: readonly [Array<string>] }
+    | { __kind: 'Excludes'; fields: readonly [Array<string>] };
 
-export type MetadataAdditionalFieldRestrictionArgs =
-  MetadataAdditionalFieldRestriction;
+export type MetadataAdditionalFieldRestrictionArgs = MetadataAdditionalFieldRestriction;
 
 export function getMetadataAdditionalFieldRestrictionEncoder(): Encoder<MetadataAdditionalFieldRestrictionArgs> {
-  return getDiscriminatedUnionEncoder([
-    [
-      'Includes',
-      getStructEncoder([
+    return getDiscriminatedUnionEncoder([
         [
-          'fields',
-          getTupleEncoder([
-            getArrayEncoder(
-              addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())
-            ),
-          ]),
+            'Includes',
+            getStructEncoder([
+                ['fields', getTupleEncoder([getArrayEncoder(addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder()))])],
+            ]),
         ],
-      ]),
-    ],
-    [
-      'Excludes',
-      getStructEncoder([
         [
-          'fields',
-          getTupleEncoder([
-            getArrayEncoder(
-              addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())
-            ),
-          ]),
+            'Excludes',
+            getStructEncoder([
+                ['fields', getTupleEncoder([getArrayEncoder(addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder()))])],
+            ]),
         ],
-      ]),
-    ],
-  ]);
+    ]);
 }
 
 export function getMetadataAdditionalFieldRestrictionDecoder(): Decoder<MetadataAdditionalFieldRestriction> {
-  return getDiscriminatedUnionDecoder([
-    [
-      'Includes',
-      getStructDecoder([
+    return getDiscriminatedUnionDecoder([
         [
-          'fields',
-          getTupleDecoder([
-            getArrayDecoder(
-              addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())
-            ),
-          ]),
+            'Includes',
+            getStructDecoder([
+                ['fields', getTupleDecoder([getArrayDecoder(addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder()))])],
+            ]),
         ],
-      ]),
-    ],
-    [
-      'Excludes',
-      getStructDecoder([
         [
-          'fields',
-          getTupleDecoder([
-            getArrayDecoder(
-              addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())
-            ),
-          ]),
+            'Excludes',
+            getStructDecoder([
+                ['fields', getTupleDecoder([getArrayDecoder(addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder()))])],
+            ]),
         ],
-      ]),
-    ],
-  ]);
+    ]);
 }
 
 export function getMetadataAdditionalFieldRestrictionCodec(): Codec<
-  MetadataAdditionalFieldRestrictionArgs,
-  MetadataAdditionalFieldRestriction
+    MetadataAdditionalFieldRestrictionArgs,
+    MetadataAdditionalFieldRestriction
 > {
-  return combineCodec(
-    getMetadataAdditionalFieldRestrictionEncoder(),
-    getMetadataAdditionalFieldRestrictionDecoder()
-  );
+    return combineCodec(getMetadataAdditionalFieldRestrictionEncoder(), getMetadataAdditionalFieldRestrictionDecoder());
 }
 
 // Data Enum Helpers.
 export function metadataAdditionalFieldRestriction(
-  kind: 'Includes',
-  data: GetDiscriminatedUnionVariantContent<
-    MetadataAdditionalFieldRestrictionArgs,
-    '__kind',
-    'Includes'
-  >['fields']
-): GetDiscriminatedUnionVariant<
-  MetadataAdditionalFieldRestrictionArgs,
-  '__kind',
-  'Includes'
->;
+    kind: 'Includes',
+    data: GetDiscriminatedUnionVariantContent<MetadataAdditionalFieldRestrictionArgs, '__kind', 'Includes'>['fields']
+): GetDiscriminatedUnionVariant<MetadataAdditionalFieldRestrictionArgs, '__kind', 'Includes'>;
 export function metadataAdditionalFieldRestriction(
-  kind: 'Excludes',
-  data: GetDiscriminatedUnionVariantContent<
-    MetadataAdditionalFieldRestrictionArgs,
-    '__kind',
-    'Excludes'
-  >['fields']
-): GetDiscriminatedUnionVariant<
-  MetadataAdditionalFieldRestrictionArgs,
-  '__kind',
-  'Excludes'
->;
-export function metadataAdditionalFieldRestriction<
-  K extends MetadataAdditionalFieldRestrictionArgs['__kind'],
-  Data,
->(kind: K, data?: Data) {
-  return Array.isArray(data)
-    ? { __kind: kind, fields: data }
-    : { __kind: kind, ...(data ?? {}) };
+    kind: 'Excludes',
+    data: GetDiscriminatedUnionVariantContent<MetadataAdditionalFieldRestrictionArgs, '__kind', 'Excludes'>['fields']
+): GetDiscriminatedUnionVariant<MetadataAdditionalFieldRestrictionArgs, '__kind', 'Excludes'>;
+export function metadataAdditionalFieldRestriction<K extends MetadataAdditionalFieldRestrictionArgs['__kind'], Data>(
+    kind: K,
+    data?: Data
+) {
+    return Array.isArray(data) ? { __kind: kind, fields: data } : { __kind: kind, ...(data ?? {}) };
 }
 
-export function isMetadataAdditionalFieldRestriction<
-  K extends MetadataAdditionalFieldRestriction['__kind'],
->(
-  kind: K,
-  value: MetadataAdditionalFieldRestriction
+export function isMetadataAdditionalFieldRestriction<K extends MetadataAdditionalFieldRestriction['__kind']>(
+    kind: K,
+    value: MetadataAdditionalFieldRestriction
 ): value is MetadataAdditionalFieldRestriction & { __kind: K } {
-  return value.__kind === kind;
+    return value.__kind === kind;
 }

--- a/test/e2e/anchor/src/generated/types/metadataAdditionalFieldRule.ts
+++ b/test/e2e/anchor/src/generated/types/metadataAdditionalFieldRule.ts
@@ -7,28 +7,28 @@
  */
 
 import {
-  addDecoderSizePrefix,
-  addEncoderSizePrefix,
-  combineCodec,
-  getOptionDecoder,
-  getOptionEncoder,
-  getStructDecoder,
-  getStructEncoder,
-  getU32Decoder,
-  getU32Encoder,
-  getUtf8Decoder,
-  getUtf8Encoder,
-  type Codec,
-  type Decoder,
-  type Encoder,
-  type Option,
-  type OptionOrNullable,
+    addDecoderSizePrefix,
+    addEncoderSizePrefix,
+    combineCodec,
+    getOptionDecoder,
+    getOptionEncoder,
+    getStructDecoder,
+    getStructEncoder,
+    getU32Decoder,
+    getU32Encoder,
+    getUtf8Decoder,
+    getUtf8Encoder,
+    type Codec,
+    type Decoder,
+    type Encoder,
+    type Option,
+    type OptionOrNullable,
 } from '@solana/kit';
 import {
-  getMetadataAdditionalFieldRestrictionDecoder,
-  getMetadataAdditionalFieldRestrictionEncoder,
-  type MetadataAdditionalFieldRestriction,
-  type MetadataAdditionalFieldRestrictionArgs,
+    getMetadataAdditionalFieldRestrictionDecoder,
+    getMetadataAdditionalFieldRestrictionEncoder,
+    type MetadataAdditionalFieldRestriction,
+    type MetadataAdditionalFieldRestrictionArgs,
 } from '.';
 
 /**
@@ -36,41 +36,32 @@ import {
  * The field must exist and the value must pass the restriction.
  */
 export type MetadataAdditionalFieldRule = {
-  field: string;
-  valueRestrictions: Option<MetadataAdditionalFieldRestriction>;
+    field: string;
+    valueRestrictions: Option<MetadataAdditionalFieldRestriction>;
 };
 
 export type MetadataAdditionalFieldRuleArgs = {
-  field: string;
-  valueRestrictions: OptionOrNullable<MetadataAdditionalFieldRestrictionArgs>;
+    field: string;
+    valueRestrictions: OptionOrNullable<MetadataAdditionalFieldRestrictionArgs>;
 };
 
 export function getMetadataAdditionalFieldRuleEncoder(): Encoder<MetadataAdditionalFieldRuleArgs> {
-  return getStructEncoder([
-    ['field', addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
-    [
-      'valueRestrictions',
-      getOptionEncoder(getMetadataAdditionalFieldRestrictionEncoder()),
-    ],
-  ]);
+    return getStructEncoder([
+        ['field', addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
+        ['valueRestrictions', getOptionEncoder(getMetadataAdditionalFieldRestrictionEncoder())],
+    ]);
 }
 
 export function getMetadataAdditionalFieldRuleDecoder(): Decoder<MetadataAdditionalFieldRule> {
-  return getStructDecoder([
-    ['field', addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())],
-    [
-      'valueRestrictions',
-      getOptionDecoder(getMetadataAdditionalFieldRestrictionDecoder()),
-    ],
-  ]);
+    return getStructDecoder([
+        ['field', addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())],
+        ['valueRestrictions', getOptionDecoder(getMetadataAdditionalFieldRestrictionDecoder())],
+    ]);
 }
 
 export function getMetadataAdditionalFieldRuleCodec(): Codec<
-  MetadataAdditionalFieldRuleArgs,
-  MetadataAdditionalFieldRule
+    MetadataAdditionalFieldRuleArgs,
+    MetadataAdditionalFieldRule
 > {
-  return combineCodec(
-    getMetadataAdditionalFieldRuleEncoder(),
-    getMetadataAdditionalFieldRuleDecoder()
-  );
+    return combineCodec(getMetadataAdditionalFieldRuleEncoder(), getMetadataAdditionalFieldRuleDecoder());
 }

--- a/test/e2e/anchor/src/generated/types/transferAmountRule.ts
+++ b/test/e2e/anchor/src/generated/types/transferAmountRule.ts
@@ -7,20 +7,20 @@
  */
 
 import {
-  combineCodec,
-  getDiscriminatedUnionDecoder,
-  getDiscriminatedUnionEncoder,
-  getStructDecoder,
-  getStructEncoder,
-  getTupleDecoder,
-  getTupleEncoder,
-  getU64Decoder,
-  getU64Encoder,
-  type Codec,
-  type Decoder,
-  type Encoder,
-  type GetDiscriminatedUnionVariant,
-  type GetDiscriminatedUnionVariantContent,
+    combineCodec,
+    getDiscriminatedUnionDecoder,
+    getDiscriminatedUnionEncoder,
+    getStructDecoder,
+    getStructEncoder,
+    getTupleDecoder,
+    getTupleEncoder,
+    getU64Decoder,
+    getU64Encoder,
+    type Codec,
+    type Decoder,
+    type Encoder,
+    type GetDiscriminatedUnionVariant,
+    type GetDiscriminatedUnionVariantContent,
 } from '@solana/kit';
 
 /**
@@ -28,118 +28,63 @@ import {
  * The rules can be above, below, equal to, or within a range.
  */
 export type TransferAmountRule =
-  | { __kind: 'Above'; fields: readonly [bigint] }
-  | { __kind: 'Below'; fields: readonly [bigint] }
-  | { __kind: 'Equal'; fields: readonly [bigint] }
-  | { __kind: 'Rang'; fields: readonly [bigint, bigint] };
+    | { __kind: 'Above'; fields: readonly [bigint] }
+    | { __kind: 'Below'; fields: readonly [bigint] }
+    | { __kind: 'Equal'; fields: readonly [bigint] }
+    | { __kind: 'Rang'; fields: readonly [bigint, bigint] };
 
 export type TransferAmountRuleArgs =
-  | { __kind: 'Above'; fields: readonly [number | bigint] }
-  | { __kind: 'Below'; fields: readonly [number | bigint] }
-  | { __kind: 'Equal'; fields: readonly [number | bigint] }
-  | { __kind: 'Rang'; fields: readonly [number | bigint, number | bigint] };
+    | { __kind: 'Above'; fields: readonly [number | bigint] }
+    | { __kind: 'Below'; fields: readonly [number | bigint] }
+    | { __kind: 'Equal'; fields: readonly [number | bigint] }
+    | { __kind: 'Rang'; fields: readonly [number | bigint, number | bigint] };
 
 export function getTransferAmountRuleEncoder(): Encoder<TransferAmountRuleArgs> {
-  return getDiscriminatedUnionEncoder([
-    [
-      'Above',
-      getStructEncoder([['fields', getTupleEncoder([getU64Encoder()])]]),
-    ],
-    [
-      'Below',
-      getStructEncoder([['fields', getTupleEncoder([getU64Encoder()])]]),
-    ],
-    [
-      'Equal',
-      getStructEncoder([['fields', getTupleEncoder([getU64Encoder()])]]),
-    ],
-    [
-      'Rang',
-      getStructEncoder([
-        ['fields', getTupleEncoder([getU64Encoder(), getU64Encoder()])],
-      ]),
-    ],
-  ]);
+    return getDiscriminatedUnionEncoder([
+        ['Above', getStructEncoder([['fields', getTupleEncoder([getU64Encoder()])]])],
+        ['Below', getStructEncoder([['fields', getTupleEncoder([getU64Encoder()])]])],
+        ['Equal', getStructEncoder([['fields', getTupleEncoder([getU64Encoder()])]])],
+        ['Rang', getStructEncoder([['fields', getTupleEncoder([getU64Encoder(), getU64Encoder()])]])],
+    ]);
 }
 
 export function getTransferAmountRuleDecoder(): Decoder<TransferAmountRule> {
-  return getDiscriminatedUnionDecoder([
-    [
-      'Above',
-      getStructDecoder([['fields', getTupleDecoder([getU64Decoder()])]]),
-    ],
-    [
-      'Below',
-      getStructDecoder([['fields', getTupleDecoder([getU64Decoder()])]]),
-    ],
-    [
-      'Equal',
-      getStructDecoder([['fields', getTupleDecoder([getU64Decoder()])]]),
-    ],
-    [
-      'Rang',
-      getStructDecoder([
-        ['fields', getTupleDecoder([getU64Decoder(), getU64Decoder()])],
-      ]),
-    ],
-  ]);
+    return getDiscriminatedUnionDecoder([
+        ['Above', getStructDecoder([['fields', getTupleDecoder([getU64Decoder()])]])],
+        ['Below', getStructDecoder([['fields', getTupleDecoder([getU64Decoder()])]])],
+        ['Equal', getStructDecoder([['fields', getTupleDecoder([getU64Decoder()])]])],
+        ['Rang', getStructDecoder([['fields', getTupleDecoder([getU64Decoder(), getU64Decoder()])]])],
+    ]);
 }
 
-export function getTransferAmountRuleCodec(): Codec<
-  TransferAmountRuleArgs,
-  TransferAmountRule
-> {
-  return combineCodec(
-    getTransferAmountRuleEncoder(),
-    getTransferAmountRuleDecoder()
-  );
+export function getTransferAmountRuleCodec(): Codec<TransferAmountRuleArgs, TransferAmountRule> {
+    return combineCodec(getTransferAmountRuleEncoder(), getTransferAmountRuleDecoder());
 }
 
 // Data Enum Helpers.
 export function transferAmountRule(
-  kind: 'Above',
-  data: GetDiscriminatedUnionVariantContent<
-    TransferAmountRuleArgs,
-    '__kind',
-    'Above'
-  >['fields']
+    kind: 'Above',
+    data: GetDiscriminatedUnionVariantContent<TransferAmountRuleArgs, '__kind', 'Above'>['fields']
 ): GetDiscriminatedUnionVariant<TransferAmountRuleArgs, '__kind', 'Above'>;
 export function transferAmountRule(
-  kind: 'Below',
-  data: GetDiscriminatedUnionVariantContent<
-    TransferAmountRuleArgs,
-    '__kind',
-    'Below'
-  >['fields']
+    kind: 'Below',
+    data: GetDiscriminatedUnionVariantContent<TransferAmountRuleArgs, '__kind', 'Below'>['fields']
 ): GetDiscriminatedUnionVariant<TransferAmountRuleArgs, '__kind', 'Below'>;
 export function transferAmountRule(
-  kind: 'Equal',
-  data: GetDiscriminatedUnionVariantContent<
-    TransferAmountRuleArgs,
-    '__kind',
-    'Equal'
-  >['fields']
+    kind: 'Equal',
+    data: GetDiscriminatedUnionVariantContent<TransferAmountRuleArgs, '__kind', 'Equal'>['fields']
 ): GetDiscriminatedUnionVariant<TransferAmountRuleArgs, '__kind', 'Equal'>;
 export function transferAmountRule(
-  kind: 'Rang',
-  data: GetDiscriminatedUnionVariantContent<
-    TransferAmountRuleArgs,
-    '__kind',
-    'Rang'
-  >['fields']
+    kind: 'Rang',
+    data: GetDiscriminatedUnionVariantContent<TransferAmountRuleArgs, '__kind', 'Rang'>['fields']
 ): GetDiscriminatedUnionVariant<TransferAmountRuleArgs, '__kind', 'Rang'>;
-export function transferAmountRule<
-  K extends TransferAmountRuleArgs['__kind'],
-  Data,
->(kind: K, data?: Data) {
-  return Array.isArray(data)
-    ? { __kind: kind, fields: data }
-    : { __kind: kind, ...(data ?? {}) };
+export function transferAmountRule<K extends TransferAmountRuleArgs['__kind'], Data>(kind: K, data?: Data) {
+    return Array.isArray(data) ? { __kind: kind, fields: data } : { __kind: kind, ...(data ?? {}) };
 }
 
 export function isTransferAmountRule<K extends TransferAmountRule['__kind']>(
-  kind: K,
-  value: TransferAmountRule
+    kind: K,
+    value: TransferAmountRule
 ): value is TransferAmountRule & { __kind: K } {
-  return value.__kind === kind;
+    return value.__kind === kind;
 }

--- a/test/e2e/anchor/test/_setup.ts
+++ b/test/e2e/anchor/test/_setup.ts
@@ -10,6 +10,7 @@ import {
   type TransactionSigner,
   airdropFactory,
   assertIsSendableTransaction,
+  assertIsTransactionWithBlockhashLifetime,
   createSolanaRpc,
   createSolanaRpcSubscriptions,
   createTransactionMessage,
@@ -76,6 +77,7 @@ export const signAndSendTransaction = async (
     await signTransactionMessageWithSigners(transactionMessage);
   const signature = getSignatureFromTransaction(signedTransaction);
   assertIsSendableTransaction(signedTransaction);
+  assertIsTransactionWithBlockhashLifetime(signedTransaction);
   await sendAndConfirmTransactionFactory(client)(signedTransaction, {
     commitment,
   });

--- a/test/e2e/dummy/.prettierrc.json
+++ b/test/e2e/dummy/.prettierrc.json
@@ -1,9 +1,0 @@
-{
-  "semi": true,
-  "singleQuote": true,
-  "trailingComma": "es5",
-  "useTabs": false,
-  "tabWidth": 2,
-  "arrowParens": "always",
-  "printWidth": 80
-}

--- a/test/e2e/dummy/package.json
+++ b/test/e2e/dummy/package.json
@@ -10,6 +10,9 @@
     "lint": "eslint --ext js,ts,tsx src && prettier --check src test",
     "lint:fix": "eslint --fix --ext js,ts,tsx src && prettier --write src test"
   },
+  "dependencies": {
+    "@solana/kit": "^5.0.0"
+  },
   "license": "MIT",
   "ava": {
     "typescript": {
@@ -18,6 +21,5 @@
         "test/": "dist/test/"
       }
     }
-  },
-  "packageManager": "pnpm@9.1.0"
+  }
 }

--- a/test/e2e/dummy/src/generated/instructions/instruction1.ts
+++ b/test/e2e/dummy/src/generated/instructions/instruction1.ts
@@ -6,40 +6,31 @@
  * @see https://github.com/codama-idl/codama
  */
 
-import {
-  type AccountMeta,
-  type Address,
-  type Instruction,
-  type InstructionWithAccounts,
-} from '@solana/kit';
+import { type AccountMeta, type Address, type Instruction, type InstructionWithAccounts } from '@solana/kit';
 import { DUMMY_PROGRAM_ADDRESS } from '../programs';
 
 export type Instruction1Instruction<
-  TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> & InstructionWithAccounts<TRemainingAccounts>;
 
 export type Instruction1Input = {};
 
-export function getInstruction1Instruction<
-  TProgramAddress extends Address = typeof DUMMY_PROGRAM_ADDRESS,
->(config?: {
-  programAddress?: TProgramAddress;
+export function getInstruction1Instruction<TProgramAddress extends Address = typeof DUMMY_PROGRAM_ADDRESS>(config?: {
+    programAddress?: TProgramAddress;
 }): Instruction1Instruction<TProgramAddress> {
-  // Program address.
-  const programAddress = config?.programAddress ?? DUMMY_PROGRAM_ADDRESS;
+    // Program address.
+    const programAddress = config?.programAddress ?? DUMMY_PROGRAM_ADDRESS;
 
-  return Object.freeze({
-    programAddress,
-  } as Instruction1Instruction<TProgramAddress>);
+    return Object.freeze({ programAddress } as Instruction1Instruction<TProgramAddress>);
 }
 
-export type ParsedInstruction1Instruction<
-  TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
-> = { programAddress: Address<TProgram> };
+export type ParsedInstruction1Instruction<TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS> = {
+    programAddress: Address<TProgram>;
+};
 
 export function parseInstruction1Instruction<TProgram extends string>(
-  instruction: Instruction<TProgram>
+    instruction: Instruction<TProgram>
 ): ParsedInstruction1Instruction<TProgram> {
-  return { programAddress: instruction.programAddress };
+    return { programAddress: instruction.programAddress };
 }

--- a/test/e2e/dummy/src/generated/instructions/instruction2.ts
+++ b/test/e2e/dummy/src/generated/instructions/instruction2.ts
@@ -7,52 +7,48 @@
  */
 
 import {
-  AccountRole,
-  type AccountMeta,
-  type Address,
-  type Instruction,
-  type InstructionWithAccounts,
+    AccountRole,
+    type AccountMeta,
+    type Address,
+    type Instruction,
+    type InstructionWithAccounts,
 } from '@solana/kit';
 import { DUMMY_PROGRAM_ADDRESS } from '../programs';
 
 export type Instruction2Instruction<
-  TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> & InstructionWithAccounts<TRemainingAccounts>;
 
 export type Instruction2Input = {
-  remainingAccounts?: Array<Address>;
+    remainingAccounts?: Array<Address>;
 };
 
-export function getInstruction2Instruction<
-  TProgramAddress extends Address = typeof DUMMY_PROGRAM_ADDRESS,
->(
-  input: Instruction2Input,
-  config?: { programAddress?: TProgramAddress }
+export function getInstruction2Instruction<TProgramAddress extends Address = typeof DUMMY_PROGRAM_ADDRESS>(
+    input: Instruction2Input,
+    config?: { programAddress?: TProgramAddress }
 ): Instruction2Instruction<TProgramAddress> {
-  // Program address.
-  const programAddress = config?.programAddress ?? DUMMY_PROGRAM_ADDRESS;
+    // Program address.
+    const programAddress = config?.programAddress ?? DUMMY_PROGRAM_ADDRESS;
 
-  // Original args.
-  const args = { ...input };
+    // Original args.
+    const args = { ...input };
 
-  // Remaining accounts.
-  const remainingAccounts: AccountMeta[] = (args.remainingAccounts ?? []).map(
-    (address) => ({ address, role: AccountRole.READONLY })
-  );
+    // Remaining accounts.
+    const remainingAccounts: AccountMeta[] = (args.remainingAccounts ?? []).map(address => ({
+        address,
+        role: AccountRole.READONLY,
+    }));
 
-  return Object.freeze({
-    accounts: remainingAccounts,
-    programAddress,
-  } as Instruction2Instruction<TProgramAddress>);
+    return Object.freeze({ accounts: remainingAccounts, programAddress } as Instruction2Instruction<TProgramAddress>);
 }
 
-export type ParsedInstruction2Instruction<
-  TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
-> = { programAddress: Address<TProgram> };
+export type ParsedInstruction2Instruction<TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS> = {
+    programAddress: Address<TProgram>;
+};
 
 export function parseInstruction2Instruction<TProgram extends string>(
-  instruction: Instruction<TProgram>
+    instruction: Instruction<TProgram>
 ): ParsedInstruction2Instruction<TProgram> {
-  return { programAddress: instruction.programAddress };
+    return { programAddress: instruction.programAddress };
 }

--- a/test/e2e/dummy/src/generated/instructions/instruction3.ts
+++ b/test/e2e/dummy/src/generated/instructions/instruction3.ts
@@ -7,87 +7,81 @@
  */
 
 import {
-  combineCodec,
-  getStructDecoder,
-  getStructEncoder,
-  getU32Decoder,
-  getU32Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyUint8Array,
+    combineCodec,
+    getStructDecoder,
+    getStructEncoder,
+    getU32Decoder,
+    getU32Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyUint8Array,
 } from '@solana/kit';
 import { DUMMY_PROGRAM_ADDRESS } from '../programs';
 
 export const INSTRUCTION3_DISCRIMINATOR = 42;
 
 export function getInstruction3DiscriminatorBytes() {
-  return getU32Encoder().encode(INSTRUCTION3_DISCRIMINATOR);
+    return getU32Encoder().encode(INSTRUCTION3_DISCRIMINATOR);
 }
 
 export type Instruction3Instruction<
-  TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
-> = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<TRemainingAccounts>;
+    TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> & InstructionWithData<ReadonlyUint8Array> & InstructionWithAccounts<TRemainingAccounts>;
 
 export type Instruction3InstructionData = { discriminator: number };
 
 export type Instruction3InstructionDataArgs = {};
 
 export function getInstruction3InstructionDataEncoder(): FixedSizeEncoder<Instruction3InstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([['discriminator', getU32Encoder()]]),
-    (value) => ({ ...value, discriminator: INSTRUCTION3_DISCRIMINATOR })
-  );
+    return transformEncoder(getStructEncoder([['discriminator', getU32Encoder()]]), value => ({
+        ...value,
+        discriminator: INSTRUCTION3_DISCRIMINATOR,
+    }));
 }
 
 export function getInstruction3InstructionDataDecoder(): FixedSizeDecoder<Instruction3InstructionData> {
-  return getStructDecoder([['discriminator', getU32Decoder()]]);
+    return getStructDecoder([['discriminator', getU32Decoder()]]);
 }
 
 export function getInstruction3InstructionDataCodec(): FixedSizeCodec<
-  Instruction3InstructionDataArgs,
-  Instruction3InstructionData
+    Instruction3InstructionDataArgs,
+    Instruction3InstructionData
 > {
-  return combineCodec(
-    getInstruction3InstructionDataEncoder(),
-    getInstruction3InstructionDataDecoder()
-  );
+    return combineCodec(getInstruction3InstructionDataEncoder(), getInstruction3InstructionDataDecoder());
 }
 
 export type Instruction3Input = {};
 
-export function getInstruction3Instruction<
-  TProgramAddress extends Address = typeof DUMMY_PROGRAM_ADDRESS,
->(config?: {
-  programAddress?: TProgramAddress;
+export function getInstruction3Instruction<TProgramAddress extends Address = typeof DUMMY_PROGRAM_ADDRESS>(config?: {
+    programAddress?: TProgramAddress;
 }): Instruction3Instruction<TProgramAddress> {
-  // Program address.
-  const programAddress = config?.programAddress ?? DUMMY_PROGRAM_ADDRESS;
+    // Program address.
+    const programAddress = config?.programAddress ?? DUMMY_PROGRAM_ADDRESS;
 
-  return Object.freeze({
-    data: getInstruction3InstructionDataEncoder().encode({}),
-    programAddress,
-  } as Instruction3Instruction<TProgramAddress>);
+    return Object.freeze({
+        data: getInstruction3InstructionDataEncoder().encode({}),
+        programAddress,
+    } as Instruction3Instruction<TProgramAddress>);
 }
 
-export type ParsedInstruction3Instruction<
-  TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
-> = { programAddress: Address<TProgram>; data: Instruction3InstructionData };
+export type ParsedInstruction3Instruction<TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS> = {
+    programAddress: Address<TProgram>;
+    data: Instruction3InstructionData;
+};
 
 export function parseInstruction3Instruction<TProgram extends string>(
-  instruction: Instruction<TProgram> & InstructionWithData<ReadonlyUint8Array>
+    instruction: Instruction<TProgram> & InstructionWithData<ReadonlyUint8Array>
 ): ParsedInstruction3Instruction<TProgram> {
-  return {
-    programAddress: instruction.programAddress,
-    data: getInstruction3InstructionDataDecoder().decode(instruction.data),
-  };
+    return {
+        programAddress: instruction.programAddress,
+        data: getInstruction3InstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/dummy/src/generated/instructions/instruction4.ts
+++ b/test/e2e/dummy/src/generated/instructions/instruction4.ts
@@ -7,85 +7,77 @@
  */
 
 import {
-  combineCodec,
-  getStructDecoder,
-  getStructEncoder,
-  getU64Decoder,
-  getU64Encoder,
-  type AccountMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyUint8Array,
+    combineCodec,
+    getStructDecoder,
+    getStructEncoder,
+    getU64Decoder,
+    getU64Encoder,
+    type AccountMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyUint8Array,
 } from '@solana/kit';
 import { DUMMY_PROGRAM_ADDRESS } from '../programs';
 
 export type Instruction4Instruction<
-  TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
-> = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<TRemainingAccounts>;
+    TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> & InstructionWithData<ReadonlyUint8Array> & InstructionWithAccounts<TRemainingAccounts>;
 
 export type Instruction4InstructionData = { myArgument: bigint };
 
 export type Instruction4InstructionDataArgs = { myArgument: number | bigint };
 
 export function getInstruction4InstructionDataEncoder(): FixedSizeEncoder<Instruction4InstructionDataArgs> {
-  return getStructEncoder([['myArgument', getU64Encoder()]]);
+    return getStructEncoder([['myArgument', getU64Encoder()]]);
 }
 
 export function getInstruction4InstructionDataDecoder(): FixedSizeDecoder<Instruction4InstructionData> {
-  return getStructDecoder([['myArgument', getU64Decoder()]]);
+    return getStructDecoder([['myArgument', getU64Decoder()]]);
 }
 
 export function getInstruction4InstructionDataCodec(): FixedSizeCodec<
-  Instruction4InstructionDataArgs,
-  Instruction4InstructionData
+    Instruction4InstructionDataArgs,
+    Instruction4InstructionData
 > {
-  return combineCodec(
-    getInstruction4InstructionDataEncoder(),
-    getInstruction4InstructionDataDecoder()
-  );
+    return combineCodec(getInstruction4InstructionDataEncoder(), getInstruction4InstructionDataDecoder());
 }
 
 export type Instruction4Input = {
-  myArgument: Instruction4InstructionDataArgs['myArgument'];
+    myArgument: Instruction4InstructionDataArgs['myArgument'];
 };
 
-export function getInstruction4Instruction<
-  TProgramAddress extends Address = typeof DUMMY_PROGRAM_ADDRESS,
->(
-  input: Instruction4Input,
-  config?: { programAddress?: TProgramAddress }
+export function getInstruction4Instruction<TProgramAddress extends Address = typeof DUMMY_PROGRAM_ADDRESS>(
+    input: Instruction4Input,
+    config?: { programAddress?: TProgramAddress }
 ): Instruction4Instruction<TProgramAddress> {
-  // Program address.
-  const programAddress = config?.programAddress ?? DUMMY_PROGRAM_ADDRESS;
+    // Program address.
+    const programAddress = config?.programAddress ?? DUMMY_PROGRAM_ADDRESS;
 
-  // Original args.
-  const args = { ...input };
+    // Original args.
+    const args = { ...input };
 
-  return Object.freeze({
-    data: getInstruction4InstructionDataEncoder().encode(
-      args as Instruction4InstructionDataArgs
-    ),
-    programAddress,
-  } as Instruction4Instruction<TProgramAddress>);
+    return Object.freeze({
+        data: getInstruction4InstructionDataEncoder().encode(args as Instruction4InstructionDataArgs),
+        programAddress,
+    } as Instruction4Instruction<TProgramAddress>);
 }
 
-export type ParsedInstruction4Instruction<
-  TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
-> = { programAddress: Address<TProgram>; data: Instruction4InstructionData };
+export type ParsedInstruction4Instruction<TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS> = {
+    programAddress: Address<TProgram>;
+    data: Instruction4InstructionData;
+};
 
 export function parseInstruction4Instruction<TProgram extends string>(
-  instruction: Instruction<TProgram> & InstructionWithData<ReadonlyUint8Array>
+    instruction: Instruction<TProgram> & InstructionWithData<ReadonlyUint8Array>
 ): ParsedInstruction4Instruction<TProgram> {
-  return {
-    programAddress: instruction.programAddress,
-    data: getInstruction4InstructionDataDecoder().decode(instruction.data),
-  };
+    return {
+        programAddress: instruction.programAddress,
+        data: getInstruction4InstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/dummy/src/generated/instructions/instruction5.ts
+++ b/test/e2e/dummy/src/generated/instructions/instruction5.ts
@@ -7,89 +7,81 @@
  */
 
 import {
-  combineCodec,
-  getStructDecoder,
-  getStructEncoder,
-  getU64Decoder,
-  getU64Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyUint8Array,
+    combineCodec,
+    getStructDecoder,
+    getStructEncoder,
+    getU64Decoder,
+    getU64Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyUint8Array,
 } from '@solana/kit';
 import { DUMMY_PROGRAM_ADDRESS } from '../programs';
 
 export type Instruction5Instruction<
-  TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
-> = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<TRemainingAccounts>;
+    TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> & InstructionWithData<ReadonlyUint8Array> & InstructionWithAccounts<TRemainingAccounts>;
 
 export type Instruction5InstructionData = { myArgument: bigint };
 
 export type Instruction5InstructionDataArgs = { myArgument?: number | bigint };
 
 export function getInstruction5InstructionDataEncoder(): FixedSizeEncoder<Instruction5InstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([['myArgument', getU64Encoder()]]),
-    (value) => ({ ...value, myArgument: value.myArgument ?? 42 })
-  );
+    return transformEncoder(getStructEncoder([['myArgument', getU64Encoder()]]), value => ({
+        ...value,
+        myArgument: value.myArgument ?? 42,
+    }));
 }
 
 export function getInstruction5InstructionDataDecoder(): FixedSizeDecoder<Instruction5InstructionData> {
-  return getStructDecoder([['myArgument', getU64Decoder()]]);
+    return getStructDecoder([['myArgument', getU64Decoder()]]);
 }
 
 export function getInstruction5InstructionDataCodec(): FixedSizeCodec<
-  Instruction5InstructionDataArgs,
-  Instruction5InstructionData
+    Instruction5InstructionDataArgs,
+    Instruction5InstructionData
 > {
-  return combineCodec(
-    getInstruction5InstructionDataEncoder(),
-    getInstruction5InstructionDataDecoder()
-  );
+    return combineCodec(getInstruction5InstructionDataEncoder(), getInstruction5InstructionDataDecoder());
 }
 
 export type Instruction5Input = {
-  myArgument?: Instruction5InstructionDataArgs['myArgument'];
+    myArgument?: Instruction5InstructionDataArgs['myArgument'];
 };
 
-export function getInstruction5Instruction<
-  TProgramAddress extends Address = typeof DUMMY_PROGRAM_ADDRESS,
->(
-  input: Instruction5Input,
-  config?: { programAddress?: TProgramAddress }
+export function getInstruction5Instruction<TProgramAddress extends Address = typeof DUMMY_PROGRAM_ADDRESS>(
+    input: Instruction5Input,
+    config?: { programAddress?: TProgramAddress }
 ): Instruction5Instruction<TProgramAddress> {
-  // Program address.
-  const programAddress = config?.programAddress ?? DUMMY_PROGRAM_ADDRESS;
+    // Program address.
+    const programAddress = config?.programAddress ?? DUMMY_PROGRAM_ADDRESS;
 
-  // Original args.
-  const args = { ...input };
+    // Original args.
+    const args = { ...input };
 
-  return Object.freeze({
-    data: getInstruction5InstructionDataEncoder().encode(
-      args as Instruction5InstructionDataArgs
-    ),
-    programAddress,
-  } as Instruction5Instruction<TProgramAddress>);
+    return Object.freeze({
+        data: getInstruction5InstructionDataEncoder().encode(args as Instruction5InstructionDataArgs),
+        programAddress,
+    } as Instruction5Instruction<TProgramAddress>);
 }
 
-export type ParsedInstruction5Instruction<
-  TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
-> = { programAddress: Address<TProgram>; data: Instruction5InstructionData };
+export type ParsedInstruction5Instruction<TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS> = {
+    programAddress: Address<TProgram>;
+    data: Instruction5InstructionData;
+};
 
 export function parseInstruction5Instruction<TProgram extends string>(
-  instruction: Instruction<TProgram> & InstructionWithData<ReadonlyUint8Array>
+    instruction: Instruction<TProgram> & InstructionWithData<ReadonlyUint8Array>
 ): ParsedInstruction5Instruction<TProgram> {
-  return {
-    programAddress: instruction.programAddress,
-    data: getInstruction5InstructionDataDecoder().decode(instruction.data),
-  };
+    return {
+        programAddress: instruction.programAddress,
+        data: getInstruction5InstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/dummy/src/generated/instructions/instruction6.ts
+++ b/test/e2e/dummy/src/generated/instructions/instruction6.ts
@@ -7,87 +7,74 @@
  */
 
 import {
-  type AccountMeta,
-  type Address,
-  type Instruction,
-  type InstructionWithAccounts,
-  type WritableAccount,
+    type AccountMeta,
+    type Address,
+    type Instruction,
+    type InstructionWithAccounts,
+    type WritableAccount,
 } from '@solana/kit';
 import { DUMMY_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
 export type Instruction6Instruction<
-  TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
-  TAccountMyAccount extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
+    TAccountMyAccount extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithAccounts<
-    [
-      TAccountMyAccount extends string
-        ? WritableAccount<TAccountMyAccount>
-        : TAccountMyAccount,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithAccounts<
+        [
+            TAccountMyAccount extends string ? WritableAccount<TAccountMyAccount> : TAccountMyAccount,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type Instruction6Input<TAccountMyAccount extends string = string> = {
-  myAccount: Address<TAccountMyAccount>;
+    myAccount: Address<TAccountMyAccount>;
 };
 
 export function getInstruction6Instruction<
-  TAccountMyAccount extends string,
-  TProgramAddress extends Address = typeof DUMMY_PROGRAM_ADDRESS,
+    TAccountMyAccount extends string,
+    TProgramAddress extends Address = typeof DUMMY_PROGRAM_ADDRESS,
 >(
-  input: Instruction6Input<TAccountMyAccount>,
-  config?: { programAddress?: TProgramAddress }
+    input: Instruction6Input<TAccountMyAccount>,
+    config?: { programAddress?: TProgramAddress }
 ): Instruction6Instruction<TProgramAddress, TAccountMyAccount> {
-  // Program address.
-  const programAddress = config?.programAddress ?? DUMMY_PROGRAM_ADDRESS;
+    // Program address.
+    const programAddress = config?.programAddress ?? DUMMY_PROGRAM_ADDRESS;
 
-  // Original accounts.
-  const originalAccounts = {
-    myAccount: { value: input.myAccount ?? null, isWritable: true },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
+    // Original accounts.
+    const originalAccounts = { myAccount: { value: input.myAccount ?? null, isWritable: true } };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [getAccountMeta(accounts.myAccount)],
-    programAddress,
-  } as Instruction6Instruction<TProgramAddress, TAccountMyAccount>);
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({ accounts: [getAccountMeta(accounts.myAccount)], programAddress } as Instruction6Instruction<
+        TProgramAddress,
+        TAccountMyAccount
+    >);
 }
 
 export type ParsedInstruction6Instruction<
-  TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    myAccount: TAccountMetas[0];
-  };
+    programAddress: Address<TProgram>;
+    accounts: {
+        myAccount: TAccountMetas[0];
+    };
 };
 
-export function parseInstruction6Instruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
->(
-  instruction: Instruction<TProgram> & InstructionWithAccounts<TAccountMetas>
+export function parseInstruction6Instruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(
+    instruction: Instruction<TProgram> & InstructionWithAccounts<TAccountMetas>
 ): ParsedInstruction6Instruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 1) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: { myAccount: getNextAccount() },
-  };
+    if (instruction.accounts.length < 1) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return { programAddress: instruction.programAddress, accounts: { myAccount: getNextAccount() } };
 }

--- a/test/e2e/dummy/src/generated/instructions/instruction7.ts
+++ b/test/e2e/dummy/src/generated/instructions/instruction7.ts
@@ -7,93 +7,78 @@
  */
 
 import {
-  type AccountMeta,
-  type Address,
-  type Instruction,
-  type InstructionWithAccounts,
-  type WritableAccount,
+    type AccountMeta,
+    type Address,
+    type Instruction,
+    type InstructionWithAccounts,
+    type WritableAccount,
 } from '@solana/kit';
 import { DUMMY_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
 export type Instruction7Instruction<
-  TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
-  TAccountMyAccount extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
+    TAccountMyAccount extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithAccounts<
-    [
-      TAccountMyAccount extends string
-        ? WritableAccount<TAccountMyAccount>
-        : TAccountMyAccount,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithAccounts<
+        [
+            TAccountMyAccount extends string ? WritableAccount<TAccountMyAccount> : TAccountMyAccount,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type Instruction7Input<TAccountMyAccount extends string = string> = {
-  myAccount?: Address<TAccountMyAccount>;
+    myAccount?: Address<TAccountMyAccount>;
 };
 
 export function getInstruction7Instruction<
-  TAccountMyAccount extends string,
-  TProgramAddress extends Address = typeof DUMMY_PROGRAM_ADDRESS,
+    TAccountMyAccount extends string,
+    TProgramAddress extends Address = typeof DUMMY_PROGRAM_ADDRESS,
 >(
-  input: Instruction7Input<TAccountMyAccount>,
-  config?: { programAddress?: TProgramAddress }
+    input: Instruction7Input<TAccountMyAccount>,
+    config?: { programAddress?: TProgramAddress }
 ): Instruction7Instruction<TProgramAddress, TAccountMyAccount> {
-  // Program address.
-  const programAddress = config?.programAddress ?? DUMMY_PROGRAM_ADDRESS;
+    // Program address.
+    const programAddress = config?.programAddress ?? DUMMY_PROGRAM_ADDRESS;
 
-  // Original accounts.
-  const originalAccounts = {
-    myAccount: { value: input.myAccount ?? null, isWritable: true },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
+    // Original accounts.
+    const originalAccounts = { myAccount: { value: input.myAccount ?? null, isWritable: true } };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [getAccountMeta(accounts.myAccount)],
-    programAddress,
-  } as Instruction7Instruction<TProgramAddress, TAccountMyAccount>);
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({ accounts: [getAccountMeta(accounts.myAccount)], programAddress } as Instruction7Instruction<
+        TProgramAddress,
+        TAccountMyAccount
+    >);
 }
 
 export type ParsedInstruction7Instruction<
-  TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    myAccount?: TAccountMetas[0] | undefined;
-  };
+    programAddress: Address<TProgram>;
+    accounts: {
+        myAccount?: TAccountMetas[0] | undefined;
+    };
 };
 
-export function parseInstruction7Instruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
->(
-  instruction: Instruction<TProgram> & InstructionWithAccounts<TAccountMetas>
+export function parseInstruction7Instruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(
+    instruction: Instruction<TProgram> & InstructionWithAccounts<TAccountMetas>
 ): ParsedInstruction7Instruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 1) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  const getNextOptionalAccount = () => {
-    const accountMeta = getNextAccount();
-    return accountMeta.address === DUMMY_PROGRAM_ADDRESS
-      ? undefined
-      : accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: { myAccount: getNextOptionalAccount() },
-  };
+    if (instruction.accounts.length < 1) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    const getNextOptionalAccount = () => {
+        const accountMeta = getNextAccount();
+        return accountMeta.address === DUMMY_PROGRAM_ADDRESS ? undefined : accountMeta;
+    };
+    return { programAddress: instruction.programAddress, accounts: { myAccount: getNextOptionalAccount() } };
 }

--- a/test/e2e/dummy/src/generated/programs/dummy.ts
+++ b/test/e2e/dummy/src/generated/programs/dummy.ts
@@ -6,68 +6,45 @@
  * @see https://github.com/codama-idl/codama
  */
 
+import { containsBytes, getU32Encoder, type Address, type ReadonlyUint8Array } from '@solana/kit';
 import {
-  containsBytes,
-  getU32Encoder,
-  type Address,
-  type ReadonlyUint8Array,
-} from '@solana/kit';
-import {
-  type ParsedInstruction1Instruction,
-  type ParsedInstruction2Instruction,
-  type ParsedInstruction3Instruction,
-  type ParsedInstruction4Instruction,
-  type ParsedInstruction5Instruction,
-  type ParsedInstruction6Instruction,
-  type ParsedInstruction7Instruction,
+    type ParsedInstruction1Instruction,
+    type ParsedInstruction2Instruction,
+    type ParsedInstruction3Instruction,
+    type ParsedInstruction4Instruction,
+    type ParsedInstruction5Instruction,
+    type ParsedInstruction6Instruction,
+    type ParsedInstruction7Instruction,
 } from '../instructions';
 
 export const DUMMY_PROGRAM_ADDRESS =
-  'Dummy1111111111111111111111111111111111' as Address<'Dummy1111111111111111111111111111111111'>;
+    'Dummy1111111111111111111111111111111111' as Address<'Dummy1111111111111111111111111111111111'>;
 
 export enum DummyInstruction {
-  Instruction1,
-  Instruction2,
-  Instruction3,
-  Instruction4,
-  Instruction5,
-  Instruction6,
-  Instruction7,
+    Instruction1,
+    Instruction2,
+    Instruction3,
+    Instruction4,
+    Instruction5,
+    Instruction6,
+    Instruction7,
 }
 
 export function identifyDummyInstruction(
-  instruction: { data: ReadonlyUint8Array } | ReadonlyUint8Array
+    instruction: { data: ReadonlyUint8Array } | ReadonlyUint8Array
 ): DummyInstruction {
-  const data = 'data' in instruction ? instruction.data : instruction;
-  if (containsBytes(data, getU32Encoder().encode(42), 0)) {
-    return DummyInstruction.Instruction3;
-  }
-  throw new Error(
-    'The provided instruction could not be identified as a dummy instruction.'
-  );
+    const data = 'data' in instruction ? instruction.data : instruction;
+    if (containsBytes(data, getU32Encoder().encode(42), 0)) {
+        return DummyInstruction.Instruction3;
+    }
+    throw new Error('The provided instruction could not be identified as a dummy instruction.');
 }
 
-export type ParsedDummyInstruction<
-  TProgram extends string = 'Dummy1111111111111111111111111111111111',
-> =
-  | ({
-      instructionType: DummyInstruction.Instruction1;
-    } & ParsedInstruction1Instruction<TProgram>)
-  | ({
-      instructionType: DummyInstruction.Instruction2;
-    } & ParsedInstruction2Instruction<TProgram>)
-  | ({
-      instructionType: DummyInstruction.Instruction3;
-    } & ParsedInstruction3Instruction<TProgram>)
-  | ({
-      instructionType: DummyInstruction.Instruction4;
-    } & ParsedInstruction4Instruction<TProgram>)
-  | ({
-      instructionType: DummyInstruction.Instruction5;
-    } & ParsedInstruction5Instruction<TProgram>)
-  | ({
-      instructionType: DummyInstruction.Instruction6;
-    } & ParsedInstruction6Instruction<TProgram>)
-  | ({
-      instructionType: DummyInstruction.Instruction7;
-    } & ParsedInstruction7Instruction<TProgram>);
+export type ParsedDummyInstruction<TProgram extends string = 'Dummy1111111111111111111111111111111111'> =
+    | ({ instructionType: DummyInstruction.Instruction1 } & ParsedInstruction1Instruction<TProgram>)
+    | ({ instructionType: DummyInstruction.Instruction2 } & ParsedInstruction2Instruction<TProgram>)
+    | ({ instructionType: DummyInstruction.Instruction3 } & ParsedInstruction3Instruction<TProgram>)
+    | ({ instructionType: DummyInstruction.Instruction4 } & ParsedInstruction4Instruction<TProgram>)
+    | ({ instructionType: DummyInstruction.Instruction5 } & ParsedInstruction5Instruction<TProgram>)
+    | ({ instructionType: DummyInstruction.Instruction6 } & ParsedInstruction6Instruction<TProgram>)
+    | ({ instructionType: DummyInstruction.Instruction7 } & ParsedInstruction7Instruction<TProgram>);

--- a/test/e2e/dummy/src/generated/shared/index.ts
+++ b/test/e2e/dummy/src/generated/shared/index.ts
@@ -7,15 +7,15 @@
  */
 
 import {
-  AccountRole,
-  isProgramDerivedAddress,
-  isTransactionSigner as kitIsTransactionSigner,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type ProgramDerivedAddress,
-  type TransactionSigner,
-  upgradeRoleToSigner,
+    AccountRole,
+    isProgramDerivedAddress,
+    isTransactionSigner as kitIsTransactionSigner,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type ProgramDerivedAddress,
+    type TransactionSigner,
+    upgradeRoleToSigner,
 } from '@solana/kit';
 
 /**
@@ -23,10 +23,10 @@ import {
  * @internal
  */
 export function expectSome<T>(value: T | null | undefined): T {
-  if (value === null || value === undefined) {
-    throw new Error('Expected a value but received null or undefined.');
-  }
-  return value;
+    if (value === null || value === undefined) {
+        throw new Error('Expected a value but received null or undefined.');
+    }
+    return value;
 }
 
 /**
@@ -34,23 +34,18 @@ export function expectSome<T>(value: T | null | undefined): T {
  * @internal
  */
 export function expectAddress<T extends string = string>(
-  value:
-    | Address<T>
-    | ProgramDerivedAddress<T>
-    | TransactionSigner<T>
-    | null
-    | undefined
+    value: Address<T> | ProgramDerivedAddress<T> | TransactionSigner<T> | null | undefined
 ): Address<T> {
-  if (!value) {
-    throw new Error('Expected a Address.');
-  }
-  if (typeof value === 'object' && 'address' in value) {
-    return value.address;
-  }
-  if (Array.isArray(value)) {
-    return value[0] as Address<T>;
-  }
-  return value as Address<T>;
+    if (!value) {
+        throw new Error('Expected a Address.');
+    }
+    if (typeof value === 'object' && 'address' in value) {
+        return value.address;
+    }
+    if (Array.isArray(value)) {
+        return value[0] as Address<T>;
+    }
+    return value as Address<T>;
 }
 
 /**
@@ -58,17 +53,12 @@ export function expectAddress<T extends string = string>(
  * @internal
  */
 export function expectProgramDerivedAddress<T extends string = string>(
-  value:
-    | Address<T>
-    | ProgramDerivedAddress<T>
-    | TransactionSigner<T>
-    | null
-    | undefined
+    value: Address<T> | ProgramDerivedAddress<T> | TransactionSigner<T> | null | undefined
 ): ProgramDerivedAddress<T> {
-  if (!value || !Array.isArray(value) || !isProgramDerivedAddress(value)) {
-    throw new Error('Expected a ProgramDerivedAddress.');
-  }
-  return value;
+    if (!value || !Array.isArray(value) || !isProgramDerivedAddress(value)) {
+        throw new Error('Expected a ProgramDerivedAddress.');
+    }
+    return value;
 }
 
 /**
@@ -76,17 +66,12 @@ export function expectProgramDerivedAddress<T extends string = string>(
  * @internal
  */
 export function expectTransactionSigner<T extends string = string>(
-  value:
-    | Address<T>
-    | ProgramDerivedAddress<T>
-    | TransactionSigner<T>
-    | null
-    | undefined
+    value: Address<T> | ProgramDerivedAddress<T> | TransactionSigner<T> | null | undefined
 ): TransactionSigner<T> {
-  if (!value || !isTransactionSigner(value)) {
-    throw new Error('Expected a TransactionSigner.');
-  }
-  return value;
+    if (!value || !isTransactionSigner(value)) {
+        throw new Error('Expected a TransactionSigner.');
+    }
+    return value;
 }
 
 /**
@@ -94,19 +79,15 @@ export function expectTransactionSigner<T extends string = string>(
  * @internal
  */
 export type ResolvedAccount<
-  T extends string = string,
-  U extends
-    | Address<T>
-    | ProgramDerivedAddress<T>
-    | TransactionSigner<T>
-    | null =
-    | Address<T>
-    | ProgramDerivedAddress<T>
-    | TransactionSigner<T>
-    | null,
+    T extends string = string,
+    U extends Address<T> | ProgramDerivedAddress<T> | TransactionSigner<T> | null =
+        | Address<T>
+        | ProgramDerivedAddress<T>
+        | TransactionSigner<T>
+        | null,
 > = {
-  isWritable: boolean;
-  value: U;
+    isWritable: boolean;
+    value: U;
 };
 
 /**
@@ -114,51 +95,31 @@ export type ResolvedAccount<
  * @internal
  */
 export type InstructionWithByteDelta = {
-  byteDelta: number;
+    byteDelta: number;
 };
 
 /**
  * Get account metas and signers from resolved accounts.
  * @internal
  */
-export function getAccountMetaFactory(
-  programAddress: Address,
-  optionalAccountStrategy: 'omitted' | 'programId'
-) {
-  return (
-    account: ResolvedAccount
-  ): AccountMeta | AccountSignerMeta | undefined => {
-    if (!account.value) {
-      if (optionalAccountStrategy === 'omitted') return;
-      return Object.freeze({
-        address: programAddress,
-        role: AccountRole.READONLY,
-      });
-    }
+export function getAccountMetaFactory(programAddress: Address, optionalAccountStrategy: 'omitted' | 'programId') {
+    return (account: ResolvedAccount): AccountMeta | AccountSignerMeta | undefined => {
+        if (!account.value) {
+            if (optionalAccountStrategy === 'omitted') return;
+            return Object.freeze({ address: programAddress, role: AccountRole.READONLY });
+        }
 
-    const writableRole = account.isWritable
-      ? AccountRole.WRITABLE
-      : AccountRole.READONLY;
-    return Object.freeze({
-      address: expectAddress(account.value),
-      role: isTransactionSigner(account.value)
-        ? upgradeRoleToSigner(writableRole)
-        : writableRole,
-      ...(isTransactionSigner(account.value) ? { signer: account.value } : {}),
-    });
-  };
+        const writableRole = account.isWritable ? AccountRole.WRITABLE : AccountRole.READONLY;
+        return Object.freeze({
+            address: expectAddress(account.value),
+            role: isTransactionSigner(account.value) ? upgradeRoleToSigner(writableRole) : writableRole,
+            ...(isTransactionSigner(account.value) ? { signer: account.value } : {}),
+        });
+    };
 }
 
 export function isTransactionSigner<TAddress extends string = string>(
-  value:
-    | Address<TAddress>
-    | ProgramDerivedAddress<TAddress>
-    | TransactionSigner<TAddress>
+    value: Address<TAddress> | ProgramDerivedAddress<TAddress> | TransactionSigner<TAddress>
 ): value is TransactionSigner<TAddress> {
-  return (
-    !!value &&
-    typeof value === 'object' &&
-    'address' in value &&
-    kitIsTransactionSigner(value)
-  );
+    return !!value && typeof value === 'object' && 'address' in value && kitIsTransactionSigner(value);
 }

--- a/test/e2e/dummy/test/_setup.ts
+++ b/test/e2e/dummy/test/_setup.ts
@@ -10,6 +10,7 @@ import {
   type TransactionSigner,
   airdropFactory,
   assertIsSendableTransaction,
+  assertIsTransactionWithBlockhashLifetime,
   createSolanaRpc,
   createSolanaRpcSubscriptions,
   createTransactionMessage,
@@ -76,6 +77,7 @@ export const signAndSendTransaction = async (
     await signTransactionMessageWithSigners(transactionMessage);
   const signature = getSignatureFromTransaction(signedTransaction);
   assertIsSendableTransaction(signedTransaction);
+  assertIsTransactionWithBlockhashLifetime(signedTransaction);
   await sendAndConfirmTransactionFactory(client)(signedTransaction, {
     commitment,
   });

--- a/test/e2e/generate.cjs
+++ b/test/e2e/generate.cjs
@@ -3,7 +3,6 @@
 const path = require('node:path');
 const process = require('node:process');
 
-const { rootNode } = require('@codama/nodes');
 const { rootNodeFromAnchor } = require('@codama/nodes-from-anchor');
 const { readJson } = require('@codama/renderers-core');
 const { visit } = require('@codama/visitors-core');
@@ -19,17 +18,15 @@ async function main() {
 }
 
 async function generateProject(project) {
-    const idl = readJson(path.join(__dirname, project, 'idl.json'));
+    const packageFolder = path.join(__dirname, project);
+    const idl = readJson(path.join(packageFolder, 'idl.json'));
+    const node = idl?.metadata?.spec ? rootNodeFromAnchor(idl) : idl;
+    const visitor = renderVisitor(
+        path.join(packageFolder, 'src', 'generated'),
+        { packageFolder, syncPackageJson: true }
+    );
 
-    let node;
-
-    if (idl?.metadata?.spec) {
-        node = rootNodeFromAnchor(idl);
-    } else {
-        node = rootNode(idl.program, idl.additionalPrograms);
-    }
-
-    await visit(node, renderVisitor(path.join(__dirname, project, 'src', 'generated')));
+    await visit(node, visitor);
 }
 
 main().catch(err => {

--- a/test/e2e/memo/.prettierrc.json
+++ b/test/e2e/memo/.prettierrc.json
@@ -1,9 +1,0 @@
-{
-  "semi": true,
-  "singleQuote": true,
-  "trailingComma": "es5",
-  "useTabs": false,
-  "tabWidth": 2,
-  "arrowParens": "always",
-  "printWidth": 80
-}

--- a/test/e2e/memo/package.json
+++ b/test/e2e/memo/package.json
@@ -10,6 +10,9 @@
     "lint": "eslint --ext js,ts,tsx src && prettier --check src test",
     "lint:fix": "eslint --fix --ext js,ts,tsx src && prettier --write src test"
   },
+  "dependencies": {
+    "@solana/kit": "^5.0.0"
+  },
   "license": "MIT",
   "ava": {
     "typescript": {
@@ -18,6 +21,5 @@
         "test/": "dist/test/"
       }
     }
-  },
-  "packageManager": "pnpm@9.1.0"
+  }
 }

--- a/test/e2e/memo/src/generated/instructions/addMemo.ts
+++ b/test/e2e/memo/src/generated/instructions/addMemo.ts
@@ -7,98 +7,85 @@
  */
 
 import {
-  AccountRole,
-  combineCodec,
-  getStructDecoder,
-  getStructEncoder,
-  getUtf8Decoder,
-  getUtf8Encoder,
-  type AccountMeta,
-  type Address,
-  type Codec,
-  type Decoder,
-  type Encoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyUint8Array,
-  type TransactionSigner,
+    AccountRole,
+    combineCodec,
+    getStructDecoder,
+    getStructEncoder,
+    getUtf8Decoder,
+    getUtf8Encoder,
+    type AccountMeta,
+    type Address,
+    type Codec,
+    type Decoder,
+    type Encoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyUint8Array,
+    type TransactionSigner,
 } from '@solana/kit';
 import { MEMO_PROGRAM_ADDRESS } from '../programs';
 
 export type AddMemoInstruction<
-  TProgram extends string = typeof MEMO_PROGRAM_ADDRESS,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
-> = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<TRemainingAccounts>;
+    TProgram extends string = typeof MEMO_PROGRAM_ADDRESS,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> & InstructionWithData<ReadonlyUint8Array> & InstructionWithAccounts<TRemainingAccounts>;
 
 export type AddMemoInstructionData = { memo: string };
 
 export type AddMemoInstructionDataArgs = AddMemoInstructionData;
 
 export function getAddMemoInstructionDataEncoder(): Encoder<AddMemoInstructionDataArgs> {
-  return getStructEncoder([['memo', getUtf8Encoder()]]);
+    return getStructEncoder([['memo', getUtf8Encoder()]]);
 }
 
 export function getAddMemoInstructionDataDecoder(): Decoder<AddMemoInstructionData> {
-  return getStructDecoder([['memo', getUtf8Decoder()]]);
+    return getStructDecoder([['memo', getUtf8Decoder()]]);
 }
 
-export function getAddMemoInstructionDataCodec(): Codec<
-  AddMemoInstructionDataArgs,
-  AddMemoInstructionData
-> {
-  return combineCodec(
-    getAddMemoInstructionDataEncoder(),
-    getAddMemoInstructionDataDecoder()
-  );
+export function getAddMemoInstructionDataCodec(): Codec<AddMemoInstructionDataArgs, AddMemoInstructionData> {
+    return combineCodec(getAddMemoInstructionDataEncoder(), getAddMemoInstructionDataDecoder());
 }
 
 export type AddMemoInput = {
-  memo: AddMemoInstructionDataArgs['memo'];
-  signers?: Array<TransactionSigner>;
+    memo: AddMemoInstructionDataArgs['memo'];
+    signers?: Array<TransactionSigner>;
 };
 
-export function getAddMemoInstruction<
-  TProgramAddress extends Address = typeof MEMO_PROGRAM_ADDRESS,
->(
-  input: AddMemoInput,
-  config?: { programAddress?: TProgramAddress }
+export function getAddMemoInstruction<TProgramAddress extends Address = typeof MEMO_PROGRAM_ADDRESS>(
+    input: AddMemoInput,
+    config?: { programAddress?: TProgramAddress }
 ): AddMemoInstruction<TProgramAddress> {
-  // Program address.
-  const programAddress = config?.programAddress ?? MEMO_PROGRAM_ADDRESS;
+    // Program address.
+    const programAddress = config?.programAddress ?? MEMO_PROGRAM_ADDRESS;
 
-  // Original args.
-  const args = { ...input };
+    // Original args.
+    const args = { ...input };
 
-  // Remaining accounts.
-  const remainingAccounts: AccountMeta[] = (args.signers ?? []).map(
-    (signer) => ({
-      address: signer.address,
-      role: AccountRole.READONLY_SIGNER,
-      signer,
-    })
-  );
+    // Remaining accounts.
+    const remainingAccounts: AccountMeta[] = (args.signers ?? []).map(signer => ({
+        address: signer.address,
+        role: AccountRole.READONLY_SIGNER,
+        signer,
+    }));
 
-  return Object.freeze({
-    accounts: remainingAccounts,
-    data: getAddMemoInstructionDataEncoder().encode(
-      args as AddMemoInstructionDataArgs
-    ),
-    programAddress,
-  } as AddMemoInstruction<TProgramAddress>);
+    return Object.freeze({
+        accounts: remainingAccounts,
+        data: getAddMemoInstructionDataEncoder().encode(args as AddMemoInstructionDataArgs),
+        programAddress,
+    } as AddMemoInstruction<TProgramAddress>);
 }
 
-export type ParsedAddMemoInstruction<
-  TProgram extends string = typeof MEMO_PROGRAM_ADDRESS,
-> = { programAddress: Address<TProgram>; data: AddMemoInstructionData };
+export type ParsedAddMemoInstruction<TProgram extends string = typeof MEMO_PROGRAM_ADDRESS> = {
+    programAddress: Address<TProgram>;
+    data: AddMemoInstructionData;
+};
 
 export function parseAddMemoInstruction<TProgram extends string>(
-  instruction: Instruction<TProgram> & InstructionWithData<ReadonlyUint8Array>
+    instruction: Instruction<TProgram> & InstructionWithData<ReadonlyUint8Array>
 ): ParsedAddMemoInstruction<TProgram> {
-  return {
-    programAddress: instruction.programAddress,
-    data: getAddMemoInstructionDataDecoder().decode(instruction.data),
-  };
+    return {
+        programAddress: instruction.programAddress,
+        data: getAddMemoInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/memo/src/generated/programs/memo.ts
+++ b/test/e2e/memo/src/generated/programs/memo.ts
@@ -10,14 +10,12 @@ import { type Address } from '@solana/kit';
 import { type ParsedAddMemoInstruction } from '../instructions';
 
 export const MEMO_PROGRAM_ADDRESS =
-  'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr' as Address<'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr'>;
+    'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr' as Address<'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr'>;
 
 export enum MemoInstruction {
-  AddMemo,
+    AddMemo,
 }
 
-export type ParsedMemoInstruction<
-  TProgram extends string = 'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr',
-> = {
-  instructionType: MemoInstruction.AddMemo;
+export type ParsedMemoInstruction<TProgram extends string = 'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr'> = {
+    instructionType: MemoInstruction.AddMemo;
 } & ParsedAddMemoInstruction<TProgram>;

--- a/test/e2e/memo/src/generated/shared/index.ts
+++ b/test/e2e/memo/src/generated/shared/index.ts
@@ -7,15 +7,15 @@
  */
 
 import {
-  AccountRole,
-  isProgramDerivedAddress,
-  isTransactionSigner as kitIsTransactionSigner,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type ProgramDerivedAddress,
-  type TransactionSigner,
-  upgradeRoleToSigner,
+    AccountRole,
+    isProgramDerivedAddress,
+    isTransactionSigner as kitIsTransactionSigner,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type ProgramDerivedAddress,
+    type TransactionSigner,
+    upgradeRoleToSigner,
 } from '@solana/kit';
 
 /**
@@ -23,10 +23,10 @@ import {
  * @internal
  */
 export function expectSome<T>(value: T | null | undefined): T {
-  if (value === null || value === undefined) {
-    throw new Error('Expected a value but received null or undefined.');
-  }
-  return value;
+    if (value === null || value === undefined) {
+        throw new Error('Expected a value but received null or undefined.');
+    }
+    return value;
 }
 
 /**
@@ -34,23 +34,18 @@ export function expectSome<T>(value: T | null | undefined): T {
  * @internal
  */
 export function expectAddress<T extends string = string>(
-  value:
-    | Address<T>
-    | ProgramDerivedAddress<T>
-    | TransactionSigner<T>
-    | null
-    | undefined
+    value: Address<T> | ProgramDerivedAddress<T> | TransactionSigner<T> | null | undefined
 ): Address<T> {
-  if (!value) {
-    throw new Error('Expected a Address.');
-  }
-  if (typeof value === 'object' && 'address' in value) {
-    return value.address;
-  }
-  if (Array.isArray(value)) {
-    return value[0] as Address<T>;
-  }
-  return value as Address<T>;
+    if (!value) {
+        throw new Error('Expected a Address.');
+    }
+    if (typeof value === 'object' && 'address' in value) {
+        return value.address;
+    }
+    if (Array.isArray(value)) {
+        return value[0] as Address<T>;
+    }
+    return value as Address<T>;
 }
 
 /**
@@ -58,17 +53,12 @@ export function expectAddress<T extends string = string>(
  * @internal
  */
 export function expectProgramDerivedAddress<T extends string = string>(
-  value:
-    | Address<T>
-    | ProgramDerivedAddress<T>
-    | TransactionSigner<T>
-    | null
-    | undefined
+    value: Address<T> | ProgramDerivedAddress<T> | TransactionSigner<T> | null | undefined
 ): ProgramDerivedAddress<T> {
-  if (!value || !Array.isArray(value) || !isProgramDerivedAddress(value)) {
-    throw new Error('Expected a ProgramDerivedAddress.');
-  }
-  return value;
+    if (!value || !Array.isArray(value) || !isProgramDerivedAddress(value)) {
+        throw new Error('Expected a ProgramDerivedAddress.');
+    }
+    return value;
 }
 
 /**
@@ -76,17 +66,12 @@ export function expectProgramDerivedAddress<T extends string = string>(
  * @internal
  */
 export function expectTransactionSigner<T extends string = string>(
-  value:
-    | Address<T>
-    | ProgramDerivedAddress<T>
-    | TransactionSigner<T>
-    | null
-    | undefined
+    value: Address<T> | ProgramDerivedAddress<T> | TransactionSigner<T> | null | undefined
 ): TransactionSigner<T> {
-  if (!value || !isTransactionSigner(value)) {
-    throw new Error('Expected a TransactionSigner.');
-  }
-  return value;
+    if (!value || !isTransactionSigner(value)) {
+        throw new Error('Expected a TransactionSigner.');
+    }
+    return value;
 }
 
 /**
@@ -94,19 +79,15 @@ export function expectTransactionSigner<T extends string = string>(
  * @internal
  */
 export type ResolvedAccount<
-  T extends string = string,
-  U extends
-    | Address<T>
-    | ProgramDerivedAddress<T>
-    | TransactionSigner<T>
-    | null =
-    | Address<T>
-    | ProgramDerivedAddress<T>
-    | TransactionSigner<T>
-    | null,
+    T extends string = string,
+    U extends Address<T> | ProgramDerivedAddress<T> | TransactionSigner<T> | null =
+        | Address<T>
+        | ProgramDerivedAddress<T>
+        | TransactionSigner<T>
+        | null,
 > = {
-  isWritable: boolean;
-  value: U;
+    isWritable: boolean;
+    value: U;
 };
 
 /**
@@ -114,51 +95,31 @@ export type ResolvedAccount<
  * @internal
  */
 export type InstructionWithByteDelta = {
-  byteDelta: number;
+    byteDelta: number;
 };
 
 /**
  * Get account metas and signers from resolved accounts.
  * @internal
  */
-export function getAccountMetaFactory(
-  programAddress: Address,
-  optionalAccountStrategy: 'omitted' | 'programId'
-) {
-  return (
-    account: ResolvedAccount
-  ): AccountMeta | AccountSignerMeta | undefined => {
-    if (!account.value) {
-      if (optionalAccountStrategy === 'omitted') return;
-      return Object.freeze({
-        address: programAddress,
-        role: AccountRole.READONLY,
-      });
-    }
+export function getAccountMetaFactory(programAddress: Address, optionalAccountStrategy: 'omitted' | 'programId') {
+    return (account: ResolvedAccount): AccountMeta | AccountSignerMeta | undefined => {
+        if (!account.value) {
+            if (optionalAccountStrategy === 'omitted') return;
+            return Object.freeze({ address: programAddress, role: AccountRole.READONLY });
+        }
 
-    const writableRole = account.isWritable
-      ? AccountRole.WRITABLE
-      : AccountRole.READONLY;
-    return Object.freeze({
-      address: expectAddress(account.value),
-      role: isTransactionSigner(account.value)
-        ? upgradeRoleToSigner(writableRole)
-        : writableRole,
-      ...(isTransactionSigner(account.value) ? { signer: account.value } : {}),
-    });
-  };
+        const writableRole = account.isWritable ? AccountRole.WRITABLE : AccountRole.READONLY;
+        return Object.freeze({
+            address: expectAddress(account.value),
+            role: isTransactionSigner(account.value) ? upgradeRoleToSigner(writableRole) : writableRole,
+            ...(isTransactionSigner(account.value) ? { signer: account.value } : {}),
+        });
+    };
 }
 
 export function isTransactionSigner<TAddress extends string = string>(
-  value:
-    | Address<TAddress>
-    | ProgramDerivedAddress<TAddress>
-    | TransactionSigner<TAddress>
+    value: Address<TAddress> | ProgramDerivedAddress<TAddress> | TransactionSigner<TAddress>
 ): value is TransactionSigner<TAddress> {
-  return (
-    !!value &&
-    typeof value === 'object' &&
-    'address' in value &&
-    kitIsTransactionSigner(value)
-  );
+    return !!value && typeof value === 'object' && 'address' in value && kitIsTransactionSigner(value);
 }

--- a/test/e2e/memo/test/_setup.ts
+++ b/test/e2e/memo/test/_setup.ts
@@ -10,6 +10,7 @@ import {
   type TransactionSigner,
   airdropFactory,
   assertIsSendableTransaction,
+  assertIsTransactionWithBlockhashLifetime,
   createSolanaRpc,
   createSolanaRpcSubscriptions,
   createTransactionMessage,
@@ -76,6 +77,7 @@ export const signAndSendTransaction = async (
     await signTransactionMessageWithSigners(transactionMessage);
   const signature = getSignatureFromTransaction(signedTransaction);
   assertIsSendableTransaction(signedTransaction);
+  assertIsTransactionWithBlockhashLifetime(signedTransaction);
   await sendAndConfirmTransactionFactory(client)(signedTransaction, {
     commitment,
   });

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -1,9 +1,6 @@
 {
     "name": "@codama/renderers-js-e2e-monorepo",
     "private": true,
-    "dependencies": {
-        "@solana/kit": "^3.0.2"
-    },
     "devDependencies": {
         "@ava/typescript": "^6.0.0",
         "@solana/eslint-config-solana": "^3.0.0",
@@ -17,10 +14,5 @@
         "typedoc": "^0.28.12",
         "typedoc-plugin-missing-exports": "^4.1.0",
         "typescript": "^5.9.2"
-    },
-    "engines": {
-        "node": ">=20.18.0"
-    },
-    "packageManager": "pnpm@9.1.0",
-    "prettier": "@solana/prettier-config-solana"
+    }
 }

--- a/test/e2e/pnpm-lock.yaml
+++ b/test/e2e/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      '@solana/kit':
-        specifier: ^3.0.2
-        version: 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.18.0)
     devDependencies:
       '@ava/typescript':
         specifier: ^6.0.0
@@ -49,15 +45,35 @@ importers:
         specifier: ^5.9.2
         version: 5.9.2
 
-  anchor: {}
+  anchor:
+    dependencies:
+      '@solana/kit':
+        specifier: ^5.0.0
+        version: 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.18.0)
 
-  dummy: {}
+  dummy:
+    dependencies:
+      '@solana/kit':
+        specifier: ^5.0.0
+        version: 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.18.0)
 
-  memo: {}
+  memo:
+    dependencies:
+      '@solana/kit':
+        specifier: ^5.0.0
+        version: 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.18.0)
 
-  system: {}
+  system:
+    dependencies:
+      '@solana/kit':
+        specifier: ^5.0.0
+        version: 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.18.0)
 
-  token: {}
+  token:
+    dependencies:
+      '@solana/kit':
+        specifier: ^5.0.0
+        version: 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.18.0)
 
 packages:
 
@@ -445,57 +461,57 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
-  '@solana/accounts@3.0.2':
-    resolution: {integrity: sha512-eV38HyAuq61DREvlIHhrIqlG1AVBGV6FNLx67MajYQ+CAHT6N4rJ+NETqNZb6cEnj02/wBfEIdBT17nYmN3Tnw==}
+  '@solana/accounts@5.0.0':
+    resolution: {integrity: sha512-0JzBdEobgp8NBdhhu+GgwNDh7e8KkHDsSTVZAnNQgvT3taOz0Mwv5E48MuEeDhW6DLFwWVAx/FO3pvibG/NGwA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/addresses@3.0.2':
-    resolution: {integrity: sha512-ULqKK1IZkxW8tEZWJ2lxhKxPEHEZgOCDbY+WW9yR3ZVG5gQf0h1lntCVXRyS50xfsIjWVXuQS4y2uVsSAcYdsw==}
+  '@solana/addresses@5.0.0':
+    resolution: {integrity: sha512-bVk+khc1ZZQHMri25csosM/ikuyPcB/CZidDM/ZMBX0CoJErpHJnmcID5mYOmv4/UHbqo2OANuEaGcFO0Q37sw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/assertions@3.0.2':
-    resolution: {integrity: sha512-MsIWJHyqutBT9j633p2IjvPFG0XSd6KOQ3pwGHTJN2AyG/qg9hZKs9I1bYuFaMm+f7N2RFQq+B3Tx6Vsdl92JQ==}
+  '@solana/assertions@5.0.0':
+    resolution: {integrity: sha512-2kIykk90kYciQW6bp+KaE6jRd1Y2CgHPeJxxlc5chQnjhoG6eiD8VXvocs6AvqPTht0p/SoEj9jH5tT4oG/bcg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/codecs-core@3.0.2':
-    resolution: {integrity: sha512-vpy8ySWgPF8+APwpeEr4dQbU/EyHjisd/TywIw3rymguWeZ9/wcThS0WDRi08Z44W6InCIbtI08RdtuHQZoSag==}
+  '@solana/codecs-core@5.0.0':
+    resolution: {integrity: sha512-rCG2d8OaamVF2/J//YyCgDqNJpUytVVltw9C8mJtEz5c6Se/LR6BFuG8g4xeJswq/ab4RFk5/HFdgbvNjKgQjA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/codecs-data-structures@3.0.2':
-    resolution: {integrity: sha512-07L3czS7xughfCSx2pTC4/3amyjuCd3kOW4m4RJoXqWVzyg5lX4vCIVrlQE4MtM7/5SLLvGHXbCPHcp92esGcQ==}
+  '@solana/codecs-data-structures@5.0.0':
+    resolution: {integrity: sha512-y503Pqmv0LHcfcf0vQJGaxDvydQJbyCo8nK3nxn56EhFj5lBQ1NWb3WvTd83epigwuZurW2MhJARrpikfhQglQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/codecs-numbers@3.0.2':
-    resolution: {integrity: sha512-Yr9kWo2BF4Wdu9mhceUQ3ksA6ZTi2CvQr8GWkRh9DQjvmrdqE2vwxwWWcmnzGDzwbta5o4tAr8JjtAtmwpiLEg==}
+  '@solana/codecs-numbers@5.0.0':
+    resolution: {integrity: sha512-a2+skRLuUK02f/XFe4L0e1+wHCyfK25PkyseFps1v1l4pvevukFwth/EhSyrs6w5CsTJRVoR7MuE3E00PM4egw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/codecs-strings@3.0.2':
-    resolution: {integrity: sha512-V7Ivy3TjdrLL4E3wT2d32MpGYQFWM1UKnevLXPib/Aqws4nP/bGMHq6gSIJ4b9HrkFfrlEgSjusOyEJbRBBFag==}
+  '@solana/codecs-strings@5.0.0':
+    resolution: {integrity: sha512-ALkRwpV8bGR6qjAYw0YXZwp2YI4wzvKOJGmx04Ut8gMdbaUx7qOcJkhEQKI6ZVC3lAWSIS1N1wGccUZDwvfKxw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
       typescript: '>=5.3.3'
 
-  '@solana/codecs@3.0.2':
-    resolution: {integrity: sha512-ihsmK+OnwuVd5le66lIDqsj0BQiHiYbL3pv4kUCVacxoo8pgqxGHTPh1/Ei1GNSm2N7LF/kwPvnZVECgY+ZaJg==}
+  '@solana/codecs@5.0.0':
+    resolution: {integrity: sha512-KOw0gFUSBxIMDWLJ3AkVFkEci91dw0Rpx3C6y83Our7fSW+SEP8vRZklCElieYR85LHVB1QIEhoeHR7rc+Ifkw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/errors@3.0.2':
-    resolution: {integrity: sha512-0B4y9JUsX8/DzflhdSXSAF+UPUKyo1R1rrQ/ShS/8ApCOIWIFqZlve0TPatuTOGGNBememoukPOvDVtFy0ZYpg==}
+  '@solana/errors@5.0.0':
+    resolution: {integrity: sha512-gTuhzO6E+ydfAAzqmqdPcvFyJwAzFKKIrqtnZPpgAuomcPYu+HSo0tuwSM/cTX0djmHt+GoOsf/julph+nvs2w==}
     engines: {node: '>=20.18.0'}
     hasBin: true
     peerDependencies:
@@ -514,171 +530,171 @@ packages:
       eslint-plugin-typescript-sort-keys: ^3.2.0
       typescript: ^5.1.6
 
-  '@solana/fast-stable-stringify@3.0.2':
-    resolution: {integrity: sha512-IFs/g0vPd7KGmX/XlWOx1EmGvNOz9RUAXt20DL1UKl3uoor/kUeM+Axt2Ey85njp3c4Y8rP5j2pXPuErkiuPbA==}
+  '@solana/fast-stable-stringify@5.0.0':
+    resolution: {integrity: sha512-sGTbu7a4/olL+8EIOOJ7IZjzqOOpCJcK1UaVJ6015sRgo9vwGf4jg9KtXEYv5LVhLCTYmAb50L4BaIUcBph/Ig==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/functional@3.0.2':
-    resolution: {integrity: sha512-sTLgutPHKzDcyQaGvNpmWvdHMrKPMF51XLymFh9oMK5WAJTBXU5yl4DWGGy5FmpMX8UP4/fSdDjDuCgTeslVrw==}
+  '@solana/functional@5.0.0':
+    resolution: {integrity: sha512-UNBrpfzBL4dKD2iucjNnrkFbnjz5ZYDu2OvrIBAcCSQsxxgHMamUj1n3EDe6kl1us49YG1r05Ho8QLqNrbkVbw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/instruction-plans@3.0.2':
-    resolution: {integrity: sha512-kobDyIio7cOCcoVw5WJrAm6w6wwg4SW9hLryqE1RcaLGdYPluE130Kcnn/YHr41VwKkqvaGc55nQAe8kHCwaXA==}
+  '@solana/instruction-plans@5.0.0':
+    resolution: {integrity: sha512-n9oFOMFUPYKEhsXzrXT97QBQ2WvOTar+5SFEj/IOtRuCn4gl2kh0369cjXZpFwUdE3tmKr1zfYFNwbtiNx5pvg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/instructions@3.0.2':
-    resolution: {integrity: sha512-y7ycX8FMWwEr8gfqCJQAUJmhvzJ8VyW0ofWfcjpy09+oT1tNihTHINbWr/E9qRtr8oDVV+u2RIz5ScbCLZetTg==}
+  '@solana/instructions@5.0.0':
+    resolution: {integrity: sha512-12dbrmwERT1o6NTr/Uvrjj/ZsiteSXoT5Gi+dnjIeRNHWg9H+gEFuFzJvTDVKlNg34CZ71xdvbVdbV0V8gKGvg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/keys@3.0.2':
-    resolution: {integrity: sha512-+0SIFLs+IufkJlOYrZU1GHF7br5y5M5Rroq1Ctwjw7YfTp84UhSoZzkntxdhgwq+CrdNHgZcxCiHqo65XzOuwA==}
+  '@solana/keys@5.0.0':
+    resolution: {integrity: sha512-kWkR7NslpTttk5i1BhBNCDtVQDkEtgkdsM3Jp9TGPk0GFjBjBwrQStw3vvwLe8itEIvRFGFZU6JHEk8HLS0WLQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/kit@3.0.2':
-    resolution: {integrity: sha512-30wcrnxI3jGv3yuNCZ4iJbwu/Yvk0zhqc3kjpcVz7gVAkCcjtyn/l2BETl/7vwKCBKwqIZ2G01hSGyfwNtjrkg==}
+  '@solana/kit@5.0.0':
+    resolution: {integrity: sha512-3ahtzmmMgU+1l2YMhQJSKKm14IdvCycOE/m4XNMu/4icBIptmBgZxrmgRpPHqBilBa+Krp/hBuTg4HWl9IAgWw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/nominal-types@3.0.2':
-    resolution: {integrity: sha512-KrZ/a16+HDDpOrkDVFvDQrFDDZf+kNuD3zmU/5KbxQ0kn9uuEFb9/P9Vct3R8qacshH73lHWOz+006Bb+xX88A==}
+  '@solana/nominal-types@5.0.0':
+    resolution: {integrity: sha512-Qn7xH4UG2rDAv+wAyheP4jWvX3oQmbZ/woxFZwug7PaRLvyjUswGr38Hil+SjiQyFDo+un1UqWM9N9yusUeeZQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/options@3.0.2':
-    resolution: {integrity: sha512-hthTZ7CBoRmlDF4aNbjzUf8qzlmXXW7XzIZNXO0xfeGexC+j7noxowHgOlK9a7Lpk+0EDF1LFkMYTh3Wy6nR6w==}
+  '@solana/options@5.0.0':
+    resolution: {integrity: sha512-ezHVBFb9FXVSn8LUVRD2tLb6fejU0x8KtGEYyCYh0J0pQuXSITV0IQCjcEopvu/ZxWdXOJyzjvmymnhz90on5A==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/programs@3.0.2':
-    resolution: {integrity: sha512-dXAFJB5fqv6umgWUcu0sijy74wT+VrUh7tcSZTMO0vjnSDLM/p5nJ9puiUrPUwQMLXgJ/8yY5YL27wHBq02vjQ==}
+  '@solana/programs@5.0.0':
+    resolution: {integrity: sha512-BKOfBDrSUCJGZ+qKk2aFLu0nU9/84o6z/VDCJkLjaNNuTv8nOlSYq5flNzo1eyJmnpyW372qNvqqRN3AS23+FQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/promises@3.0.2':
-    resolution: {integrity: sha512-HlYVdT4ysRmCJcQ3wG/KIMx9CRZ+Wp6kW5HXpi7zS/2bSu2fTf/QDZAs7Tps4eVM7AD8XWVKgbmxR3U4EJiMNA==}
+  '@solana/promises@5.0.0':
+    resolution: {integrity: sha512-Qmg3UfYfWINEUvBQL3DkPOq34tTg5cfrkPlDtJmi8RVifsPqb6hksbKZGu7ASLZohxIDGmnYQY6oELI7Me+5yw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/rpc-api@3.0.2':
-    resolution: {integrity: sha512-40wi0De41McJM81HekgGR+lHaGHYIJPFvbZ9VvS40LYqVJjCaded1bgSEeFUaDVgJHs4uL0LX2sFruJQ48O/bw==}
+  '@solana/rpc-api@5.0.0':
+    resolution: {integrity: sha512-IJbZZnX2B1ldXPok1NhneXTYq9ZvdJbE5Pryr03pZTlPJaWGqDcZuQ14nwR4s6PoUUgdT+p87QlLZqLb8MusoQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/rpc-parsed-types@3.0.2':
-    resolution: {integrity: sha512-1V+hzHNkKXrMXKnF/kWkE+2m95QKsnYRFOKSi8a/zB2FZ6P33ckQa9ITMOM0DAH4CBPQlMAg/k90lHQGSHINtA==}
+  '@solana/rpc-parsed-types@5.0.0':
+    resolution: {integrity: sha512-fU9uqlOYAaBqgk2qCl+ntenBm7wuSFBRbIO/rVjeBPd/qPCvNZU+qFET+ERLK6wbCTSz0MmdHqPn1V8KCMOvZQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/rpc-spec-types@3.0.2':
-    resolution: {integrity: sha512-y+Syivahjlv2qbBwHGZYuFaxHMPWcxMCY8bqQBLdssDxoVTMFunALgeZ6JKD+FT2a58yL+Cpsd7fL6FdMiQIDg==}
+  '@solana/rpc-spec-types@5.0.0':
+    resolution: {integrity: sha512-B0P/ylXVaCG5oSIV+kB88s2qoW996D8iKhc7RyF0C/AyYvklF6kCwv0N9ZVrWp0ibjlQ8St290WbBHJyo7QZkA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/rpc-spec@3.0.2':
-    resolution: {integrity: sha512-SvHCrpwdzhMQ4bvBBMdeSRxBnP85MbuRv5ePGZHEo9fkgJuOVigGjA7kdvcMhX1m0OO4iOb8YUWs+Vqj3dBqzQ==}
+  '@solana/rpc-spec@5.0.0':
+    resolution: {integrity: sha512-1LD2SYEQ5bYhiBumznAPzymtxSX4nYLZd6u+FA0bAxNBVzHDvUUQzVSXHAoWROhlGrCyvtALTs9u0DIDlgZHCA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/rpc-subscriptions-api@3.0.2':
-    resolution: {integrity: sha512-moMGc62Arftbs3lFMY7lu8iMBrKn7P/BAb5Vv76MqlUioW0ip1PTH9zsK2i5GGfOFSWKE/WqyzJR1A6GIiUQYQ==}
+  '@solana/rpc-subscriptions-api@5.0.0':
+    resolution: {integrity: sha512-DGUn3C12swV2FConOlLFN14npIrCtnxehtMLjszMC7g6p/P6WNIz5uAgF7YcIkLBDV8uTeWhM0azmK+V8Qqhvg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/rpc-subscriptions-channel-websocket@3.0.2':
-    resolution: {integrity: sha512-2m5c1RT/XC6uVdBL4uuU70nBtlOn6/1h9/BXhe17xcdYU+8w75b9rkTCBmMwu0W/VZHJXRi3J1RsHPCaxnPk7w==}
+  '@solana/rpc-subscriptions-channel-websocket@5.0.0':
+    resolution: {integrity: sha512-vsYXyjVX/kExfpr91zfMKTmWKKFCM+dkhXQDAz5aEE7kAF3KSZDiOGeYvN8Rc85lbIt9QK6BLAT+NBMv4/N9Qg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
       ws: ^8.18.0
 
-  '@solana/rpc-subscriptions-spec@3.0.2':
-    resolution: {integrity: sha512-x15UeQVuHbEC6+sgebn+iBhDVaPNBnBiUHYYY78kLDNCZiO5/SEyUXn96W8SNXS3CdT+6bN55gb/LhsWpZN4Ng==}
+  '@solana/rpc-subscriptions-spec@5.0.0':
+    resolution: {integrity: sha512-erRLvZMncwnciJP6I1SlAk0CyRGIgt83PyHWOVCRXENP9Q5dZbZ9pm4lar2yIp8EjIMnodGHsQWIlKc1hlCQlQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/rpc-subscriptions@3.0.2':
-    resolution: {integrity: sha512-EKxt9WfUpSWj9uZw9xyMXXZhF6IJXcdbWwzjU/BGca/nwjMUub78hCWBn7ImcXwePDooXfbqj3HYZ6FY6TQoIQ==}
+  '@solana/rpc-subscriptions@5.0.0':
+    resolution: {integrity: sha512-cziOSzom/bwFZXViR9J+MxDsdLMcfvrXGw5Icng7dYODFKuVqfsDrQoG8uekJc4fREnbPEM2U+u9YnYSYbFbww==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/rpc-transformers@3.0.2':
-    resolution: {integrity: sha512-qPOrGZ9ieYAplIEYdVTzWquFd8TSYPgZ9lyRH7yScUywimDUnK5h/Rg4dm6TYo7RIj5wxdx244/m436HkgmqPA==}
+  '@solana/rpc-transformers@5.0.0':
+    resolution: {integrity: sha512-EMHhSgfF6/T4FfHbLaBP08SIj1ZAjxJr6WPNZMHLV7Cup8UfiB9TNV+bPQkum7JbVQNhUKzkKEEmyYqPfQoV9w==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/rpc-transport-http@3.0.2':
-    resolution: {integrity: sha512-2bEsYGUTYxuFyzz+gc3afx/xagn4ZA499/xHt4XrWaPcqL9P4/oPcg99kdFkzPJII2dHCVCOh2h65j3+VvM7Yg==}
+  '@solana/rpc-transport-http@5.0.0':
+    resolution: {integrity: sha512-RoIEvWp7yc7rIRzNkOyjLs2UQF0odIEMWj87dbD4Ir4hwTCGo/TSTfQF/8KDV2etdke3Fa1K+W1NkpG2POqWFg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/rpc-types@3.0.2':
-    resolution: {integrity: sha512-0OHQ6j6ncBY88IDVSeXf1mqW8KMO8SQsHK/PFLVgJr2Z5FkanCRCzCX2agShOFIVT41lR5jiRhHW8DnUX2C0Hg==}
+  '@solana/rpc-types@5.0.0':
+    resolution: {integrity: sha512-JMbhwnV6nX4ezJv/KmaElOR0r/MZTKzKpaz6cv7FopLNuPrYCBrRCZKuM2XQh6gUbt9Mey08/KBOmOGmzTbL/g==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/rpc@3.0.2':
-    resolution: {integrity: sha512-62DLIC/8g5+3MdsZ5qkdsAY4sMeGHnoPjgbz07OCYppALm4oFSv79w184oLivvYPdjrhkMCW1RW9yHnZ/r4U8g==}
+  '@solana/rpc@5.0.0':
+    resolution: {integrity: sha512-Myx/ZBmMHkgh9Di3tLzc+vd30f+6YC1JXr9+YmIHKEeqN/+iTHkDJU2E/hGRLy8vTOBOU7+2466A+dLnSVuGkg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/signers@3.0.2':
-    resolution: {integrity: sha512-B7G42k9g8sxsnwcnCzhSD918kFy6N08fzyV9fGCgq/Zc/dYTxXwclmnvDoG1wqR51EKNNTVNK8dgXzRLfiQX2w==}
+  '@solana/signers@5.0.0':
+    resolution: {integrity: sha512-9Hw6HekSEzj5O7UBBFPrxk96W5e8tMI3n7KbW7/QiKBDpuvYw9WtnjOsWUE7LqQoc1P0JjGEsrmxE9raQBLvuQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/subscribable@3.0.2':
-    resolution: {integrity: sha512-t/quWveT3zcBSYGWr75qezL90qRnw9g3e7h5ZjEpW2bUEr4/MvHfPbV8H4GMidIm7AHBWvohuDj5ddovqGpVDQ==}
+  '@solana/subscribable@5.0.0':
+    resolution: {integrity: sha512-C2TydIRRd5XUJ8asbARi67Sj/3DRLubWalnNoafBhDsrb88jsRVylntvwXgBw/+lwJdEPEsUnxvcdgdm+3lFlw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/sysvars@3.0.2':
-    resolution: {integrity: sha512-t3yh2lmHXBdDj3eS9ufD3XMf4zMwi/HhJql8281mWFZ2p1tflNUTWrK2Wo7BbPn5OfPhQ0U2ilv6OSvub3mMLg==}
+  '@solana/sysvars@5.0.0':
+    resolution: {integrity: sha512-F/GEb2rS8mrgDd79lDPyu8za9jGE6cRlS4jHNeKCkvOCJxdKQbX34JIzx4kwzjtvk7O8/yrDHfGdpA8nBg/l4w==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/transaction-confirmation@3.0.2':
-    resolution: {integrity: sha512-w/ZarOIyzNnCl+OzSVhiNeMipJu/8Qrcu6s/wOfRO/lu+oO39L2SbUwxqb/FMATd3fK8+TRW21hWGHcvCXxMFw==}
+  '@solana/transaction-confirmation@5.0.0':
+    resolution: {integrity: sha512-LpusTopYIuQC8hBCloExkTr4Z5/zdp5f4IIbzD5XFeW3xXPZytS3H1IDMGk4bmLdZi9zQNA4lnNHKra5IncRbw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/transaction-messages@3.0.2':
-    resolution: {integrity: sha512-EXbOsi6A6KMpVONb5wuQ/99aFXFXbxOvY4ndbkmp1lvhpahK3j2DuOwUT4tJeYKU7Xb7ktCA/IiL+PvEJIeX0A==}
+  '@solana/transaction-messages@5.0.0':
+    resolution: {integrity: sha512-rJLe1wUGW5DovQFV0gjXHXnriPxTBgZ3TvGWnjCu2OIBU8mcQkQVJ7zzVZY2IAYlmJ6OSF9nvzhSt/ncPbkJPg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/transactions@3.0.2':
-    resolution: {integrity: sha512-V1OmbQBOn6UT7JfGQXNHX2QAQbprNfk30/Clh3udvNcGqD1DrYRiYuy3g/PAh5hKVf142URfMDk3Ptr+8ylrCA==}
+  '@solana/transactions@5.0.0':
+    resolution: {integrity: sha512-4TcsqH7JtgRKGGBIRRGz0n+tXu4h5TPPC49kkV0ygIndQaHW7FOZUYTwQ0epq0A5h9KYi+ClNbzF9xiuDbAD5Q==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -938,8 +954,8 @@ packages:
     resolution: {integrity: sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
-  chalk@5.6.0:
-    resolution: {integrity: sha512-46QrSQFyVSEyYAgQ22hQ+zDa60YHA4fBstHmtSApj1Y5vKtG27fWowW03jCk5KcbXEWPZUIR894aARCA/G1kfQ==}
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   chokidar@4.0.3:
@@ -979,8 +995,8 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  commander@14.0.0:
-    resolution: {integrity: sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==}
+  commander@14.0.1:
+    resolution: {integrity: sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A==}
     engines: {node: '>=20'}
 
   commander@4.1.1:
@@ -1986,8 +2002,8 @@ packages:
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
-  undici-types@7.15.0:
-    resolution: {integrity: sha512-Xyn5T99wU4kPhLZMm+ElE6M+IoSeG8Se7eG9xoZ82ZgVHJ07wb/IWcDZeXe2GOPkavcJ8ko5oSlXMDRl/QgY9Q==}
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
@@ -2365,75 +2381,75 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@solana/accounts@3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+  '@solana/accounts@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
     dependencies:
-      '@solana/addresses': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/codecs-core': 3.0.2(typescript@5.9.2)
-      '@solana/codecs-strings': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/errors': 3.0.2(typescript@5.9.2)
-      '@solana/rpc-spec': 3.0.2(typescript@5.9.2)
-      '@solana/rpc-types': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/addresses': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/codecs-core': 5.0.0(typescript@5.9.2)
+      '@solana/codecs-strings': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/errors': 5.0.0(typescript@5.9.2)
+      '@solana/rpc-spec': 5.0.0(typescript@5.9.2)
+      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
       typescript: 5.9.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/addresses@3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+  '@solana/addresses@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
     dependencies:
-      '@solana/assertions': 3.0.2(typescript@5.9.2)
-      '@solana/codecs-core': 3.0.2(typescript@5.9.2)
-      '@solana/codecs-strings': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/errors': 3.0.2(typescript@5.9.2)
-      '@solana/nominal-types': 3.0.2(typescript@5.9.2)
+      '@solana/assertions': 5.0.0(typescript@5.9.2)
+      '@solana/codecs-core': 5.0.0(typescript@5.9.2)
+      '@solana/codecs-strings': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/errors': 5.0.0(typescript@5.9.2)
+      '@solana/nominal-types': 5.0.0(typescript@5.9.2)
       typescript: 5.9.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/assertions@3.0.2(typescript@5.9.2)':
+  '@solana/assertions@5.0.0(typescript@5.9.2)':
     dependencies:
-      '@solana/errors': 3.0.2(typescript@5.9.2)
+      '@solana/errors': 5.0.0(typescript@5.9.2)
       typescript: 5.9.2
 
-  '@solana/codecs-core@3.0.2(typescript@5.9.2)':
+  '@solana/codecs-core@5.0.0(typescript@5.9.2)':
     dependencies:
-      '@solana/errors': 3.0.2(typescript@5.9.2)
+      '@solana/errors': 5.0.0(typescript@5.9.2)
       typescript: 5.9.2
 
-  '@solana/codecs-data-structures@3.0.2(typescript@5.9.2)':
+  '@solana/codecs-data-structures@5.0.0(typescript@5.9.2)':
     dependencies:
-      '@solana/codecs-core': 3.0.2(typescript@5.9.2)
-      '@solana/codecs-numbers': 3.0.2(typescript@5.9.2)
-      '@solana/errors': 3.0.2(typescript@5.9.2)
+      '@solana/codecs-core': 5.0.0(typescript@5.9.2)
+      '@solana/codecs-numbers': 5.0.0(typescript@5.9.2)
+      '@solana/errors': 5.0.0(typescript@5.9.2)
       typescript: 5.9.2
 
-  '@solana/codecs-numbers@3.0.2(typescript@5.9.2)':
+  '@solana/codecs-numbers@5.0.0(typescript@5.9.2)':
     dependencies:
-      '@solana/codecs-core': 3.0.2(typescript@5.9.2)
-      '@solana/errors': 3.0.2(typescript@5.9.2)
+      '@solana/codecs-core': 5.0.0(typescript@5.9.2)
+      '@solana/errors': 5.0.0(typescript@5.9.2)
       typescript: 5.9.2
 
-  '@solana/codecs-strings@3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+  '@solana/codecs-strings@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
     dependencies:
-      '@solana/codecs-core': 3.0.2(typescript@5.9.2)
-      '@solana/codecs-numbers': 3.0.2(typescript@5.9.2)
-      '@solana/errors': 3.0.2(typescript@5.9.2)
+      '@solana/codecs-core': 5.0.0(typescript@5.9.2)
+      '@solana/codecs-numbers': 5.0.0(typescript@5.9.2)
+      '@solana/errors': 5.0.0(typescript@5.9.2)
       fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.9.2
 
-  '@solana/codecs@3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+  '@solana/codecs@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
     dependencies:
-      '@solana/codecs-core': 3.0.2(typescript@5.9.2)
-      '@solana/codecs-data-structures': 3.0.2(typescript@5.9.2)
-      '@solana/codecs-numbers': 3.0.2(typescript@5.9.2)
-      '@solana/codecs-strings': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/options': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/codecs-core': 5.0.0(typescript@5.9.2)
+      '@solana/codecs-data-structures': 5.0.0(typescript@5.9.2)
+      '@solana/codecs-numbers': 5.0.0(typescript@5.9.2)
+      '@solana/codecs-strings': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/options': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
       typescript: 5.9.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/errors@3.0.2(typescript@5.9.2)':
+  '@solana/errors@5.0.0(typescript@5.9.2)':
     dependencies:
-      chalk: 5.6.0
-      commander: 14.0.0
+      chalk: 5.6.2
+      commander: 14.0.1
       typescript: 5.9.2
 
   '@solana/eslint-config-solana@3.0.6(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2))(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2))(eslint-plugin-react-hooks@4.6.2(eslint@8.57.1))(eslint-plugin-simple-import-sort@12.1.1(eslint@8.57.1))(eslint-plugin-sort-keys-fix@1.1.2)(eslint-plugin-typescript-sort-keys@3.3.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2)':
@@ -2448,295 +2464,295 @@ snapshots:
       eslint-plugin-typescript-sort-keys: 3.3.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2)
       typescript: 5.9.2
 
-  '@solana/fast-stable-stringify@3.0.2(typescript@5.9.2)':
+  '@solana/fast-stable-stringify@5.0.0(typescript@5.9.2)':
     dependencies:
       typescript: 5.9.2
 
-  '@solana/functional@3.0.2(typescript@5.9.2)':
+  '@solana/functional@5.0.0(typescript@5.9.2)':
     dependencies:
       typescript: 5.9.2
 
-  '@solana/instruction-plans@3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+  '@solana/instruction-plans@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
     dependencies:
-      '@solana/errors': 3.0.2(typescript@5.9.2)
-      '@solana/instructions': 3.0.2(typescript@5.9.2)
-      '@solana/promises': 3.0.2(typescript@5.9.2)
-      '@solana/transaction-messages': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/transactions': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/instructions@3.0.2(typescript@5.9.2)':
-    dependencies:
-      '@solana/codecs-core': 3.0.2(typescript@5.9.2)
-      '@solana/errors': 3.0.2(typescript@5.9.2)
-      typescript: 5.9.2
-
-  '@solana/keys@3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
-    dependencies:
-      '@solana/assertions': 3.0.2(typescript@5.9.2)
-      '@solana/codecs-core': 3.0.2(typescript@5.9.2)
-      '@solana/codecs-strings': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/errors': 3.0.2(typescript@5.9.2)
-      '@solana/nominal-types': 3.0.2(typescript@5.9.2)
+      '@solana/errors': 5.0.0(typescript@5.9.2)
+      '@solana/instructions': 5.0.0(typescript@5.9.2)
+      '@solana/promises': 5.0.0(typescript@5.9.2)
+      '@solana/transaction-messages': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/transactions': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
       typescript: 5.9.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/kit@3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.18.0)':
+  '@solana/instructions@5.0.0(typescript@5.9.2)':
     dependencies:
-      '@solana/accounts': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/addresses': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/codecs': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/errors': 3.0.2(typescript@5.9.2)
-      '@solana/functional': 3.0.2(typescript@5.9.2)
-      '@solana/instruction-plans': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/instructions': 3.0.2(typescript@5.9.2)
-      '@solana/keys': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/programs': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/rpc': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/rpc-parsed-types': 3.0.2(typescript@5.9.2)
-      '@solana/rpc-spec-types': 3.0.2(typescript@5.9.2)
-      '@solana/rpc-subscriptions': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.18.0)
-      '@solana/rpc-types': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/signers': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/sysvars': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/transaction-confirmation': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.18.0)
-      '@solana/transaction-messages': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/transactions': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/codecs-core': 5.0.0(typescript@5.9.2)
+      '@solana/errors': 5.0.0(typescript@5.9.2)
+      typescript: 5.9.2
+
+  '@solana/keys@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+    dependencies:
+      '@solana/assertions': 5.0.0(typescript@5.9.2)
+      '@solana/codecs-core': 5.0.0(typescript@5.9.2)
+      '@solana/codecs-strings': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/errors': 5.0.0(typescript@5.9.2)
+      '@solana/nominal-types': 5.0.0(typescript@5.9.2)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.18.0)':
+    dependencies:
+      '@solana/accounts': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/addresses': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/codecs': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/errors': 5.0.0(typescript@5.9.2)
+      '@solana/functional': 5.0.0(typescript@5.9.2)
+      '@solana/instruction-plans': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/instructions': 5.0.0(typescript@5.9.2)
+      '@solana/keys': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/programs': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/rpc': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/rpc-parsed-types': 5.0.0(typescript@5.9.2)
+      '@solana/rpc-spec-types': 5.0.0(typescript@5.9.2)
+      '@solana/rpc-subscriptions': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.18.0)
+      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/signers': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/sysvars': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/transaction-confirmation': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.18.0)
+      '@solana/transaction-messages': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/transactions': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
       typescript: 5.9.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - ws
 
-  '@solana/nominal-types@3.0.2(typescript@5.9.2)':
+  '@solana/nominal-types@5.0.0(typescript@5.9.2)':
     dependencies:
       typescript: 5.9.2
 
-  '@solana/options@3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+  '@solana/options@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
     dependencies:
-      '@solana/codecs-core': 3.0.2(typescript@5.9.2)
-      '@solana/codecs-data-structures': 3.0.2(typescript@5.9.2)
-      '@solana/codecs-numbers': 3.0.2(typescript@5.9.2)
-      '@solana/codecs-strings': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/errors': 3.0.2(typescript@5.9.2)
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/programs@3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
-    dependencies:
-      '@solana/addresses': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/errors': 3.0.2(typescript@5.9.2)
+      '@solana/codecs-core': 5.0.0(typescript@5.9.2)
+      '@solana/codecs-data-structures': 5.0.0(typescript@5.9.2)
+      '@solana/codecs-numbers': 5.0.0(typescript@5.9.2)
+      '@solana/codecs-strings': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/errors': 5.0.0(typescript@5.9.2)
       typescript: 5.9.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/promises@3.0.2(typescript@5.9.2)':
+  '@solana/programs@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
     dependencies:
-      typescript: 5.9.2
-
-  '@solana/rpc-api@3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
-    dependencies:
-      '@solana/addresses': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/codecs-core': 3.0.2(typescript@5.9.2)
-      '@solana/codecs-strings': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/errors': 3.0.2(typescript@5.9.2)
-      '@solana/keys': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/rpc-parsed-types': 3.0.2(typescript@5.9.2)
-      '@solana/rpc-spec': 3.0.2(typescript@5.9.2)
-      '@solana/rpc-transformers': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/rpc-types': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/transaction-messages': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/transactions': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/addresses': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/errors': 5.0.0(typescript@5.9.2)
       typescript: 5.9.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-parsed-types@3.0.2(typescript@5.9.2)':
+  '@solana/promises@5.0.0(typescript@5.9.2)':
     dependencies:
       typescript: 5.9.2
 
-  '@solana/rpc-spec-types@3.0.2(typescript@5.9.2)':
+  '@solana/rpc-api@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
     dependencies:
-      typescript: 5.9.2
-
-  '@solana/rpc-spec@3.0.2(typescript@5.9.2)':
-    dependencies:
-      '@solana/errors': 3.0.2(typescript@5.9.2)
-      '@solana/rpc-spec-types': 3.0.2(typescript@5.9.2)
-      typescript: 5.9.2
-
-  '@solana/rpc-subscriptions-api@3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
-    dependencies:
-      '@solana/addresses': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/keys': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/rpc-subscriptions-spec': 3.0.2(typescript@5.9.2)
-      '@solana/rpc-transformers': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/rpc-types': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/transaction-messages': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/transactions': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/addresses': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/codecs-core': 5.0.0(typescript@5.9.2)
+      '@solana/codecs-strings': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/errors': 5.0.0(typescript@5.9.2)
+      '@solana/keys': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/rpc-parsed-types': 5.0.0(typescript@5.9.2)
+      '@solana/rpc-spec': 5.0.0(typescript@5.9.2)
+      '@solana/rpc-transformers': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/transaction-messages': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/transactions': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
       typescript: 5.9.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-subscriptions-channel-websocket@3.0.2(typescript@5.9.2)(ws@8.18.0)':
+  '@solana/rpc-parsed-types@5.0.0(typescript@5.9.2)':
     dependencies:
-      '@solana/errors': 3.0.2(typescript@5.9.2)
-      '@solana/functional': 3.0.2(typescript@5.9.2)
-      '@solana/rpc-subscriptions-spec': 3.0.2(typescript@5.9.2)
-      '@solana/subscribable': 3.0.2(typescript@5.9.2)
+      typescript: 5.9.2
+
+  '@solana/rpc-spec-types@5.0.0(typescript@5.9.2)':
+    dependencies:
+      typescript: 5.9.2
+
+  '@solana/rpc-spec@5.0.0(typescript@5.9.2)':
+    dependencies:
+      '@solana/errors': 5.0.0(typescript@5.9.2)
+      '@solana/rpc-spec-types': 5.0.0(typescript@5.9.2)
+      typescript: 5.9.2
+
+  '@solana/rpc-subscriptions-api@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+    dependencies:
+      '@solana/addresses': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/keys': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/rpc-subscriptions-spec': 5.0.0(typescript@5.9.2)
+      '@solana/rpc-transformers': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/transaction-messages': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/transactions': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-subscriptions-channel-websocket@5.0.0(typescript@5.9.2)(ws@8.18.0)':
+    dependencies:
+      '@solana/errors': 5.0.0(typescript@5.9.2)
+      '@solana/functional': 5.0.0(typescript@5.9.2)
+      '@solana/rpc-subscriptions-spec': 5.0.0(typescript@5.9.2)
+      '@solana/subscribable': 5.0.0(typescript@5.9.2)
       typescript: 5.9.2
       ws: 8.18.0
 
-  '@solana/rpc-subscriptions-spec@3.0.2(typescript@5.9.2)':
+  '@solana/rpc-subscriptions-spec@5.0.0(typescript@5.9.2)':
     dependencies:
-      '@solana/errors': 3.0.2(typescript@5.9.2)
-      '@solana/promises': 3.0.2(typescript@5.9.2)
-      '@solana/rpc-spec-types': 3.0.2(typescript@5.9.2)
-      '@solana/subscribable': 3.0.2(typescript@5.9.2)
+      '@solana/errors': 5.0.0(typescript@5.9.2)
+      '@solana/promises': 5.0.0(typescript@5.9.2)
+      '@solana/rpc-spec-types': 5.0.0(typescript@5.9.2)
+      '@solana/subscribable': 5.0.0(typescript@5.9.2)
       typescript: 5.9.2
 
-  '@solana/rpc-subscriptions@3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.18.0)':
+  '@solana/rpc-subscriptions@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.18.0)':
     dependencies:
-      '@solana/errors': 3.0.2(typescript@5.9.2)
-      '@solana/fast-stable-stringify': 3.0.2(typescript@5.9.2)
-      '@solana/functional': 3.0.2(typescript@5.9.2)
-      '@solana/promises': 3.0.2(typescript@5.9.2)
-      '@solana/rpc-spec-types': 3.0.2(typescript@5.9.2)
-      '@solana/rpc-subscriptions-api': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/rpc-subscriptions-channel-websocket': 3.0.2(typescript@5.9.2)(ws@8.18.0)
-      '@solana/rpc-subscriptions-spec': 3.0.2(typescript@5.9.2)
-      '@solana/rpc-transformers': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/rpc-types': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/subscribable': 3.0.2(typescript@5.9.2)
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-      - ws
-
-  '@solana/rpc-transformers@3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
-    dependencies:
-      '@solana/errors': 3.0.2(typescript@5.9.2)
-      '@solana/functional': 3.0.2(typescript@5.9.2)
-      '@solana/nominal-types': 3.0.2(typescript@5.9.2)
-      '@solana/rpc-spec-types': 3.0.2(typescript@5.9.2)
-      '@solana/rpc-types': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/rpc-transport-http@3.0.2(typescript@5.9.2)':
-    dependencies:
-      '@solana/errors': 3.0.2(typescript@5.9.2)
-      '@solana/rpc-spec': 3.0.2(typescript@5.9.2)
-      '@solana/rpc-spec-types': 3.0.2(typescript@5.9.2)
-      typescript: 5.9.2
-      undici-types: 7.15.0
-
-  '@solana/rpc-types@3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
-    dependencies:
-      '@solana/addresses': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/codecs-core': 3.0.2(typescript@5.9.2)
-      '@solana/codecs-numbers': 3.0.2(typescript@5.9.2)
-      '@solana/codecs-strings': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/errors': 3.0.2(typescript@5.9.2)
-      '@solana/nominal-types': 3.0.2(typescript@5.9.2)
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/rpc@3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
-    dependencies:
-      '@solana/errors': 3.0.2(typescript@5.9.2)
-      '@solana/fast-stable-stringify': 3.0.2(typescript@5.9.2)
-      '@solana/functional': 3.0.2(typescript@5.9.2)
-      '@solana/rpc-api': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/rpc-spec': 3.0.2(typescript@5.9.2)
-      '@solana/rpc-spec-types': 3.0.2(typescript@5.9.2)
-      '@solana/rpc-transformers': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/rpc-transport-http': 3.0.2(typescript@5.9.2)
-      '@solana/rpc-types': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/signers@3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
-    dependencies:
-      '@solana/addresses': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/codecs-core': 3.0.2(typescript@5.9.2)
-      '@solana/errors': 3.0.2(typescript@5.9.2)
-      '@solana/instructions': 3.0.2(typescript@5.9.2)
-      '@solana/keys': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/nominal-types': 3.0.2(typescript@5.9.2)
-      '@solana/transaction-messages': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/transactions': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/subscribable@3.0.2(typescript@5.9.2)':
-    dependencies:
-      '@solana/errors': 3.0.2(typescript@5.9.2)
-      typescript: 5.9.2
-
-  '@solana/sysvars@3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
-    dependencies:
-      '@solana/accounts': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/codecs': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/errors': 3.0.2(typescript@5.9.2)
-      '@solana/rpc-types': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/transaction-confirmation@3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.18.0)':
-    dependencies:
-      '@solana/addresses': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/codecs-strings': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/errors': 3.0.2(typescript@5.9.2)
-      '@solana/keys': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/promises': 3.0.2(typescript@5.9.2)
-      '@solana/rpc': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/rpc-subscriptions': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.18.0)
-      '@solana/rpc-types': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/transaction-messages': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/transactions': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/errors': 5.0.0(typescript@5.9.2)
+      '@solana/fast-stable-stringify': 5.0.0(typescript@5.9.2)
+      '@solana/functional': 5.0.0(typescript@5.9.2)
+      '@solana/promises': 5.0.0(typescript@5.9.2)
+      '@solana/rpc-spec-types': 5.0.0(typescript@5.9.2)
+      '@solana/rpc-subscriptions-api': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/rpc-subscriptions-channel-websocket': 5.0.0(typescript@5.9.2)(ws@8.18.0)
+      '@solana/rpc-subscriptions-spec': 5.0.0(typescript@5.9.2)
+      '@solana/rpc-transformers': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/subscribable': 5.0.0(typescript@5.9.2)
       typescript: 5.9.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - ws
 
-  '@solana/transaction-messages@3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+  '@solana/rpc-transformers@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
     dependencies:
-      '@solana/addresses': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/codecs-core': 3.0.2(typescript@5.9.2)
-      '@solana/codecs-data-structures': 3.0.2(typescript@5.9.2)
-      '@solana/codecs-numbers': 3.0.2(typescript@5.9.2)
-      '@solana/errors': 3.0.2(typescript@5.9.2)
-      '@solana/functional': 3.0.2(typescript@5.9.2)
-      '@solana/instructions': 3.0.2(typescript@5.9.2)
-      '@solana/nominal-types': 3.0.2(typescript@5.9.2)
-      '@solana/rpc-types': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/errors': 5.0.0(typescript@5.9.2)
+      '@solana/functional': 5.0.0(typescript@5.9.2)
+      '@solana/nominal-types': 5.0.0(typescript@5.9.2)
+      '@solana/rpc-spec-types': 5.0.0(typescript@5.9.2)
+      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
       typescript: 5.9.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transactions@3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+  '@solana/rpc-transport-http@5.0.0(typescript@5.9.2)':
     dependencies:
-      '@solana/addresses': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/codecs-core': 3.0.2(typescript@5.9.2)
-      '@solana/codecs-data-structures': 3.0.2(typescript@5.9.2)
-      '@solana/codecs-numbers': 3.0.2(typescript@5.9.2)
-      '@solana/codecs-strings': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/errors': 3.0.2(typescript@5.9.2)
-      '@solana/functional': 3.0.2(typescript@5.9.2)
-      '@solana/instructions': 3.0.2(typescript@5.9.2)
-      '@solana/keys': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/nominal-types': 3.0.2(typescript@5.9.2)
-      '@solana/rpc-types': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/transaction-messages': 3.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/errors': 5.0.0(typescript@5.9.2)
+      '@solana/rpc-spec': 5.0.0(typescript@5.9.2)
+      '@solana/rpc-spec-types': 5.0.0(typescript@5.9.2)
+      typescript: 5.9.2
+      undici-types: 7.16.0
+
+  '@solana/rpc-types@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+    dependencies:
+      '@solana/addresses': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/codecs-core': 5.0.0(typescript@5.9.2)
+      '@solana/codecs-numbers': 5.0.0(typescript@5.9.2)
+      '@solana/codecs-strings': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/errors': 5.0.0(typescript@5.9.2)
+      '@solana/nominal-types': 5.0.0(typescript@5.9.2)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+    dependencies:
+      '@solana/errors': 5.0.0(typescript@5.9.2)
+      '@solana/fast-stable-stringify': 5.0.0(typescript@5.9.2)
+      '@solana/functional': 5.0.0(typescript@5.9.2)
+      '@solana/rpc-api': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/rpc-spec': 5.0.0(typescript@5.9.2)
+      '@solana/rpc-spec-types': 5.0.0(typescript@5.9.2)
+      '@solana/rpc-transformers': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/rpc-transport-http': 5.0.0(typescript@5.9.2)
+      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/signers@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+    dependencies:
+      '@solana/addresses': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/codecs-core': 5.0.0(typescript@5.9.2)
+      '@solana/errors': 5.0.0(typescript@5.9.2)
+      '@solana/instructions': 5.0.0(typescript@5.9.2)
+      '@solana/keys': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/nominal-types': 5.0.0(typescript@5.9.2)
+      '@solana/transaction-messages': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/transactions': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/subscribable@5.0.0(typescript@5.9.2)':
+    dependencies:
+      '@solana/errors': 5.0.0(typescript@5.9.2)
+      typescript: 5.9.2
+
+  '@solana/sysvars@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+    dependencies:
+      '@solana/accounts': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/codecs': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/errors': 5.0.0(typescript@5.9.2)
+      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transaction-confirmation@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.18.0)':
+    dependencies:
+      '@solana/addresses': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/codecs-strings': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/errors': 5.0.0(typescript@5.9.2)
+      '@solana/keys': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/promises': 5.0.0(typescript@5.9.2)
+      '@solana/rpc': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/rpc-subscriptions': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.18.0)
+      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/transaction-messages': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/transactions': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - ws
+
+  '@solana/transaction-messages@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+    dependencies:
+      '@solana/addresses': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/codecs-core': 5.0.0(typescript@5.9.2)
+      '@solana/codecs-data-structures': 5.0.0(typescript@5.9.2)
+      '@solana/codecs-numbers': 5.0.0(typescript@5.9.2)
+      '@solana/errors': 5.0.0(typescript@5.9.2)
+      '@solana/functional': 5.0.0(typescript@5.9.2)
+      '@solana/instructions': 5.0.0(typescript@5.9.2)
+      '@solana/nominal-types': 5.0.0(typescript@5.9.2)
+      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transactions@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+    dependencies:
+      '@solana/addresses': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/codecs-core': 5.0.0(typescript@5.9.2)
+      '@solana/codecs-data-structures': 5.0.0(typescript@5.9.2)
+      '@solana/codecs-numbers': 5.0.0(typescript@5.9.2)
+      '@solana/codecs-strings': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/errors': 5.0.0(typescript@5.9.2)
+      '@solana/functional': 5.0.0(typescript@5.9.2)
+      '@solana/instructions': 5.0.0(typescript@5.9.2)
+      '@solana/keys': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/nominal-types': 5.0.0(typescript@5.9.2)
+      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/transaction-messages': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
       typescript: 5.9.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -3057,7 +3073,7 @@ snapshots:
 
   chalk@5.4.1: {}
 
-  chalk@5.6.0: {}
+  chalk@5.6.2: {}
 
   chokidar@4.0.3:
     dependencies:
@@ -3092,7 +3108,7 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  commander@14.0.0: {}
+  commander@14.0.1: {}
 
   commander@4.1.1: {}
 
@@ -4054,7 +4070,7 @@ snapshots:
 
   ufo@1.6.1: {}
 
-  undici-types@7.15.0: {}
+  undici-types@7.16.0: {}
 
   unicorn-magic@0.3.0: {}
 

--- a/test/e2e/system/.prettierrc.json
+++ b/test/e2e/system/.prettierrc.json
@@ -1,9 +1,0 @@
-{
-  "semi": true,
-  "singleQuote": true,
-  "trailingComma": "es5",
-  "useTabs": false,
-  "tabWidth": 2,
-  "arrowParens": "always",
-  "printWidth": 80
-}

--- a/test/e2e/system/package.json
+++ b/test/e2e/system/package.json
@@ -10,6 +10,9 @@
     "lint": "eslint --ext js,ts,tsx src && prettier --check src test",
     "lint:fix": "eslint --fix --ext js,ts,tsx src && prettier --write src test"
   },
+  "dependencies": {
+    "@solana/kit": "^5.0.0"
+  },
   "license": "MIT",
   "ava": {
     "typescript": {
@@ -18,6 +21,5 @@
         "test/": "dist/test/"
       }
     }
-  },
-  "packageManager": "pnpm@9.1.0"
+  }
 }

--- a/test/e2e/system/src/generated/accounts/nonce.ts
+++ b/test/e2e/system/src/generated/accounts/nonce.ts
@@ -7,139 +7,136 @@
  */
 
 import {
-  assertAccountExists,
-  assertAccountsExist,
-  combineCodec,
-  decodeAccount,
-  fetchEncodedAccount,
-  fetchEncodedAccounts,
-  getAddressDecoder,
-  getAddressEncoder,
-  getLamportsDecoder,
-  getLamportsEncoder,
-  getStructDecoder,
-  getStructEncoder,
-  getU64Decoder,
-  getU64Encoder,
-  type Account,
-  type Address,
-  type EncodedAccount,
-  type FetchAccountConfig,
-  type FetchAccountsConfig,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Lamports,
-  type MaybeAccount,
-  type MaybeEncodedAccount,
+    assertAccountExists,
+    assertAccountsExist,
+    combineCodec,
+    decodeAccount,
+    fetchEncodedAccount,
+    fetchEncodedAccounts,
+    getAddressDecoder,
+    getAddressEncoder,
+    getLamportsDecoder,
+    getLamportsEncoder,
+    getStructDecoder,
+    getStructEncoder,
+    getU64Decoder,
+    getU64Encoder,
+    type Account,
+    type Address,
+    type EncodedAccount,
+    type FetchAccountConfig,
+    type FetchAccountsConfig,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Lamports,
+    type MaybeAccount,
+    type MaybeEncodedAccount,
 } from '@solana/kit';
 import {
-  getNonceStateDecoder,
-  getNonceStateEncoder,
-  getNonceVersionDecoder,
-  getNonceVersionEncoder,
-  type NonceState,
-  type NonceStateArgs,
-  type NonceVersion,
-  type NonceVersionArgs,
+    getNonceStateDecoder,
+    getNonceStateEncoder,
+    getNonceVersionDecoder,
+    getNonceVersionEncoder,
+    type NonceState,
+    type NonceStateArgs,
+    type NonceVersion,
+    type NonceVersionArgs,
 } from '../types';
 
 export type Nonce = {
-  version: NonceVersion;
-  state: NonceState;
-  authority: Address;
-  blockhash: Address;
-  lamportsPerSignature: Lamports;
+    version: NonceVersion;
+    state: NonceState;
+    authority: Address;
+    blockhash: Address;
+    lamportsPerSignature: Lamports;
 };
 
 export type NonceArgs = {
-  version: NonceVersionArgs;
-  state: NonceStateArgs;
-  authority: Address;
-  blockhash: Address;
-  lamportsPerSignature: Lamports;
+    version: NonceVersionArgs;
+    state: NonceStateArgs;
+    authority: Address;
+    blockhash: Address;
+    lamportsPerSignature: Lamports;
 };
 
 /** Gets the encoder for {@link NonceArgs} account data. */
 export function getNonceEncoder(): FixedSizeEncoder<NonceArgs> {
-  return getStructEncoder([
-    ['version', getNonceVersionEncoder()],
-    ['state', getNonceStateEncoder()],
-    ['authority', getAddressEncoder()],
-    ['blockhash', getAddressEncoder()],
-    ['lamportsPerSignature', getLamportsEncoder(getU64Encoder())],
-  ]);
+    return getStructEncoder([
+        ['version', getNonceVersionEncoder()],
+        ['state', getNonceStateEncoder()],
+        ['authority', getAddressEncoder()],
+        ['blockhash', getAddressEncoder()],
+        ['lamportsPerSignature', getLamportsEncoder(getU64Encoder())],
+    ]);
 }
 
 /** Gets the decoder for {@link Nonce} account data. */
 export function getNonceDecoder(): FixedSizeDecoder<Nonce> {
-  return getStructDecoder([
-    ['version', getNonceVersionDecoder()],
-    ['state', getNonceStateDecoder()],
-    ['authority', getAddressDecoder()],
-    ['blockhash', getAddressDecoder()],
-    ['lamportsPerSignature', getLamportsDecoder(getU64Decoder())],
-  ]);
+    return getStructDecoder([
+        ['version', getNonceVersionDecoder()],
+        ['state', getNonceStateDecoder()],
+        ['authority', getAddressDecoder()],
+        ['blockhash', getAddressDecoder()],
+        ['lamportsPerSignature', getLamportsDecoder(getU64Decoder())],
+    ]);
 }
 
 /** Gets the codec for {@link Nonce} account data. */
 export function getNonceCodec(): FixedSizeCodec<NonceArgs, Nonce> {
-  return combineCodec(getNonceEncoder(), getNonceDecoder());
+    return combineCodec(getNonceEncoder(), getNonceDecoder());
 }
 
 export function decodeNonce<TAddress extends string = string>(
-  encodedAccount: EncodedAccount<TAddress>
+    encodedAccount: EncodedAccount<TAddress>
 ): Account<Nonce, TAddress>;
 export function decodeNonce<TAddress extends string = string>(
-  encodedAccount: MaybeEncodedAccount<TAddress>
+    encodedAccount: MaybeEncodedAccount<TAddress>
 ): MaybeAccount<Nonce, TAddress>;
 export function decodeNonce<TAddress extends string = string>(
-  encodedAccount: EncodedAccount<TAddress> | MaybeEncodedAccount<TAddress>
+    encodedAccount: EncodedAccount<TAddress> | MaybeEncodedAccount<TAddress>
 ): Account<Nonce, TAddress> | MaybeAccount<Nonce, TAddress> {
-  return decodeAccount(
-    encodedAccount as MaybeEncodedAccount<TAddress>,
-    getNonceDecoder()
-  );
+    return decodeAccount(encodedAccount as MaybeEncodedAccount<TAddress>, getNonceDecoder());
 }
 
 export async function fetchNonce<TAddress extends string = string>(
-  rpc: Parameters<typeof fetchEncodedAccount>[0],
-  address: Address<TAddress>,
-  config?: FetchAccountConfig
+    rpc: Parameters<typeof fetchEncodedAccount>[0],
+    address: Address<TAddress>,
+    config?: FetchAccountConfig
 ): Promise<Account<Nonce, TAddress>> {
-  const maybeAccount = await fetchMaybeNonce(rpc, address, config);
-  assertAccountExists(maybeAccount);
-  return maybeAccount;
+    const maybeAccount = await fetchMaybeNonce(rpc, address, config);
+    assertAccountExists(maybeAccount);
+    return maybeAccount;
 }
 
 export async function fetchMaybeNonce<TAddress extends string = string>(
-  rpc: Parameters<typeof fetchEncodedAccount>[0],
-  address: Address<TAddress>,
-  config?: FetchAccountConfig
+    rpc: Parameters<typeof fetchEncodedAccount>[0],
+    address: Address<TAddress>,
+    config?: FetchAccountConfig
 ): Promise<MaybeAccount<Nonce, TAddress>> {
-  const maybeAccount = await fetchEncodedAccount(rpc, address, config);
-  return decodeNonce(maybeAccount);
+    const maybeAccount = await fetchEncodedAccount(rpc, address, config);
+    return decodeNonce(maybeAccount);
 }
 
 export async function fetchAllNonce(
-  rpc: Parameters<typeof fetchEncodedAccounts>[0],
-  addresses: Array<Address>,
-  config?: FetchAccountsConfig
+    rpc: Parameters<typeof fetchEncodedAccounts>[0],
+    addresses: Array<Address>,
+    config?: FetchAccountsConfig
 ): Promise<Account<Nonce>[]> {
-  const maybeAccounts = await fetchAllMaybeNonce(rpc, addresses, config);
-  assertAccountsExist(maybeAccounts);
-  return maybeAccounts;
+    const maybeAccounts = await fetchAllMaybeNonce(rpc, addresses, config);
+    assertAccountsExist(maybeAccounts);
+    return maybeAccounts;
 }
 
 export async function fetchAllMaybeNonce(
-  rpc: Parameters<typeof fetchEncodedAccounts>[0],
-  addresses: Array<Address>,
-  config?: FetchAccountsConfig
+    rpc: Parameters<typeof fetchEncodedAccounts>[0],
+    addresses: Array<Address>,
+    config?: FetchAccountsConfig
 ): Promise<MaybeAccount<Nonce>[]> {
-  const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
-  return maybeAccounts.map((maybeAccount) => decodeNonce(maybeAccount));
+    const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
+    return maybeAccounts.map(maybeAccount => decodeNonce(maybeAccount));
 }
 
 export function getNonceSize(): number {
-  return 80;
+    return 80;
 }

--- a/test/e2e/system/src/generated/errors/system.ts
+++ b/test/e2e/system/src/generated/errors/system.ts
@@ -7,10 +7,10 @@
  */
 
 import {
-  isProgramError,
-  type Address,
-  type SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM,
-  type SolanaError,
+    isProgramError,
+    type Address,
+    type SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM,
+    type SolanaError,
 } from '@solana/kit';
 import { SYSTEM_PROGRAM_ADDRESS } from '../programs';
 
@@ -34,51 +34,44 @@ export const SYSTEM_ERROR__NONCE_BLOCKHASH_NOT_EXPIRED = 0x7; // 7
 export const SYSTEM_ERROR__NONCE_UNEXPECTED_BLOCKHASH_VALUE = 0x8; // 8
 
 export type SystemError =
-  | typeof SYSTEM_ERROR__ACCOUNT_ALREADY_IN_USE
-  | typeof SYSTEM_ERROR__ADDRESS_WITH_SEED_MISMATCH
-  | typeof SYSTEM_ERROR__INVALID_ACCOUNT_DATA_LENGTH
-  | typeof SYSTEM_ERROR__INVALID_PROGRAM_ID
-  | typeof SYSTEM_ERROR__MAX_SEED_LENGTH_EXCEEDED
-  | typeof SYSTEM_ERROR__NONCE_BLOCKHASH_NOT_EXPIRED
-  | typeof SYSTEM_ERROR__NONCE_NO_RECENT_BLOCKHASHES
-  | typeof SYSTEM_ERROR__NONCE_UNEXPECTED_BLOCKHASH_VALUE
-  | typeof SYSTEM_ERROR__RESULT_WITH_NEGATIVE_LAMPORTS;
+    | typeof SYSTEM_ERROR__ACCOUNT_ALREADY_IN_USE
+    | typeof SYSTEM_ERROR__ADDRESS_WITH_SEED_MISMATCH
+    | typeof SYSTEM_ERROR__INVALID_ACCOUNT_DATA_LENGTH
+    | typeof SYSTEM_ERROR__INVALID_PROGRAM_ID
+    | typeof SYSTEM_ERROR__MAX_SEED_LENGTH_EXCEEDED
+    | typeof SYSTEM_ERROR__NONCE_BLOCKHASH_NOT_EXPIRED
+    | typeof SYSTEM_ERROR__NONCE_NO_RECENT_BLOCKHASHES
+    | typeof SYSTEM_ERROR__NONCE_UNEXPECTED_BLOCKHASH_VALUE
+    | typeof SYSTEM_ERROR__RESULT_WITH_NEGATIVE_LAMPORTS;
 
 let systemErrorMessages: Record<SystemError, string> | undefined;
 if (process.env.NODE_ENV !== 'production') {
-  systemErrorMessages = {
-    [SYSTEM_ERROR__ACCOUNT_ALREADY_IN_USE]: `an account with the same address already exists`,
-    [SYSTEM_ERROR__ADDRESS_WITH_SEED_MISMATCH]: `provided address does not match addressed derived from seed`,
-    [SYSTEM_ERROR__INVALID_ACCOUNT_DATA_LENGTH]: `cannot allocate account data of this length`,
-    [SYSTEM_ERROR__INVALID_PROGRAM_ID]: `cannot assign account to this program id`,
-    [SYSTEM_ERROR__MAX_SEED_LENGTH_EXCEEDED]: `length of requested seed is too long`,
-    [SYSTEM_ERROR__NONCE_BLOCKHASH_NOT_EXPIRED]: `stored nonce is still in recent_blockhashes`,
-    [SYSTEM_ERROR__NONCE_NO_RECENT_BLOCKHASHES]: `advancing stored nonce requires a populated RecentBlockhashes sysvar`,
-    [SYSTEM_ERROR__NONCE_UNEXPECTED_BLOCKHASH_VALUE]: `specified nonce does not match stored nonce`,
-    [SYSTEM_ERROR__RESULT_WITH_NEGATIVE_LAMPORTS]: `account does not have enough SOL to perform the operation`,
-  };
+    systemErrorMessages = {
+        [SYSTEM_ERROR__ACCOUNT_ALREADY_IN_USE]: `an account with the same address already exists`,
+        [SYSTEM_ERROR__ADDRESS_WITH_SEED_MISMATCH]: `provided address does not match addressed derived from seed`,
+        [SYSTEM_ERROR__INVALID_ACCOUNT_DATA_LENGTH]: `cannot allocate account data of this length`,
+        [SYSTEM_ERROR__INVALID_PROGRAM_ID]: `cannot assign account to this program id`,
+        [SYSTEM_ERROR__MAX_SEED_LENGTH_EXCEEDED]: `length of requested seed is too long`,
+        [SYSTEM_ERROR__NONCE_BLOCKHASH_NOT_EXPIRED]: `stored nonce is still in recent_blockhashes`,
+        [SYSTEM_ERROR__NONCE_NO_RECENT_BLOCKHASHES]: `advancing stored nonce requires a populated RecentBlockhashes sysvar`,
+        [SYSTEM_ERROR__NONCE_UNEXPECTED_BLOCKHASH_VALUE]: `specified nonce does not match stored nonce`,
+        [SYSTEM_ERROR__RESULT_WITH_NEGATIVE_LAMPORTS]: `account does not have enough SOL to perform the operation`,
+    };
 }
 
 export function getSystemErrorMessage(code: SystemError): string {
-  if (process.env.NODE_ENV !== 'production') {
-    return (systemErrorMessages as Record<SystemError, string>)[code];
-  }
+    if (process.env.NODE_ENV !== 'production') {
+        return (systemErrorMessages as Record<SystemError, string>)[code];
+    }
 
-  return 'Error message not available in production bundles.';
+    return 'Error message not available in production bundles.';
 }
 
 export function isSystemError<TProgramErrorCode extends SystemError>(
-  error: unknown,
-  transactionMessage: {
-    instructions: Record<number, { programAddress: Address }>;
-  },
-  code?: TProgramErrorCode
+    error: unknown,
+    transactionMessage: { instructions: Record<number, { programAddress: Address }> },
+    code?: TProgramErrorCode
 ): error is SolanaError<typeof SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM> &
-  Readonly<{ context: Readonly<{ code: TProgramErrorCode }> }> {
-  return isProgramError<TProgramErrorCode>(
-    error,
-    transactionMessage,
-    SYSTEM_PROGRAM_ADDRESS,
-    code
-  );
+    Readonly<{ context: Readonly<{ code: TProgramErrorCode }> }> {
+    return isProgramError<TProgramErrorCode>(error, transactionMessage, SYSTEM_PROGRAM_ADDRESS, code);
 }

--- a/test/e2e/system/src/generated/instructions/advanceNonceAccount.ts
+++ b/test/e2e/system/src/generated/instructions/advanceNonceAccount.ts
@@ -7,26 +7,26 @@
  */
 
 import {
-  combineCodec,
-  getStructDecoder,
-  getStructEncoder,
-  getU32Decoder,
-  getU32Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyAccount,
-  type ReadonlySignerAccount,
-  type ReadonlyUint8Array,
-  type TransactionSigner,
-  type WritableAccount,
+    combineCodec,
+    getStructDecoder,
+    getStructEncoder,
+    getU32Decoder,
+    getU32Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyAccount,
+    type ReadonlySignerAccount,
+    type ReadonlyUint8Array,
+    type TransactionSigner,
+    type WritableAccount,
 } from '@solana/kit';
 import { SYSTEM_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -34,170 +34,149 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const ADVANCE_NONCE_ACCOUNT_DISCRIMINATOR = 4;
 
 export function getAdvanceNonceAccountDiscriminatorBytes() {
-  return getU32Encoder().encode(ADVANCE_NONCE_ACCOUNT_DISCRIMINATOR);
+    return getU32Encoder().encode(ADVANCE_NONCE_ACCOUNT_DISCRIMINATOR);
 }
 
 export type AdvanceNonceAccountInstruction<
-  TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountNonceAccount extends string | AccountMeta<string> = string,
-  TAccountRecentBlockhashesSysvar extends string | AccountMeta<string> =
-    'SysvarRecentB1ockHashes11111111111111111111',
-  TAccountNonceAuthority extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountNonceAccount extends string | AccountMeta<string> = string,
+    TAccountRecentBlockhashesSysvar extends string | AccountMeta<string> =
+        'SysvarRecentB1ockHashes11111111111111111111',
+    TAccountNonceAuthority extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountNonceAccount extends string
-        ? WritableAccount<TAccountNonceAccount>
-        : TAccountNonceAccount,
-      TAccountRecentBlockhashesSysvar extends string
-        ? ReadonlyAccount<TAccountRecentBlockhashesSysvar>
-        : TAccountRecentBlockhashesSysvar,
-      TAccountNonceAuthority extends string
-        ? ReadonlySignerAccount<TAccountNonceAuthority> &
-            AccountSignerMeta<TAccountNonceAuthority>
-        : TAccountNonceAuthority,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountNonceAccount extends string ? WritableAccount<TAccountNonceAccount> : TAccountNonceAccount,
+            TAccountRecentBlockhashesSysvar extends string
+                ? ReadonlyAccount<TAccountRecentBlockhashesSysvar>
+                : TAccountRecentBlockhashesSysvar,
+            TAccountNonceAuthority extends string
+                ? ReadonlySignerAccount<TAccountNonceAuthority> & AccountSignerMeta<TAccountNonceAuthority>
+                : TAccountNonceAuthority,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type AdvanceNonceAccountInstructionData = { discriminator: number };
 
 export type AdvanceNonceAccountInstructionDataArgs = {};
 
 export function getAdvanceNonceAccountInstructionDataEncoder(): FixedSizeEncoder<AdvanceNonceAccountInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([['discriminator', getU32Encoder()]]),
-    (value) => ({
-      ...value,
-      discriminator: ADVANCE_NONCE_ACCOUNT_DISCRIMINATOR,
-    })
-  );
+    return transformEncoder(getStructEncoder([['discriminator', getU32Encoder()]]), value => ({
+        ...value,
+        discriminator: ADVANCE_NONCE_ACCOUNT_DISCRIMINATOR,
+    }));
 }
 
 export function getAdvanceNonceAccountInstructionDataDecoder(): FixedSizeDecoder<AdvanceNonceAccountInstructionData> {
-  return getStructDecoder([['discriminator', getU32Decoder()]]);
+    return getStructDecoder([['discriminator', getU32Decoder()]]);
 }
 
 export function getAdvanceNonceAccountInstructionDataCodec(): FixedSizeCodec<
-  AdvanceNonceAccountInstructionDataArgs,
-  AdvanceNonceAccountInstructionData
+    AdvanceNonceAccountInstructionDataArgs,
+    AdvanceNonceAccountInstructionData
 > {
-  return combineCodec(
-    getAdvanceNonceAccountInstructionDataEncoder(),
-    getAdvanceNonceAccountInstructionDataDecoder()
-  );
+    return combineCodec(getAdvanceNonceAccountInstructionDataEncoder(), getAdvanceNonceAccountInstructionDataDecoder());
 }
 
 export type AdvanceNonceAccountInput<
-  TAccountNonceAccount extends string = string,
-  TAccountRecentBlockhashesSysvar extends string = string,
-  TAccountNonceAuthority extends string = string,
+    TAccountNonceAccount extends string = string,
+    TAccountRecentBlockhashesSysvar extends string = string,
+    TAccountNonceAuthority extends string = string,
 > = {
-  nonceAccount: Address<TAccountNonceAccount>;
-  recentBlockhashesSysvar?: Address<TAccountRecentBlockhashesSysvar>;
-  nonceAuthority: TransactionSigner<TAccountNonceAuthority>;
+    nonceAccount: Address<TAccountNonceAccount>;
+    recentBlockhashesSysvar?: Address<TAccountRecentBlockhashesSysvar>;
+    nonceAuthority: TransactionSigner<TAccountNonceAuthority>;
 };
 
 export function getAdvanceNonceAccountInstruction<
-  TAccountNonceAccount extends string,
-  TAccountRecentBlockhashesSysvar extends string,
-  TAccountNonceAuthority extends string,
-  TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountNonceAccount extends string,
+    TAccountRecentBlockhashesSysvar extends string,
+    TAccountNonceAuthority extends string,
+    TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
 >(
-  input: AdvanceNonceAccountInput<
-    TAccountNonceAccount,
-    TAccountRecentBlockhashesSysvar,
-    TAccountNonceAuthority
-  >,
-  config?: { programAddress?: TProgramAddress }
+    input: AdvanceNonceAccountInput<TAccountNonceAccount, TAccountRecentBlockhashesSysvar, TAccountNonceAuthority>,
+    config?: { programAddress?: TProgramAddress }
 ): AdvanceNonceAccountInstruction<
-  TProgramAddress,
-  TAccountNonceAccount,
-  TAccountRecentBlockhashesSysvar,
-  TAccountNonceAuthority
-> {
-  // Program address.
-  const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
-
-  // Original accounts.
-  const originalAccounts = {
-    nonceAccount: { value: input.nonceAccount ?? null, isWritable: true },
-    recentBlockhashesSysvar: {
-      value: input.recentBlockhashesSysvar ?? null,
-      isWritable: false,
-    },
-    nonceAuthority: { value: input.nonceAuthority ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
-
-  // Resolve default values.
-  if (!accounts.recentBlockhashesSysvar.value) {
-    accounts.recentBlockhashesSysvar.value =
-      'SysvarRecentB1ockHashes11111111111111111111' as Address<'SysvarRecentB1ockHashes11111111111111111111'>;
-  }
-
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.nonceAccount),
-      getAccountMeta(accounts.recentBlockhashesSysvar),
-      getAccountMeta(accounts.nonceAuthority),
-    ],
-    data: getAdvanceNonceAccountInstructionDataEncoder().encode({}),
-    programAddress,
-  } as AdvanceNonceAccountInstruction<
     TProgramAddress,
     TAccountNonceAccount,
     TAccountRecentBlockhashesSysvar,
     TAccountNonceAuthority
-  >);
+> {
+    // Program address.
+    const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
+
+    // Original accounts.
+    const originalAccounts = {
+        nonceAccount: { value: input.nonceAccount ?? null, isWritable: true },
+        recentBlockhashesSysvar: { value: input.recentBlockhashesSysvar ?? null, isWritable: false },
+        nonceAuthority: { value: input.nonceAuthority ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
+
+    // Resolve default values.
+    if (!accounts.recentBlockhashesSysvar.value) {
+        accounts.recentBlockhashesSysvar.value =
+            'SysvarRecentB1ockHashes11111111111111111111' as Address<'SysvarRecentB1ockHashes11111111111111111111'>;
+    }
+
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [
+            getAccountMeta(accounts.nonceAccount),
+            getAccountMeta(accounts.recentBlockhashesSysvar),
+            getAccountMeta(accounts.nonceAuthority),
+        ],
+        data: getAdvanceNonceAccountInstructionDataEncoder().encode({}),
+        programAddress,
+    } as AdvanceNonceAccountInstruction<
+        TProgramAddress,
+        TAccountNonceAccount,
+        TAccountRecentBlockhashesSysvar,
+        TAccountNonceAuthority
+    >);
 }
 
 export type ParsedAdvanceNonceAccountInstruction<
-  TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    nonceAccount: TAccountMetas[0];
-    recentBlockhashesSysvar: TAccountMetas[1];
-    nonceAuthority: TAccountMetas[2];
-  };
-  data: AdvanceNonceAccountInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        nonceAccount: TAccountMetas[0];
+        recentBlockhashesSysvar: TAccountMetas[1];
+        nonceAuthority: TAccountMetas[2];
+    };
+    data: AdvanceNonceAccountInstructionData;
 };
 
 export function parseAdvanceNonceAccountInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
+    TProgram extends string,
+    TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedAdvanceNonceAccountInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 3) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: {
-      nonceAccount: getNextAccount(),
-      recentBlockhashesSysvar: getNextAccount(),
-      nonceAuthority: getNextAccount(),
-    },
-    data: getAdvanceNonceAccountInstructionDataDecoder().decode(
-      instruction.data
-    ),
-  };
+    if (instruction.accounts.length < 3) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: {
+            nonceAccount: getNextAccount(),
+            recentBlockhashesSysvar: getNextAccount(),
+            nonceAuthority: getNextAccount(),
+        },
+        data: getAdvanceNonceAccountInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/system/src/generated/instructions/allocate.ts
+++ b/test/e2e/system/src/generated/instructions/allocate.ts
@@ -7,26 +7,26 @@
  */
 
 import {
-  combineCodec,
-  getStructDecoder,
-  getStructEncoder,
-  getU32Decoder,
-  getU32Encoder,
-  getU64Decoder,
-  getU64Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyUint8Array,
-  type TransactionSigner,
-  type WritableSignerAccount,
+    combineCodec,
+    getStructDecoder,
+    getStructEncoder,
+    getU32Decoder,
+    getU32Encoder,
+    getU64Decoder,
+    getU64Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyUint8Array,
+    type TransactionSigner,
+    type WritableSignerAccount,
 } from '@solana/kit';
 import { SYSTEM_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -34,125 +34,111 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const ALLOCATE_DISCRIMINATOR = 8;
 
 export function getAllocateDiscriminatorBytes() {
-  return getU32Encoder().encode(ALLOCATE_DISCRIMINATOR);
+    return getU32Encoder().encode(ALLOCATE_DISCRIMINATOR);
 }
 
 export type AllocateInstruction<
-  TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountNewAccount extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountNewAccount extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountNewAccount extends string
-        ? WritableSignerAccount<TAccountNewAccount> &
-            AccountSignerMeta<TAccountNewAccount>
-        : TAccountNewAccount,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountNewAccount extends string
+                ? WritableSignerAccount<TAccountNewAccount> & AccountSignerMeta<TAccountNewAccount>
+                : TAccountNewAccount,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type AllocateInstructionData = { discriminator: number; space: bigint };
 
 export type AllocateInstructionDataArgs = { space: number | bigint };
 
 export function getAllocateInstructionDataEncoder(): FixedSizeEncoder<AllocateInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', getU32Encoder()],
-      ['space', getU64Encoder()],
-    ]),
-    (value) => ({ ...value, discriminator: ALLOCATE_DISCRIMINATOR })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', getU32Encoder()],
+            ['space', getU64Encoder()],
+        ]),
+        value => ({ ...value, discriminator: ALLOCATE_DISCRIMINATOR })
+    );
 }
 
 export function getAllocateInstructionDataDecoder(): FixedSizeDecoder<AllocateInstructionData> {
-  return getStructDecoder([
-    ['discriminator', getU32Decoder()],
-    ['space', getU64Decoder()],
-  ]);
+    return getStructDecoder([
+        ['discriminator', getU32Decoder()],
+        ['space', getU64Decoder()],
+    ]);
 }
 
 export function getAllocateInstructionDataCodec(): FixedSizeCodec<
-  AllocateInstructionDataArgs,
-  AllocateInstructionData
+    AllocateInstructionDataArgs,
+    AllocateInstructionData
 > {
-  return combineCodec(
-    getAllocateInstructionDataEncoder(),
-    getAllocateInstructionDataDecoder()
-  );
+    return combineCodec(getAllocateInstructionDataEncoder(), getAllocateInstructionDataDecoder());
 }
 
 export type AllocateInput<TAccountNewAccount extends string = string> = {
-  newAccount: TransactionSigner<TAccountNewAccount>;
-  space: AllocateInstructionDataArgs['space'];
+    newAccount: TransactionSigner<TAccountNewAccount>;
+    space: AllocateInstructionDataArgs['space'];
 };
 
 export function getAllocateInstruction<
-  TAccountNewAccount extends string,
-  TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountNewAccount extends string,
+    TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
 >(
-  input: AllocateInput<TAccountNewAccount>,
-  config?: { programAddress?: TProgramAddress }
+    input: AllocateInput<TAccountNewAccount>,
+    config?: { programAddress?: TProgramAddress }
 ): AllocateInstruction<TProgramAddress, TAccountNewAccount> {
-  // Program address.
-  const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
+    // Program address.
+    const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
 
-  // Original accounts.
-  const originalAccounts = {
-    newAccount: { value: input.newAccount ?? null, isWritable: true },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
+    // Original accounts.
+    const originalAccounts = { newAccount: { value: input.newAccount ?? null, isWritable: true } };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
 
-  // Original args.
-  const args = { ...input };
+    // Original args.
+    const args = { ...input };
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [getAccountMeta(accounts.newAccount)],
-    data: getAllocateInstructionDataEncoder().encode(
-      args as AllocateInstructionDataArgs
-    ),
-    programAddress,
-  } as AllocateInstruction<TProgramAddress, TAccountNewAccount>);
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [getAccountMeta(accounts.newAccount)],
+        data: getAllocateInstructionDataEncoder().encode(args as AllocateInstructionDataArgs),
+        programAddress,
+    } as AllocateInstruction<TProgramAddress, TAccountNewAccount>);
 }
 
 export type ParsedAllocateInstruction<
-  TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    newAccount: TAccountMetas[0];
-  };
-  data: AllocateInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        newAccount: TAccountMetas[0];
+    };
+    data: AllocateInstructionData;
 };
 
-export function parseAllocateInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
->(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+export function parseAllocateInstruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedAllocateInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 1) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: { newAccount: getNextAccount() },
-    data: getAllocateInstructionDataDecoder().decode(instruction.data),
-  };
+    if (instruction.accounts.length < 1) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { newAccount: getNextAccount() },
+        data: getAllocateInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/system/src/generated/instructions/allocateWithSeed.ts
+++ b/test/e2e/system/src/generated/instructions/allocateWithSeed.ts
@@ -7,33 +7,33 @@
  */
 
 import {
-  addDecoderSizePrefix,
-  addEncoderSizePrefix,
-  combineCodec,
-  getAddressDecoder,
-  getAddressEncoder,
-  getStructDecoder,
-  getStructEncoder,
-  getU32Decoder,
-  getU32Encoder,
-  getU64Decoder,
-  getU64Encoder,
-  getUtf8Decoder,
-  getUtf8Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type Codec,
-  type Decoder,
-  type Encoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlySignerAccount,
-  type ReadonlyUint8Array,
-  type TransactionSigner,
-  type WritableAccount,
+    addDecoderSizePrefix,
+    addEncoderSizePrefix,
+    combineCodec,
+    getAddressDecoder,
+    getAddressEncoder,
+    getStructDecoder,
+    getStructEncoder,
+    getU32Decoder,
+    getU32Encoder,
+    getU64Decoder,
+    getU64Encoder,
+    getUtf8Decoder,
+    getUtf8Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type Codec,
+    type Decoder,
+    type Encoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlySignerAccount,
+    type ReadonlyUint8Array,
+    type TransactionSigner,
+    type WritableAccount,
 } from '@solana/kit';
 import { SYSTEM_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -41,167 +41,142 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const ALLOCATE_WITH_SEED_DISCRIMINATOR = 9;
 
 export function getAllocateWithSeedDiscriminatorBytes() {
-  return getU32Encoder().encode(ALLOCATE_WITH_SEED_DISCRIMINATOR);
+    return getU32Encoder().encode(ALLOCATE_WITH_SEED_DISCRIMINATOR);
 }
 
 export type AllocateWithSeedInstruction<
-  TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountNewAccount extends string | AccountMeta<string> = string,
-  TAccountBaseAccount extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountNewAccount extends string | AccountMeta<string> = string,
+    TAccountBaseAccount extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountNewAccount extends string
-        ? WritableAccount<TAccountNewAccount>
-        : TAccountNewAccount,
-      TAccountBaseAccount extends string
-        ? ReadonlySignerAccount<TAccountBaseAccount> &
-            AccountSignerMeta<TAccountBaseAccount>
-        : TAccountBaseAccount,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountNewAccount extends string ? WritableAccount<TAccountNewAccount> : TAccountNewAccount,
+            TAccountBaseAccount extends string
+                ? ReadonlySignerAccount<TAccountBaseAccount> & AccountSignerMeta<TAccountBaseAccount>
+                : TAccountBaseAccount,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type AllocateWithSeedInstructionData = {
-  discriminator: number;
-  base: Address;
-  seed: string;
-  space: bigint;
-  programAddress: Address;
+    discriminator: number;
+    base: Address;
+    seed: string;
+    space: bigint;
+    programAddress: Address;
 };
 
 export type AllocateWithSeedInstructionDataArgs = {
-  base: Address;
-  seed: string;
-  space: number | bigint;
-  programAddress: Address;
+    base: Address;
+    seed: string;
+    space: number | bigint;
+    programAddress: Address;
 };
 
 export function getAllocateWithSeedInstructionDataEncoder(): Encoder<AllocateWithSeedInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', getU32Encoder()],
-      ['base', getAddressEncoder()],
-      ['seed', addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
-      ['space', getU64Encoder()],
-      ['programAddress', getAddressEncoder()],
-    ]),
-    (value) => ({ ...value, discriminator: ALLOCATE_WITH_SEED_DISCRIMINATOR })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', getU32Encoder()],
+            ['base', getAddressEncoder()],
+            ['seed', addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
+            ['space', getU64Encoder()],
+            ['programAddress', getAddressEncoder()],
+        ]),
+        value => ({ ...value, discriminator: ALLOCATE_WITH_SEED_DISCRIMINATOR })
+    );
 }
 
 export function getAllocateWithSeedInstructionDataDecoder(): Decoder<AllocateWithSeedInstructionData> {
-  return getStructDecoder([
-    ['discriminator', getU32Decoder()],
-    ['base', getAddressDecoder()],
-    ['seed', addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())],
-    ['space', getU64Decoder()],
-    ['programAddress', getAddressDecoder()],
-  ]);
+    return getStructDecoder([
+        ['discriminator', getU32Decoder()],
+        ['base', getAddressDecoder()],
+        ['seed', addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())],
+        ['space', getU64Decoder()],
+        ['programAddress', getAddressDecoder()],
+    ]);
 }
 
 export function getAllocateWithSeedInstructionDataCodec(): Codec<
-  AllocateWithSeedInstructionDataArgs,
-  AllocateWithSeedInstructionData
+    AllocateWithSeedInstructionDataArgs,
+    AllocateWithSeedInstructionData
 > {
-  return combineCodec(
-    getAllocateWithSeedInstructionDataEncoder(),
-    getAllocateWithSeedInstructionDataDecoder()
-  );
+    return combineCodec(getAllocateWithSeedInstructionDataEncoder(), getAllocateWithSeedInstructionDataDecoder());
 }
 
 export type AllocateWithSeedInput<
-  TAccountNewAccount extends string = string,
-  TAccountBaseAccount extends string = string,
+    TAccountNewAccount extends string = string,
+    TAccountBaseAccount extends string = string,
 > = {
-  newAccount: Address<TAccountNewAccount>;
-  baseAccount: TransactionSigner<TAccountBaseAccount>;
-  base: AllocateWithSeedInstructionDataArgs['base'];
-  seed: AllocateWithSeedInstructionDataArgs['seed'];
-  space: AllocateWithSeedInstructionDataArgs['space'];
-  programAddress: AllocateWithSeedInstructionDataArgs['programAddress'];
+    newAccount: Address<TAccountNewAccount>;
+    baseAccount: TransactionSigner<TAccountBaseAccount>;
+    base: AllocateWithSeedInstructionDataArgs['base'];
+    seed: AllocateWithSeedInstructionDataArgs['seed'];
+    space: AllocateWithSeedInstructionDataArgs['space'];
+    programAddress: AllocateWithSeedInstructionDataArgs['programAddress'];
 };
 
 export function getAllocateWithSeedInstruction<
-  TAccountNewAccount extends string,
-  TAccountBaseAccount extends string,
-  TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountNewAccount extends string,
+    TAccountBaseAccount extends string,
+    TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
 >(
-  input: AllocateWithSeedInput<TAccountNewAccount, TAccountBaseAccount>,
-  config?: { programAddress?: TProgramAddress }
-): AllocateWithSeedInstruction<
-  TProgramAddress,
-  TAccountNewAccount,
-  TAccountBaseAccount
-> {
-  // Program address.
-  const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
+    input: AllocateWithSeedInput<TAccountNewAccount, TAccountBaseAccount>,
+    config?: { programAddress?: TProgramAddress }
+): AllocateWithSeedInstruction<TProgramAddress, TAccountNewAccount, TAccountBaseAccount> {
+    // Program address.
+    const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
 
-  // Original accounts.
-  const originalAccounts = {
-    newAccount: { value: input.newAccount ?? null, isWritable: true },
-    baseAccount: { value: input.baseAccount ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
+    // Original accounts.
+    const originalAccounts = {
+        newAccount: { value: input.newAccount ?? null, isWritable: true },
+        baseAccount: { value: input.baseAccount ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
 
-  // Original args.
-  const args = { ...input };
+    // Original args.
+    const args = { ...input };
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.newAccount),
-      getAccountMeta(accounts.baseAccount),
-    ],
-    data: getAllocateWithSeedInstructionDataEncoder().encode(
-      args as AllocateWithSeedInstructionDataArgs
-    ),
-    programAddress,
-  } as AllocateWithSeedInstruction<
-    TProgramAddress,
-    TAccountNewAccount,
-    TAccountBaseAccount
-  >);
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [getAccountMeta(accounts.newAccount), getAccountMeta(accounts.baseAccount)],
+        data: getAllocateWithSeedInstructionDataEncoder().encode(args as AllocateWithSeedInstructionDataArgs),
+        programAddress,
+    } as AllocateWithSeedInstruction<TProgramAddress, TAccountNewAccount, TAccountBaseAccount>);
 }
 
 export type ParsedAllocateWithSeedInstruction<
-  TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    newAccount: TAccountMetas[0];
-    baseAccount: TAccountMetas[1];
-  };
-  data: AllocateWithSeedInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        newAccount: TAccountMetas[0];
+        baseAccount: TAccountMetas[1];
+    };
+    data: AllocateWithSeedInstructionData;
 };
 
-export function parseAllocateWithSeedInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
->(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+export function parseAllocateWithSeedInstruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedAllocateWithSeedInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 2) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: { newAccount: getNextAccount(), baseAccount: getNextAccount() },
-    data: getAllocateWithSeedInstructionDataDecoder().decode(instruction.data),
-  };
+    if (instruction.accounts.length < 2) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { newAccount: getNextAccount(), baseAccount: getNextAccount() },
+        data: getAllocateWithSeedInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/system/src/generated/instructions/assign.ts
+++ b/test/e2e/system/src/generated/instructions/assign.ts
@@ -7,26 +7,26 @@
  */
 
 import {
-  combineCodec,
-  getAddressDecoder,
-  getAddressEncoder,
-  getStructDecoder,
-  getStructEncoder,
-  getU32Decoder,
-  getU32Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyUint8Array,
-  type TransactionSigner,
-  type WritableSignerAccount,
+    combineCodec,
+    getAddressDecoder,
+    getAddressEncoder,
+    getStructDecoder,
+    getStructEncoder,
+    getU32Decoder,
+    getU32Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyUint8Array,
+    type TransactionSigner,
+    type WritableSignerAccount,
 } from '@solana/kit';
 import { SYSTEM_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -34,128 +34,108 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const ASSIGN_DISCRIMINATOR = 1;
 
 export function getAssignDiscriminatorBytes() {
-  return getU32Encoder().encode(ASSIGN_DISCRIMINATOR);
+    return getU32Encoder().encode(ASSIGN_DISCRIMINATOR);
 }
 
 export type AssignInstruction<
-  TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountAccount extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountAccount extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountAccount extends string
-        ? WritableSignerAccount<TAccountAccount> &
-            AccountSignerMeta<TAccountAccount>
-        : TAccountAccount,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountAccount extends string
+                ? WritableSignerAccount<TAccountAccount> & AccountSignerMeta<TAccountAccount>
+                : TAccountAccount,
+            ...TRemainingAccounts,
+        ]
+    >;
 
-export type AssignInstructionData = {
-  discriminator: number;
-  programAddress: Address;
-};
+export type AssignInstructionData = { discriminator: number; programAddress: Address };
 
 export type AssignInstructionDataArgs = { programAddress: Address };
 
 export function getAssignInstructionDataEncoder(): FixedSizeEncoder<AssignInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', getU32Encoder()],
-      ['programAddress', getAddressEncoder()],
-    ]),
-    (value) => ({ ...value, discriminator: ASSIGN_DISCRIMINATOR })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', getU32Encoder()],
+            ['programAddress', getAddressEncoder()],
+        ]),
+        value => ({ ...value, discriminator: ASSIGN_DISCRIMINATOR })
+    );
 }
 
 export function getAssignInstructionDataDecoder(): FixedSizeDecoder<AssignInstructionData> {
-  return getStructDecoder([
-    ['discriminator', getU32Decoder()],
-    ['programAddress', getAddressDecoder()],
-  ]);
+    return getStructDecoder([
+        ['discriminator', getU32Decoder()],
+        ['programAddress', getAddressDecoder()],
+    ]);
 }
 
-export function getAssignInstructionDataCodec(): FixedSizeCodec<
-  AssignInstructionDataArgs,
-  AssignInstructionData
-> {
-  return combineCodec(
-    getAssignInstructionDataEncoder(),
-    getAssignInstructionDataDecoder()
-  );
+export function getAssignInstructionDataCodec(): FixedSizeCodec<AssignInstructionDataArgs, AssignInstructionData> {
+    return combineCodec(getAssignInstructionDataEncoder(), getAssignInstructionDataDecoder());
 }
 
 export type AssignInput<TAccountAccount extends string = string> = {
-  account: TransactionSigner<TAccountAccount>;
-  programAddress: AssignInstructionDataArgs['programAddress'];
+    account: TransactionSigner<TAccountAccount>;
+    programAddress: AssignInstructionDataArgs['programAddress'];
 };
 
 export function getAssignInstruction<
-  TAccountAccount extends string,
-  TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountAccount extends string,
+    TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
 >(
-  input: AssignInput<TAccountAccount>,
-  config?: { programAddress?: TProgramAddress }
+    input: AssignInput<TAccountAccount>,
+    config?: { programAddress?: TProgramAddress }
 ): AssignInstruction<TProgramAddress, TAccountAccount> {
-  // Program address.
-  const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
+    // Program address.
+    const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
 
-  // Original accounts.
-  const originalAccounts = {
-    account: { value: input.account ?? null, isWritable: true },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
+    // Original accounts.
+    const originalAccounts = { account: { value: input.account ?? null, isWritable: true } };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
 
-  // Original args.
-  const args = { ...input };
+    // Original args.
+    const args = { ...input };
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [getAccountMeta(accounts.account)],
-    data: getAssignInstructionDataEncoder().encode(
-      args as AssignInstructionDataArgs
-    ),
-    programAddress,
-  } as AssignInstruction<TProgramAddress, TAccountAccount>);
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [getAccountMeta(accounts.account)],
+        data: getAssignInstructionDataEncoder().encode(args as AssignInstructionDataArgs),
+        programAddress,
+    } as AssignInstruction<TProgramAddress, TAccountAccount>);
 }
 
 export type ParsedAssignInstruction<
-  TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    account: TAccountMetas[0];
-  };
-  data: AssignInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        account: TAccountMetas[0];
+    };
+    data: AssignInstructionData;
 };
 
-export function parseAssignInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
->(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+export function parseAssignInstruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedAssignInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 1) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: { account: getNextAccount() },
-    data: getAssignInstructionDataDecoder().decode(instruction.data),
-  };
+    if (instruction.accounts.length < 1) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { account: getNextAccount() },
+        data: getAssignInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/system/src/generated/instructions/assignWithSeed.ts
+++ b/test/e2e/system/src/generated/instructions/assignWithSeed.ts
@@ -7,31 +7,31 @@
  */
 
 import {
-  addDecoderSizePrefix,
-  addEncoderSizePrefix,
-  combineCodec,
-  getAddressDecoder,
-  getAddressEncoder,
-  getStructDecoder,
-  getStructEncoder,
-  getU32Decoder,
-  getU32Encoder,
-  getUtf8Decoder,
-  getUtf8Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type Codec,
-  type Decoder,
-  type Encoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlySignerAccount,
-  type ReadonlyUint8Array,
-  type TransactionSigner,
-  type WritableAccount,
+    addDecoderSizePrefix,
+    addEncoderSizePrefix,
+    combineCodec,
+    getAddressDecoder,
+    getAddressEncoder,
+    getStructDecoder,
+    getStructEncoder,
+    getU32Decoder,
+    getU32Encoder,
+    getUtf8Decoder,
+    getUtf8Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type Codec,
+    type Decoder,
+    type Encoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlySignerAccount,
+    type ReadonlyUint8Array,
+    type TransactionSigner,
+    type WritableAccount,
 } from '@solana/kit';
 import { SYSTEM_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -39,162 +39,133 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const ASSIGN_WITH_SEED_DISCRIMINATOR = 10;
 
 export function getAssignWithSeedDiscriminatorBytes() {
-  return getU32Encoder().encode(ASSIGN_WITH_SEED_DISCRIMINATOR);
+    return getU32Encoder().encode(ASSIGN_WITH_SEED_DISCRIMINATOR);
 }
 
 export type AssignWithSeedInstruction<
-  TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountAccount extends string | AccountMeta<string> = string,
-  TAccountBaseAccount extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountAccount extends string | AccountMeta<string> = string,
+    TAccountBaseAccount extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountAccount extends string
-        ? WritableAccount<TAccountAccount>
-        : TAccountAccount,
-      TAccountBaseAccount extends string
-        ? ReadonlySignerAccount<TAccountBaseAccount> &
-            AccountSignerMeta<TAccountBaseAccount>
-        : TAccountBaseAccount,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountAccount extends string ? WritableAccount<TAccountAccount> : TAccountAccount,
+            TAccountBaseAccount extends string
+                ? ReadonlySignerAccount<TAccountBaseAccount> & AccountSignerMeta<TAccountBaseAccount>
+                : TAccountBaseAccount,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type AssignWithSeedInstructionData = {
-  discriminator: number;
-  base: Address;
-  seed: string;
-  programAddress: Address;
+    discriminator: number;
+    base: Address;
+    seed: string;
+    programAddress: Address;
 };
 
-export type AssignWithSeedInstructionDataArgs = {
-  base: Address;
-  seed: string;
-  programAddress: Address;
-};
+export type AssignWithSeedInstructionDataArgs = { base: Address; seed: string; programAddress: Address };
 
 export function getAssignWithSeedInstructionDataEncoder(): Encoder<AssignWithSeedInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', getU32Encoder()],
-      ['base', getAddressEncoder()],
-      ['seed', addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
-      ['programAddress', getAddressEncoder()],
-    ]),
-    (value) => ({ ...value, discriminator: ASSIGN_WITH_SEED_DISCRIMINATOR })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', getU32Encoder()],
+            ['base', getAddressEncoder()],
+            ['seed', addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
+            ['programAddress', getAddressEncoder()],
+        ]),
+        value => ({ ...value, discriminator: ASSIGN_WITH_SEED_DISCRIMINATOR })
+    );
 }
 
 export function getAssignWithSeedInstructionDataDecoder(): Decoder<AssignWithSeedInstructionData> {
-  return getStructDecoder([
-    ['discriminator', getU32Decoder()],
-    ['base', getAddressDecoder()],
-    ['seed', addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())],
-    ['programAddress', getAddressDecoder()],
-  ]);
+    return getStructDecoder([
+        ['discriminator', getU32Decoder()],
+        ['base', getAddressDecoder()],
+        ['seed', addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())],
+        ['programAddress', getAddressDecoder()],
+    ]);
 }
 
 export function getAssignWithSeedInstructionDataCodec(): Codec<
-  AssignWithSeedInstructionDataArgs,
-  AssignWithSeedInstructionData
+    AssignWithSeedInstructionDataArgs,
+    AssignWithSeedInstructionData
 > {
-  return combineCodec(
-    getAssignWithSeedInstructionDataEncoder(),
-    getAssignWithSeedInstructionDataDecoder()
-  );
+    return combineCodec(getAssignWithSeedInstructionDataEncoder(), getAssignWithSeedInstructionDataDecoder());
 }
 
 export type AssignWithSeedInput<
-  TAccountAccount extends string = string,
-  TAccountBaseAccount extends string = string,
+    TAccountAccount extends string = string,
+    TAccountBaseAccount extends string = string,
 > = {
-  account: Address<TAccountAccount>;
-  baseAccount: TransactionSigner<TAccountBaseAccount>;
-  base: AssignWithSeedInstructionDataArgs['base'];
-  seed: AssignWithSeedInstructionDataArgs['seed'];
-  programAddress: AssignWithSeedInstructionDataArgs['programAddress'];
+    account: Address<TAccountAccount>;
+    baseAccount: TransactionSigner<TAccountBaseAccount>;
+    base: AssignWithSeedInstructionDataArgs['base'];
+    seed: AssignWithSeedInstructionDataArgs['seed'];
+    programAddress: AssignWithSeedInstructionDataArgs['programAddress'];
 };
 
 export function getAssignWithSeedInstruction<
-  TAccountAccount extends string,
-  TAccountBaseAccount extends string,
-  TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountAccount extends string,
+    TAccountBaseAccount extends string,
+    TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
 >(
-  input: AssignWithSeedInput<TAccountAccount, TAccountBaseAccount>,
-  config?: { programAddress?: TProgramAddress }
-): AssignWithSeedInstruction<
-  TProgramAddress,
-  TAccountAccount,
-  TAccountBaseAccount
-> {
-  // Program address.
-  const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
+    input: AssignWithSeedInput<TAccountAccount, TAccountBaseAccount>,
+    config?: { programAddress?: TProgramAddress }
+): AssignWithSeedInstruction<TProgramAddress, TAccountAccount, TAccountBaseAccount> {
+    // Program address.
+    const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
 
-  // Original accounts.
-  const originalAccounts = {
-    account: { value: input.account ?? null, isWritable: true },
-    baseAccount: { value: input.baseAccount ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
+    // Original accounts.
+    const originalAccounts = {
+        account: { value: input.account ?? null, isWritable: true },
+        baseAccount: { value: input.baseAccount ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
 
-  // Original args.
-  const args = { ...input };
+    // Original args.
+    const args = { ...input };
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.account),
-      getAccountMeta(accounts.baseAccount),
-    ],
-    data: getAssignWithSeedInstructionDataEncoder().encode(
-      args as AssignWithSeedInstructionDataArgs
-    ),
-    programAddress,
-  } as AssignWithSeedInstruction<
-    TProgramAddress,
-    TAccountAccount,
-    TAccountBaseAccount
-  >);
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [getAccountMeta(accounts.account), getAccountMeta(accounts.baseAccount)],
+        data: getAssignWithSeedInstructionDataEncoder().encode(args as AssignWithSeedInstructionDataArgs),
+        programAddress,
+    } as AssignWithSeedInstruction<TProgramAddress, TAccountAccount, TAccountBaseAccount>);
 }
 
 export type ParsedAssignWithSeedInstruction<
-  TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    account: TAccountMetas[0];
-    baseAccount: TAccountMetas[1];
-  };
-  data: AssignWithSeedInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        account: TAccountMetas[0];
+        baseAccount: TAccountMetas[1];
+    };
+    data: AssignWithSeedInstructionData;
 };
 
-export function parseAssignWithSeedInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
->(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+export function parseAssignWithSeedInstruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedAssignWithSeedInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 2) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: { account: getNextAccount(), baseAccount: getNextAccount() },
-    data: getAssignWithSeedInstructionDataDecoder().decode(instruction.data),
-  };
+    if (instruction.accounts.length < 2) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { account: getNextAccount(), baseAccount: getNextAccount() },
+        data: getAssignWithSeedInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/system/src/generated/instructions/authorizeNonceAccount.ts
+++ b/test/e2e/system/src/generated/instructions/authorizeNonceAccount.ts
@@ -7,27 +7,27 @@
  */
 
 import {
-  combineCodec,
-  getAddressDecoder,
-  getAddressEncoder,
-  getStructDecoder,
-  getStructEncoder,
-  getU32Decoder,
-  getU32Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlySignerAccount,
-  type ReadonlyUint8Array,
-  type TransactionSigner,
-  type WritableAccount,
+    combineCodec,
+    getAddressDecoder,
+    getAddressEncoder,
+    getStructDecoder,
+    getStructEncoder,
+    getU32Decoder,
+    getU32Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlySignerAccount,
+    type ReadonlyUint8Array,
+    type TransactionSigner,
+    type WritableAccount,
 } from '@solana/kit';
 import { SYSTEM_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -35,163 +35,128 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const AUTHORIZE_NONCE_ACCOUNT_DISCRIMINATOR = 7;
 
 export function getAuthorizeNonceAccountDiscriminatorBytes() {
-  return getU32Encoder().encode(AUTHORIZE_NONCE_ACCOUNT_DISCRIMINATOR);
+    return getU32Encoder().encode(AUTHORIZE_NONCE_ACCOUNT_DISCRIMINATOR);
 }
 
 export type AuthorizeNonceAccountInstruction<
-  TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountNonceAccount extends string | AccountMeta<string> = string,
-  TAccountNonceAuthority extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountNonceAccount extends string | AccountMeta<string> = string,
+    TAccountNonceAuthority extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountNonceAccount extends string
-        ? WritableAccount<TAccountNonceAccount>
-        : TAccountNonceAccount,
-      TAccountNonceAuthority extends string
-        ? ReadonlySignerAccount<TAccountNonceAuthority> &
-            AccountSignerMeta<TAccountNonceAuthority>
-        : TAccountNonceAuthority,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountNonceAccount extends string ? WritableAccount<TAccountNonceAccount> : TAccountNonceAccount,
+            TAccountNonceAuthority extends string
+                ? ReadonlySignerAccount<TAccountNonceAuthority> & AccountSignerMeta<TAccountNonceAuthority>
+                : TAccountNonceAuthority,
+            ...TRemainingAccounts,
+        ]
+    >;
 
-export type AuthorizeNonceAccountInstructionData = {
-  discriminator: number;
-  newNonceAuthority: Address;
-};
+export type AuthorizeNonceAccountInstructionData = { discriminator: number; newNonceAuthority: Address };
 
-export type AuthorizeNonceAccountInstructionDataArgs = {
-  newNonceAuthority: Address;
-};
+export type AuthorizeNonceAccountInstructionDataArgs = { newNonceAuthority: Address };
 
 export function getAuthorizeNonceAccountInstructionDataEncoder(): FixedSizeEncoder<AuthorizeNonceAccountInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', getU32Encoder()],
-      ['newNonceAuthority', getAddressEncoder()],
-    ]),
-    (value) => ({
-      ...value,
-      discriminator: AUTHORIZE_NONCE_ACCOUNT_DISCRIMINATOR,
-    })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', getU32Encoder()],
+            ['newNonceAuthority', getAddressEncoder()],
+        ]),
+        value => ({ ...value, discriminator: AUTHORIZE_NONCE_ACCOUNT_DISCRIMINATOR })
+    );
 }
 
 export function getAuthorizeNonceAccountInstructionDataDecoder(): FixedSizeDecoder<AuthorizeNonceAccountInstructionData> {
-  return getStructDecoder([
-    ['discriminator', getU32Decoder()],
-    ['newNonceAuthority', getAddressDecoder()],
-  ]);
+    return getStructDecoder([
+        ['discriminator', getU32Decoder()],
+        ['newNonceAuthority', getAddressDecoder()],
+    ]);
 }
 
 export function getAuthorizeNonceAccountInstructionDataCodec(): FixedSizeCodec<
-  AuthorizeNonceAccountInstructionDataArgs,
-  AuthorizeNonceAccountInstructionData
+    AuthorizeNonceAccountInstructionDataArgs,
+    AuthorizeNonceAccountInstructionData
 > {
-  return combineCodec(
-    getAuthorizeNonceAccountInstructionDataEncoder(),
-    getAuthorizeNonceAccountInstructionDataDecoder()
-  );
+    return combineCodec(
+        getAuthorizeNonceAccountInstructionDataEncoder(),
+        getAuthorizeNonceAccountInstructionDataDecoder()
+    );
 }
 
 export type AuthorizeNonceAccountInput<
-  TAccountNonceAccount extends string = string,
-  TAccountNonceAuthority extends string = string,
+    TAccountNonceAccount extends string = string,
+    TAccountNonceAuthority extends string = string,
 > = {
-  nonceAccount: Address<TAccountNonceAccount>;
-  nonceAuthority: TransactionSigner<TAccountNonceAuthority>;
-  newNonceAuthority: AuthorizeNonceAccountInstructionDataArgs['newNonceAuthority'];
+    nonceAccount: Address<TAccountNonceAccount>;
+    nonceAuthority: TransactionSigner<TAccountNonceAuthority>;
+    newNonceAuthority: AuthorizeNonceAccountInstructionDataArgs['newNonceAuthority'];
 };
 
 export function getAuthorizeNonceAccountInstruction<
-  TAccountNonceAccount extends string,
-  TAccountNonceAuthority extends string,
-  TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountNonceAccount extends string,
+    TAccountNonceAuthority extends string,
+    TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
 >(
-  input: AuthorizeNonceAccountInput<
-    TAccountNonceAccount,
-    TAccountNonceAuthority
-  >,
-  config?: { programAddress?: TProgramAddress }
-): AuthorizeNonceAccountInstruction<
-  TProgramAddress,
-  TAccountNonceAccount,
-  TAccountNonceAuthority
-> {
-  // Program address.
-  const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
+    input: AuthorizeNonceAccountInput<TAccountNonceAccount, TAccountNonceAuthority>,
+    config?: { programAddress?: TProgramAddress }
+): AuthorizeNonceAccountInstruction<TProgramAddress, TAccountNonceAccount, TAccountNonceAuthority> {
+    // Program address.
+    const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
 
-  // Original accounts.
-  const originalAccounts = {
-    nonceAccount: { value: input.nonceAccount ?? null, isWritable: true },
-    nonceAuthority: { value: input.nonceAuthority ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
+    // Original accounts.
+    const originalAccounts = {
+        nonceAccount: { value: input.nonceAccount ?? null, isWritable: true },
+        nonceAuthority: { value: input.nonceAuthority ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
 
-  // Original args.
-  const args = { ...input };
+    // Original args.
+    const args = { ...input };
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.nonceAccount),
-      getAccountMeta(accounts.nonceAuthority),
-    ],
-    data: getAuthorizeNonceAccountInstructionDataEncoder().encode(
-      args as AuthorizeNonceAccountInstructionDataArgs
-    ),
-    programAddress,
-  } as AuthorizeNonceAccountInstruction<
-    TProgramAddress,
-    TAccountNonceAccount,
-    TAccountNonceAuthority
-  >);
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [getAccountMeta(accounts.nonceAccount), getAccountMeta(accounts.nonceAuthority)],
+        data: getAuthorizeNonceAccountInstructionDataEncoder().encode(args as AuthorizeNonceAccountInstructionDataArgs),
+        programAddress,
+    } as AuthorizeNonceAccountInstruction<TProgramAddress, TAccountNonceAccount, TAccountNonceAuthority>);
 }
 
 export type ParsedAuthorizeNonceAccountInstruction<
-  TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    nonceAccount: TAccountMetas[0];
-    nonceAuthority: TAccountMetas[1];
-  };
-  data: AuthorizeNonceAccountInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        nonceAccount: TAccountMetas[0];
+        nonceAuthority: TAccountMetas[1];
+    };
+    data: AuthorizeNonceAccountInstructionData;
 };
 
 export function parseAuthorizeNonceAccountInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
+    TProgram extends string,
+    TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedAuthorizeNonceAccountInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 2) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: {
-      nonceAccount: getNextAccount(),
-      nonceAuthority: getNextAccount(),
-    },
-    data: getAuthorizeNonceAccountInstructionDataDecoder().decode(
-      instruction.data
-    ),
-  };
+    if (instruction.accounts.length < 2) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { nonceAccount: getNextAccount(), nonceAuthority: getNextAccount() },
+        data: getAuthorizeNonceAccountInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/system/src/generated/instructions/createAccount.ts
+++ b/test/e2e/system/src/generated/instructions/createAccount.ts
@@ -7,209 +7,169 @@
  */
 
 import {
-  BASE_ACCOUNT_SIZE,
-  combineCodec,
-  getAddressDecoder,
-  getAddressEncoder,
-  getLamportsDecoder,
-  getLamportsEncoder,
-  getStructDecoder,
-  getStructEncoder,
-  getU32Decoder,
-  getU32Encoder,
-  getU64Decoder,
-  getU64Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type Lamports,
-  type ReadonlyUint8Array,
-  type TransactionSigner,
-  type WritableSignerAccount,
+    BASE_ACCOUNT_SIZE,
+    combineCodec,
+    getAddressDecoder,
+    getAddressEncoder,
+    getLamportsDecoder,
+    getLamportsEncoder,
+    getStructDecoder,
+    getStructEncoder,
+    getU32Decoder,
+    getU32Encoder,
+    getU64Decoder,
+    getU64Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type Lamports,
+    type ReadonlyUint8Array,
+    type TransactionSigner,
+    type WritableSignerAccount,
 } from '@solana/kit';
 import { SYSTEM_PROGRAM_ADDRESS } from '../programs';
-import {
-  getAccountMetaFactory,
-  type InstructionWithByteDelta,
-  type ResolvedAccount,
-} from '../shared';
+import { getAccountMetaFactory, type InstructionWithByteDelta, type ResolvedAccount } from '../shared';
 
 export const CREATE_ACCOUNT_DISCRIMINATOR = 0;
 
 export function getCreateAccountDiscriminatorBytes() {
-  return getU32Encoder().encode(CREATE_ACCOUNT_DISCRIMINATOR);
+    return getU32Encoder().encode(CREATE_ACCOUNT_DISCRIMINATOR);
 }
 
 export type CreateAccountInstruction<
-  TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountPayer extends string | AccountMeta<string> = string,
-  TAccountNewAccount extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountPayer extends string | AccountMeta<string> = string,
+    TAccountNewAccount extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountPayer extends string
-        ? WritableSignerAccount<TAccountPayer> &
-            AccountSignerMeta<TAccountPayer>
-        : TAccountPayer,
-      TAccountNewAccount extends string
-        ? WritableSignerAccount<TAccountNewAccount> &
-            AccountSignerMeta<TAccountNewAccount>
-        : TAccountNewAccount,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountPayer extends string
+                ? WritableSignerAccount<TAccountPayer> & AccountSignerMeta<TAccountPayer>
+                : TAccountPayer,
+            TAccountNewAccount extends string
+                ? WritableSignerAccount<TAccountNewAccount> & AccountSignerMeta<TAccountNewAccount>
+                : TAccountNewAccount,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type CreateAccountInstructionData = {
-  discriminator: number;
-  lamports: Lamports;
-  space: bigint;
-  programAddress: Address;
+    discriminator: number;
+    lamports: Lamports;
+    space: bigint;
+    programAddress: Address;
 };
 
-export type CreateAccountInstructionDataArgs = {
-  lamports: Lamports;
-  space: number | bigint;
-  programAddress: Address;
-};
+export type CreateAccountInstructionDataArgs = { lamports: Lamports; space: number | bigint; programAddress: Address };
 
 export function getCreateAccountInstructionDataEncoder(): FixedSizeEncoder<CreateAccountInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', getU32Encoder()],
-      ['lamports', getLamportsEncoder(getU64Encoder())],
-      ['space', getU64Encoder()],
-      ['programAddress', getAddressEncoder()],
-    ]),
-    (value) => ({ ...value, discriminator: CREATE_ACCOUNT_DISCRIMINATOR })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', getU32Encoder()],
+            ['lamports', getLamportsEncoder(getU64Encoder())],
+            ['space', getU64Encoder()],
+            ['programAddress', getAddressEncoder()],
+        ]),
+        value => ({ ...value, discriminator: CREATE_ACCOUNT_DISCRIMINATOR })
+    );
 }
 
 export function getCreateAccountInstructionDataDecoder(): FixedSizeDecoder<CreateAccountInstructionData> {
-  return getStructDecoder([
-    ['discriminator', getU32Decoder()],
-    ['lamports', getLamportsDecoder(getU64Decoder())],
-    ['space', getU64Decoder()],
-    ['programAddress', getAddressDecoder()],
-  ]);
+    return getStructDecoder([
+        ['discriminator', getU32Decoder()],
+        ['lamports', getLamportsDecoder(getU64Decoder())],
+        ['space', getU64Decoder()],
+        ['programAddress', getAddressDecoder()],
+    ]);
 }
 
 export function getCreateAccountInstructionDataCodec(): FixedSizeCodec<
-  CreateAccountInstructionDataArgs,
-  CreateAccountInstructionData
+    CreateAccountInstructionDataArgs,
+    CreateAccountInstructionData
 > {
-  return combineCodec(
-    getCreateAccountInstructionDataEncoder(),
-    getCreateAccountInstructionDataDecoder()
-  );
+    return combineCodec(getCreateAccountInstructionDataEncoder(), getCreateAccountInstructionDataDecoder());
 }
 
-export type CreateAccountInput<
-  TAccountPayer extends string = string,
-  TAccountNewAccount extends string = string,
-> = {
-  payer: TransactionSigner<TAccountPayer>;
-  newAccount: TransactionSigner<TAccountNewAccount>;
-  lamports: CreateAccountInstructionDataArgs['lamports'];
-  space: CreateAccountInstructionDataArgs['space'];
-  programAddress: CreateAccountInstructionDataArgs['programAddress'];
+export type CreateAccountInput<TAccountPayer extends string = string, TAccountNewAccount extends string = string> = {
+    payer: TransactionSigner<TAccountPayer>;
+    newAccount: TransactionSigner<TAccountNewAccount>;
+    lamports: CreateAccountInstructionDataArgs['lamports'];
+    space: CreateAccountInstructionDataArgs['space'];
+    programAddress: CreateAccountInstructionDataArgs['programAddress'];
 };
 
 export function getCreateAccountInstruction<
-  TAccountPayer extends string,
-  TAccountNewAccount extends string,
-  TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountPayer extends string,
+    TAccountNewAccount extends string,
+    TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
 >(
-  input: CreateAccountInput<TAccountPayer, TAccountNewAccount>,
-  config?: { programAddress?: TProgramAddress }
-): CreateAccountInstruction<
-  TProgramAddress,
-  TAccountPayer,
-  TAccountNewAccount
-> &
-  InstructionWithByteDelta {
-  // Program address.
-  const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
+    input: CreateAccountInput<TAccountPayer, TAccountNewAccount>,
+    config?: { programAddress?: TProgramAddress }
+): CreateAccountInstruction<TProgramAddress, TAccountPayer, TAccountNewAccount> & InstructionWithByteDelta {
+    // Program address.
+    const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
 
-  // Original accounts.
-  const originalAccounts = {
-    payer: { value: input.payer ?? null, isWritable: true },
-    newAccount: { value: input.newAccount ?? null, isWritable: true },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
+    // Original accounts.
+    const originalAccounts = {
+        payer: { value: input.payer ?? null, isWritable: true },
+        newAccount: { value: input.newAccount ?? null, isWritable: true },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
 
-  // Original args.
-  const args = { ...input };
+    // Original args.
+    const args = { ...input };
 
-  // Bytes created or reallocated by the instruction.
-  const byteDelta: number = [Number(args.space) + BASE_ACCOUNT_SIZE].reduce(
-    (a, b) => a + b,
-    0
-  );
+    // Bytes created or reallocated by the instruction.
+    const byteDelta: number = [Number(args.space) + BASE_ACCOUNT_SIZE].reduce((a, b) => a + b, 0);
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.payer),
-      getAccountMeta(accounts.newAccount),
-    ],
-    byteDelta,
-    data: getCreateAccountInstructionDataEncoder().encode(
-      args as CreateAccountInstructionDataArgs
-    ),
-    programAddress,
-  } as CreateAccountInstruction<
-    TProgramAddress,
-    TAccountPayer,
-    TAccountNewAccount
-  > &
-    InstructionWithByteDelta);
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [getAccountMeta(accounts.payer), getAccountMeta(accounts.newAccount)],
+        byteDelta,
+        data: getCreateAccountInstructionDataEncoder().encode(args as CreateAccountInstructionDataArgs),
+        programAddress,
+    } as CreateAccountInstruction<TProgramAddress, TAccountPayer, TAccountNewAccount> & InstructionWithByteDelta);
 }
 
 export type ParsedCreateAccountInstruction<
-  TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    payer: TAccountMetas[0];
-    newAccount: TAccountMetas[1];
-  };
-  data: CreateAccountInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        payer: TAccountMetas[0];
+        newAccount: TAccountMetas[1];
+    };
+    data: CreateAccountInstructionData;
 };
 
-export function parseCreateAccountInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
->(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+export function parseCreateAccountInstruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedCreateAccountInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 2) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: { payer: getNextAccount(), newAccount: getNextAccount() },
-    data: getCreateAccountInstructionDataDecoder().decode(instruction.data),
-  };
+    if (instruction.accounts.length < 2) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { payer: getNextAccount(), newAccount: getNextAccount() },
+        data: getCreateAccountInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/system/src/generated/instructions/createAccountWithSeed.ts
+++ b/test/e2e/system/src/generated/instructions/createAccountWithSeed.ts
@@ -7,34 +7,34 @@
  */
 
 import {
-  addDecoderSizePrefix,
-  addEncoderSizePrefix,
-  combineCodec,
-  getAddressDecoder,
-  getAddressEncoder,
-  getStructDecoder,
-  getStructEncoder,
-  getU32Decoder,
-  getU32Encoder,
-  getU64Decoder,
-  getU64Encoder,
-  getUtf8Decoder,
-  getUtf8Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type Codec,
-  type Decoder,
-  type Encoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlySignerAccount,
-  type ReadonlyUint8Array,
-  type TransactionSigner,
-  type WritableAccount,
-  type WritableSignerAccount,
+    addDecoderSizePrefix,
+    addEncoderSizePrefix,
+    combineCodec,
+    getAddressDecoder,
+    getAddressEncoder,
+    getStructDecoder,
+    getStructEncoder,
+    getU32Decoder,
+    getU32Encoder,
+    getU64Decoder,
+    getU64Encoder,
+    getUtf8Decoder,
+    getUtf8Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type Codec,
+    type Decoder,
+    type Encoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlySignerAccount,
+    type ReadonlyUint8Array,
+    type TransactionSigner,
+    type WritableAccount,
+    type WritableSignerAccount,
 } from '@solana/kit';
 import { SYSTEM_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -42,198 +42,166 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const CREATE_ACCOUNT_WITH_SEED_DISCRIMINATOR = 3;
 
 export function getCreateAccountWithSeedDiscriminatorBytes() {
-  return getU32Encoder().encode(CREATE_ACCOUNT_WITH_SEED_DISCRIMINATOR);
+    return getU32Encoder().encode(CREATE_ACCOUNT_WITH_SEED_DISCRIMINATOR);
 }
 
 export type CreateAccountWithSeedInstruction<
-  TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountPayer extends string | AccountMeta<string> = string,
-  TAccountNewAccount extends string | AccountMeta<string> = string,
-  TAccountBaseAccount extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountPayer extends string | AccountMeta<string> = string,
+    TAccountNewAccount extends string | AccountMeta<string> = string,
+    TAccountBaseAccount extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountPayer extends string
-        ? WritableSignerAccount<TAccountPayer> &
-            AccountSignerMeta<TAccountPayer>
-        : TAccountPayer,
-      TAccountNewAccount extends string
-        ? WritableAccount<TAccountNewAccount>
-        : TAccountNewAccount,
-      TAccountBaseAccount extends string
-        ? ReadonlySignerAccount<TAccountBaseAccount> &
-            AccountSignerMeta<TAccountBaseAccount>
-        : TAccountBaseAccount,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountPayer extends string
+                ? WritableSignerAccount<TAccountPayer> & AccountSignerMeta<TAccountPayer>
+                : TAccountPayer,
+            TAccountNewAccount extends string ? WritableAccount<TAccountNewAccount> : TAccountNewAccount,
+            TAccountBaseAccount extends string
+                ? ReadonlySignerAccount<TAccountBaseAccount> & AccountSignerMeta<TAccountBaseAccount>
+                : TAccountBaseAccount,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type CreateAccountWithSeedInstructionData = {
-  discriminator: number;
-  base: Address;
-  seed: string;
-  amount: bigint;
-  space: bigint;
-  programAddress: Address;
+    discriminator: number;
+    base: Address;
+    seed: string;
+    amount: bigint;
+    space: bigint;
+    programAddress: Address;
 };
 
 export type CreateAccountWithSeedInstructionDataArgs = {
-  base: Address;
-  seed: string;
-  amount: number | bigint;
-  space: number | bigint;
-  programAddress: Address;
+    base: Address;
+    seed: string;
+    amount: number | bigint;
+    space: number | bigint;
+    programAddress: Address;
 };
 
 export function getCreateAccountWithSeedInstructionDataEncoder(): Encoder<CreateAccountWithSeedInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', getU32Encoder()],
-      ['base', getAddressEncoder()],
-      ['seed', addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
-      ['amount', getU64Encoder()],
-      ['space', getU64Encoder()],
-      ['programAddress', getAddressEncoder()],
-    ]),
-    (value) => ({
-      ...value,
-      discriminator: CREATE_ACCOUNT_WITH_SEED_DISCRIMINATOR,
-    })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', getU32Encoder()],
+            ['base', getAddressEncoder()],
+            ['seed', addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
+            ['amount', getU64Encoder()],
+            ['space', getU64Encoder()],
+            ['programAddress', getAddressEncoder()],
+        ]),
+        value => ({ ...value, discriminator: CREATE_ACCOUNT_WITH_SEED_DISCRIMINATOR })
+    );
 }
 
 export function getCreateAccountWithSeedInstructionDataDecoder(): Decoder<CreateAccountWithSeedInstructionData> {
-  return getStructDecoder([
-    ['discriminator', getU32Decoder()],
-    ['base', getAddressDecoder()],
-    ['seed', addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())],
-    ['amount', getU64Decoder()],
-    ['space', getU64Decoder()],
-    ['programAddress', getAddressDecoder()],
-  ]);
+    return getStructDecoder([
+        ['discriminator', getU32Decoder()],
+        ['base', getAddressDecoder()],
+        ['seed', addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())],
+        ['amount', getU64Decoder()],
+        ['space', getU64Decoder()],
+        ['programAddress', getAddressDecoder()],
+    ]);
 }
 
 export function getCreateAccountWithSeedInstructionDataCodec(): Codec<
-  CreateAccountWithSeedInstructionDataArgs,
-  CreateAccountWithSeedInstructionData
+    CreateAccountWithSeedInstructionDataArgs,
+    CreateAccountWithSeedInstructionData
 > {
-  return combineCodec(
-    getCreateAccountWithSeedInstructionDataEncoder(),
-    getCreateAccountWithSeedInstructionDataDecoder()
-  );
+    return combineCodec(
+        getCreateAccountWithSeedInstructionDataEncoder(),
+        getCreateAccountWithSeedInstructionDataDecoder()
+    );
 }
 
 export type CreateAccountWithSeedInput<
-  TAccountPayer extends string = string,
-  TAccountNewAccount extends string = string,
-  TAccountBaseAccount extends string = string,
+    TAccountPayer extends string = string,
+    TAccountNewAccount extends string = string,
+    TAccountBaseAccount extends string = string,
 > = {
-  payer: TransactionSigner<TAccountPayer>;
-  newAccount: Address<TAccountNewAccount>;
-  baseAccount: TransactionSigner<TAccountBaseAccount>;
-  base: CreateAccountWithSeedInstructionDataArgs['base'];
-  seed: CreateAccountWithSeedInstructionDataArgs['seed'];
-  amount: CreateAccountWithSeedInstructionDataArgs['amount'];
-  space: CreateAccountWithSeedInstructionDataArgs['space'];
-  programAddress: CreateAccountWithSeedInstructionDataArgs['programAddress'];
+    payer: TransactionSigner<TAccountPayer>;
+    newAccount: Address<TAccountNewAccount>;
+    baseAccount: TransactionSigner<TAccountBaseAccount>;
+    base: CreateAccountWithSeedInstructionDataArgs['base'];
+    seed: CreateAccountWithSeedInstructionDataArgs['seed'];
+    amount: CreateAccountWithSeedInstructionDataArgs['amount'];
+    space: CreateAccountWithSeedInstructionDataArgs['space'];
+    programAddress: CreateAccountWithSeedInstructionDataArgs['programAddress'];
 };
 
 export function getCreateAccountWithSeedInstruction<
-  TAccountPayer extends string,
-  TAccountNewAccount extends string,
-  TAccountBaseAccount extends string,
-  TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountPayer extends string,
+    TAccountNewAccount extends string,
+    TAccountBaseAccount extends string,
+    TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
 >(
-  input: CreateAccountWithSeedInput<
-    TAccountPayer,
-    TAccountNewAccount,
-    TAccountBaseAccount
-  >,
-  config?: { programAddress?: TProgramAddress }
-): CreateAccountWithSeedInstruction<
-  TProgramAddress,
-  TAccountPayer,
-  TAccountNewAccount,
-  TAccountBaseAccount
-> {
-  // Program address.
-  const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
+    input: CreateAccountWithSeedInput<TAccountPayer, TAccountNewAccount, TAccountBaseAccount>,
+    config?: { programAddress?: TProgramAddress }
+): CreateAccountWithSeedInstruction<TProgramAddress, TAccountPayer, TAccountNewAccount, TAccountBaseAccount> {
+    // Program address.
+    const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
 
-  // Original accounts.
-  const originalAccounts = {
-    payer: { value: input.payer ?? null, isWritable: true },
-    newAccount: { value: input.newAccount ?? null, isWritable: true },
-    baseAccount: { value: input.baseAccount ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
+    // Original accounts.
+    const originalAccounts = {
+        payer: { value: input.payer ?? null, isWritable: true },
+        newAccount: { value: input.newAccount ?? null, isWritable: true },
+        baseAccount: { value: input.baseAccount ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
 
-  // Original args.
-  const args = { ...input };
+    // Original args.
+    const args = { ...input };
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.payer),
-      getAccountMeta(accounts.newAccount),
-      getAccountMeta(accounts.baseAccount),
-    ],
-    data: getCreateAccountWithSeedInstructionDataEncoder().encode(
-      args as CreateAccountWithSeedInstructionDataArgs
-    ),
-    programAddress,
-  } as CreateAccountWithSeedInstruction<
-    TProgramAddress,
-    TAccountPayer,
-    TAccountNewAccount,
-    TAccountBaseAccount
-  >);
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [
+            getAccountMeta(accounts.payer),
+            getAccountMeta(accounts.newAccount),
+            getAccountMeta(accounts.baseAccount),
+        ],
+        data: getCreateAccountWithSeedInstructionDataEncoder().encode(args as CreateAccountWithSeedInstructionDataArgs),
+        programAddress,
+    } as CreateAccountWithSeedInstruction<TProgramAddress, TAccountPayer, TAccountNewAccount, TAccountBaseAccount>);
 }
 
 export type ParsedCreateAccountWithSeedInstruction<
-  TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    payer: TAccountMetas[0];
-    newAccount: TAccountMetas[1];
-    baseAccount: TAccountMetas[2];
-  };
-  data: CreateAccountWithSeedInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        payer: TAccountMetas[0];
+        newAccount: TAccountMetas[1];
+        baseAccount: TAccountMetas[2];
+    };
+    data: CreateAccountWithSeedInstructionData;
 };
 
 export function parseCreateAccountWithSeedInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
+    TProgram extends string,
+    TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedCreateAccountWithSeedInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 3) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: {
-      payer: getNextAccount(),
-      newAccount: getNextAccount(),
-      baseAccount: getNextAccount(),
-    },
-    data: getCreateAccountWithSeedInstructionDataDecoder().decode(
-      instruction.data
-    ),
-  };
+    if (instruction.accounts.length < 3) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { payer: getNextAccount(), newAccount: getNextAccount(), baseAccount: getNextAccount() },
+        data: getCreateAccountWithSeedInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/system/src/generated/instructions/initializeNonceAccount.ts
+++ b/test/e2e/system/src/generated/instructions/initializeNonceAccount.ts
@@ -7,25 +7,25 @@
  */
 
 import {
-  combineCodec,
-  getAddressDecoder,
-  getAddressEncoder,
-  getStructDecoder,
-  getStructEncoder,
-  getU32Decoder,
-  getU32Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyAccount,
-  type ReadonlyUint8Array,
-  type WritableAccount,
+    combineCodec,
+    getAddressDecoder,
+    getAddressEncoder,
+    getStructDecoder,
+    getStructEncoder,
+    getU32Decoder,
+    getU32Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyAccount,
+    type ReadonlyUint8Array,
+    type WritableAccount,
 } from '@solana/kit';
 import { SYSTEM_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -33,191 +33,166 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const INITIALIZE_NONCE_ACCOUNT_DISCRIMINATOR = 6;
 
 export function getInitializeNonceAccountDiscriminatorBytes() {
-  return getU32Encoder().encode(INITIALIZE_NONCE_ACCOUNT_DISCRIMINATOR);
+    return getU32Encoder().encode(INITIALIZE_NONCE_ACCOUNT_DISCRIMINATOR);
 }
 
 export type InitializeNonceAccountInstruction<
-  TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountNonceAccount extends string | AccountMeta<string> = string,
-  TAccountRecentBlockhashesSysvar extends string | AccountMeta<string> =
-    'SysvarRecentB1ockHashes11111111111111111111',
-  TAccountRentSysvar extends string | AccountMeta<string> =
-    'SysvarRent111111111111111111111111111111111',
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountNonceAccount extends string | AccountMeta<string> = string,
+    TAccountRecentBlockhashesSysvar extends string | AccountMeta<string> =
+        'SysvarRecentB1ockHashes11111111111111111111',
+    TAccountRentSysvar extends string | AccountMeta<string> = 'SysvarRent111111111111111111111111111111111',
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountNonceAccount extends string
-        ? WritableAccount<TAccountNonceAccount>
-        : TAccountNonceAccount,
-      TAccountRecentBlockhashesSysvar extends string
-        ? ReadonlyAccount<TAccountRecentBlockhashesSysvar>
-        : TAccountRecentBlockhashesSysvar,
-      TAccountRentSysvar extends string
-        ? ReadonlyAccount<TAccountRentSysvar>
-        : TAccountRentSysvar,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountNonceAccount extends string ? WritableAccount<TAccountNonceAccount> : TAccountNonceAccount,
+            TAccountRecentBlockhashesSysvar extends string
+                ? ReadonlyAccount<TAccountRecentBlockhashesSysvar>
+                : TAccountRecentBlockhashesSysvar,
+            TAccountRentSysvar extends string ? ReadonlyAccount<TAccountRentSysvar> : TAccountRentSysvar,
+            ...TRemainingAccounts,
+        ]
+    >;
 
-export type InitializeNonceAccountInstructionData = {
-  discriminator: number;
-  nonceAuthority: Address;
-};
+export type InitializeNonceAccountInstructionData = { discriminator: number; nonceAuthority: Address };
 
-export type InitializeNonceAccountInstructionDataArgs = {
-  nonceAuthority: Address;
-};
+export type InitializeNonceAccountInstructionDataArgs = { nonceAuthority: Address };
 
 export function getInitializeNonceAccountInstructionDataEncoder(): FixedSizeEncoder<InitializeNonceAccountInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', getU32Encoder()],
-      ['nonceAuthority', getAddressEncoder()],
-    ]),
-    (value) => ({
-      ...value,
-      discriminator: INITIALIZE_NONCE_ACCOUNT_DISCRIMINATOR,
-    })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', getU32Encoder()],
+            ['nonceAuthority', getAddressEncoder()],
+        ]),
+        value => ({ ...value, discriminator: INITIALIZE_NONCE_ACCOUNT_DISCRIMINATOR })
+    );
 }
 
 export function getInitializeNonceAccountInstructionDataDecoder(): FixedSizeDecoder<InitializeNonceAccountInstructionData> {
-  return getStructDecoder([
-    ['discriminator', getU32Decoder()],
-    ['nonceAuthority', getAddressDecoder()],
-  ]);
+    return getStructDecoder([
+        ['discriminator', getU32Decoder()],
+        ['nonceAuthority', getAddressDecoder()],
+    ]);
 }
 
 export function getInitializeNonceAccountInstructionDataCodec(): FixedSizeCodec<
-  InitializeNonceAccountInstructionDataArgs,
-  InitializeNonceAccountInstructionData
+    InitializeNonceAccountInstructionDataArgs,
+    InitializeNonceAccountInstructionData
 > {
-  return combineCodec(
-    getInitializeNonceAccountInstructionDataEncoder(),
-    getInitializeNonceAccountInstructionDataDecoder()
-  );
+    return combineCodec(
+        getInitializeNonceAccountInstructionDataEncoder(),
+        getInitializeNonceAccountInstructionDataDecoder()
+    );
 }
 
 export type InitializeNonceAccountInput<
-  TAccountNonceAccount extends string = string,
-  TAccountRecentBlockhashesSysvar extends string = string,
-  TAccountRentSysvar extends string = string,
+    TAccountNonceAccount extends string = string,
+    TAccountRecentBlockhashesSysvar extends string = string,
+    TAccountRentSysvar extends string = string,
 > = {
-  nonceAccount: Address<TAccountNonceAccount>;
-  recentBlockhashesSysvar?: Address<TAccountRecentBlockhashesSysvar>;
-  rentSysvar?: Address<TAccountRentSysvar>;
-  nonceAuthority: InitializeNonceAccountInstructionDataArgs['nonceAuthority'];
+    nonceAccount: Address<TAccountNonceAccount>;
+    recentBlockhashesSysvar?: Address<TAccountRecentBlockhashesSysvar>;
+    rentSysvar?: Address<TAccountRentSysvar>;
+    nonceAuthority: InitializeNonceAccountInstructionDataArgs['nonceAuthority'];
 };
 
 export function getInitializeNonceAccountInstruction<
-  TAccountNonceAccount extends string,
-  TAccountRecentBlockhashesSysvar extends string,
-  TAccountRentSysvar extends string,
-  TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountNonceAccount extends string,
+    TAccountRecentBlockhashesSysvar extends string,
+    TAccountRentSysvar extends string,
+    TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
 >(
-  input: InitializeNonceAccountInput<
-    TAccountNonceAccount,
-    TAccountRecentBlockhashesSysvar,
-    TAccountRentSysvar
-  >,
-  config?: { programAddress?: TProgramAddress }
+    input: InitializeNonceAccountInput<TAccountNonceAccount, TAccountRecentBlockhashesSysvar, TAccountRentSysvar>,
+    config?: { programAddress?: TProgramAddress }
 ): InitializeNonceAccountInstruction<
-  TProgramAddress,
-  TAccountNonceAccount,
-  TAccountRecentBlockhashesSysvar,
-  TAccountRentSysvar
-> {
-  // Program address.
-  const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
-
-  // Original accounts.
-  const originalAccounts = {
-    nonceAccount: { value: input.nonceAccount ?? null, isWritable: true },
-    recentBlockhashesSysvar: {
-      value: input.recentBlockhashesSysvar ?? null,
-      isWritable: false,
-    },
-    rentSysvar: { value: input.rentSysvar ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
-
-  // Original args.
-  const args = { ...input };
-
-  // Resolve default values.
-  if (!accounts.recentBlockhashesSysvar.value) {
-    accounts.recentBlockhashesSysvar.value =
-      'SysvarRecentB1ockHashes11111111111111111111' as Address<'SysvarRecentB1ockHashes11111111111111111111'>;
-  }
-  if (!accounts.rentSysvar.value) {
-    accounts.rentSysvar.value =
-      'SysvarRent111111111111111111111111111111111' as Address<'SysvarRent111111111111111111111111111111111'>;
-  }
-
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.nonceAccount),
-      getAccountMeta(accounts.recentBlockhashesSysvar),
-      getAccountMeta(accounts.rentSysvar),
-    ],
-    data: getInitializeNonceAccountInstructionDataEncoder().encode(
-      args as InitializeNonceAccountInstructionDataArgs
-    ),
-    programAddress,
-  } as InitializeNonceAccountInstruction<
     TProgramAddress,
     TAccountNonceAccount,
     TAccountRecentBlockhashesSysvar,
     TAccountRentSysvar
-  >);
+> {
+    // Program address.
+    const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
+
+    // Original accounts.
+    const originalAccounts = {
+        nonceAccount: { value: input.nonceAccount ?? null, isWritable: true },
+        recentBlockhashesSysvar: { value: input.recentBlockhashesSysvar ?? null, isWritable: false },
+        rentSysvar: { value: input.rentSysvar ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
+
+    // Original args.
+    const args = { ...input };
+
+    // Resolve default values.
+    if (!accounts.recentBlockhashesSysvar.value) {
+        accounts.recentBlockhashesSysvar.value =
+            'SysvarRecentB1ockHashes11111111111111111111' as Address<'SysvarRecentB1ockHashes11111111111111111111'>;
+    }
+    if (!accounts.rentSysvar.value) {
+        accounts.rentSysvar.value =
+            'SysvarRent111111111111111111111111111111111' as Address<'SysvarRent111111111111111111111111111111111'>;
+    }
+
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [
+            getAccountMeta(accounts.nonceAccount),
+            getAccountMeta(accounts.recentBlockhashesSysvar),
+            getAccountMeta(accounts.rentSysvar),
+        ],
+        data: getInitializeNonceAccountInstructionDataEncoder().encode(
+            args as InitializeNonceAccountInstructionDataArgs
+        ),
+        programAddress,
+    } as InitializeNonceAccountInstruction<
+        TProgramAddress,
+        TAccountNonceAccount,
+        TAccountRecentBlockhashesSysvar,
+        TAccountRentSysvar
+    >);
 }
 
 export type ParsedInitializeNonceAccountInstruction<
-  TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    nonceAccount: TAccountMetas[0];
-    recentBlockhashesSysvar: TAccountMetas[1];
-    rentSysvar: TAccountMetas[2];
-  };
-  data: InitializeNonceAccountInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        nonceAccount: TAccountMetas[0];
+        recentBlockhashesSysvar: TAccountMetas[1];
+        rentSysvar: TAccountMetas[2];
+    };
+    data: InitializeNonceAccountInstructionData;
 };
 
 export function parseInitializeNonceAccountInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
+    TProgram extends string,
+    TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedInitializeNonceAccountInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 3) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: {
-      nonceAccount: getNextAccount(),
-      recentBlockhashesSysvar: getNextAccount(),
-      rentSysvar: getNextAccount(),
-    },
-    data: getInitializeNonceAccountInstructionDataDecoder().decode(
-      instruction.data
-    ),
-  };
+    if (instruction.accounts.length < 3) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: {
+            nonceAccount: getNextAccount(),
+            recentBlockhashesSysvar: getNextAccount(),
+            rentSysvar: getNextAccount(),
+        },
+        data: getInitializeNonceAccountInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/system/src/generated/instructions/transferSol.ts
+++ b/test/e2e/system/src/generated/instructions/transferSol.ts
@@ -7,27 +7,27 @@
  */
 
 import {
-  combineCodec,
-  getStructDecoder,
-  getStructEncoder,
-  getU32Decoder,
-  getU32Encoder,
-  getU64Decoder,
-  getU64Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyUint8Array,
-  type TransactionSigner,
-  type WritableAccount,
-  type WritableSignerAccount,
+    combineCodec,
+    getStructDecoder,
+    getStructEncoder,
+    getU32Decoder,
+    getU32Encoder,
+    getU64Decoder,
+    getU64Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyUint8Array,
+    type TransactionSigner,
+    type WritableAccount,
+    type WritableSignerAccount,
 } from '@solana/kit';
 import { SYSTEM_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -35,150 +35,119 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const TRANSFER_SOL_DISCRIMINATOR = 2;
 
 export function getTransferSolDiscriminatorBytes() {
-  return getU32Encoder().encode(TRANSFER_SOL_DISCRIMINATOR);
+    return getU32Encoder().encode(TRANSFER_SOL_DISCRIMINATOR);
 }
 
 export type TransferSolInstruction<
-  TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountSource extends string | AccountMeta<string> = string,
-  TAccountDestination extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountSource extends string | AccountMeta<string> = string,
+    TAccountDestination extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountSource extends string
-        ? WritableSignerAccount<TAccountSource> &
-            AccountSignerMeta<TAccountSource>
-        : TAccountSource,
-      TAccountDestination extends string
-        ? WritableAccount<TAccountDestination>
-        : TAccountDestination,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountSource extends string
+                ? WritableSignerAccount<TAccountSource> & AccountSignerMeta<TAccountSource>
+                : TAccountSource,
+            TAccountDestination extends string ? WritableAccount<TAccountDestination> : TAccountDestination,
+            ...TRemainingAccounts,
+        ]
+    >;
 
-export type TransferSolInstructionData = {
-  discriminator: number;
-  amount: bigint;
-};
+export type TransferSolInstructionData = { discriminator: number; amount: bigint };
 
 export type TransferSolInstructionDataArgs = { amount: number | bigint };
 
 export function getTransferSolInstructionDataEncoder(): FixedSizeEncoder<TransferSolInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', getU32Encoder()],
-      ['amount', getU64Encoder()],
-    ]),
-    (value) => ({ ...value, discriminator: TRANSFER_SOL_DISCRIMINATOR })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', getU32Encoder()],
+            ['amount', getU64Encoder()],
+        ]),
+        value => ({ ...value, discriminator: TRANSFER_SOL_DISCRIMINATOR })
+    );
 }
 
 export function getTransferSolInstructionDataDecoder(): FixedSizeDecoder<TransferSolInstructionData> {
-  return getStructDecoder([
-    ['discriminator', getU32Decoder()],
-    ['amount', getU64Decoder()],
-  ]);
+    return getStructDecoder([
+        ['discriminator', getU32Decoder()],
+        ['amount', getU64Decoder()],
+    ]);
 }
 
 export function getTransferSolInstructionDataCodec(): FixedSizeCodec<
-  TransferSolInstructionDataArgs,
-  TransferSolInstructionData
+    TransferSolInstructionDataArgs,
+    TransferSolInstructionData
 > {
-  return combineCodec(
-    getTransferSolInstructionDataEncoder(),
-    getTransferSolInstructionDataDecoder()
-  );
+    return combineCodec(getTransferSolInstructionDataEncoder(), getTransferSolInstructionDataDecoder());
 }
 
-export type TransferSolInput<
-  TAccountSource extends string = string,
-  TAccountDestination extends string = string,
-> = {
-  source: TransactionSigner<TAccountSource>;
-  destination: Address<TAccountDestination>;
-  amount: TransferSolInstructionDataArgs['amount'];
+export type TransferSolInput<TAccountSource extends string = string, TAccountDestination extends string = string> = {
+    source: TransactionSigner<TAccountSource>;
+    destination: Address<TAccountDestination>;
+    amount: TransferSolInstructionDataArgs['amount'];
 };
 
 export function getTransferSolInstruction<
-  TAccountSource extends string,
-  TAccountDestination extends string,
-  TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountSource extends string,
+    TAccountDestination extends string,
+    TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
 >(
-  input: TransferSolInput<TAccountSource, TAccountDestination>,
-  config?: { programAddress?: TProgramAddress }
-): TransferSolInstruction<
-  TProgramAddress,
-  TAccountSource,
-  TAccountDestination
-> {
-  // Program address.
-  const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
+    input: TransferSolInput<TAccountSource, TAccountDestination>,
+    config?: { programAddress?: TProgramAddress }
+): TransferSolInstruction<TProgramAddress, TAccountSource, TAccountDestination> {
+    // Program address.
+    const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
 
-  // Original accounts.
-  const originalAccounts = {
-    source: { value: input.source ?? null, isWritable: true },
-    destination: { value: input.destination ?? null, isWritable: true },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
+    // Original accounts.
+    const originalAccounts = {
+        source: { value: input.source ?? null, isWritable: true },
+        destination: { value: input.destination ?? null, isWritable: true },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
 
-  // Original args.
-  const args = { ...input };
+    // Original args.
+    const args = { ...input };
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.source),
-      getAccountMeta(accounts.destination),
-    ],
-    data: getTransferSolInstructionDataEncoder().encode(
-      args as TransferSolInstructionDataArgs
-    ),
-    programAddress,
-  } as TransferSolInstruction<
-    TProgramAddress,
-    TAccountSource,
-    TAccountDestination
-  >);
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [getAccountMeta(accounts.source), getAccountMeta(accounts.destination)],
+        data: getTransferSolInstructionDataEncoder().encode(args as TransferSolInstructionDataArgs),
+        programAddress,
+    } as TransferSolInstruction<TProgramAddress, TAccountSource, TAccountDestination>);
 }
 
 export type ParsedTransferSolInstruction<
-  TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    source: TAccountMetas[0];
-    destination: TAccountMetas[1];
-  };
-  data: TransferSolInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        source: TAccountMetas[0];
+        destination: TAccountMetas[1];
+    };
+    data: TransferSolInstructionData;
 };
 
-export function parseTransferSolInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
->(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+export function parseTransferSolInstruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedTransferSolInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 2) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: { source: getNextAccount(), destination: getNextAccount() },
-    data: getTransferSolInstructionDataDecoder().decode(instruction.data),
-  };
+    if (instruction.accounts.length < 2) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { source: getNextAccount(), destination: getNextAccount() },
+        data: getTransferSolInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/system/src/generated/instructions/transferSolWithSeed.ts
+++ b/test/e2e/system/src/generated/instructions/transferSolWithSeed.ts
@@ -7,33 +7,33 @@
  */
 
 import {
-  addDecoderSizePrefix,
-  addEncoderSizePrefix,
-  combineCodec,
-  getAddressDecoder,
-  getAddressEncoder,
-  getStructDecoder,
-  getStructEncoder,
-  getU32Decoder,
-  getU32Encoder,
-  getU64Decoder,
-  getU64Encoder,
-  getUtf8Decoder,
-  getUtf8Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type Codec,
-  type Decoder,
-  type Encoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlySignerAccount,
-  type ReadonlyUint8Array,
-  type TransactionSigner,
-  type WritableAccount,
+    addDecoderSizePrefix,
+    addEncoderSizePrefix,
+    combineCodec,
+    getAddressDecoder,
+    getAddressEncoder,
+    getStructDecoder,
+    getStructEncoder,
+    getU32Decoder,
+    getU32Encoder,
+    getU64Decoder,
+    getU64Encoder,
+    getUtf8Decoder,
+    getUtf8Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type Codec,
+    type Decoder,
+    type Encoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlySignerAccount,
+    type ReadonlyUint8Array,
+    type TransactionSigner,
+    type WritableAccount,
 } from '@solana/kit';
 import { SYSTEM_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -41,187 +41,147 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const TRANSFER_SOL_WITH_SEED_DISCRIMINATOR = 11;
 
 export function getTransferSolWithSeedDiscriminatorBytes() {
-  return getU32Encoder().encode(TRANSFER_SOL_WITH_SEED_DISCRIMINATOR);
+    return getU32Encoder().encode(TRANSFER_SOL_WITH_SEED_DISCRIMINATOR);
 }
 
 export type TransferSolWithSeedInstruction<
-  TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountSource extends string | AccountMeta<string> = string,
-  TAccountBaseAccount extends string | AccountMeta<string> = string,
-  TAccountDestination extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountSource extends string | AccountMeta<string> = string,
+    TAccountBaseAccount extends string | AccountMeta<string> = string,
+    TAccountDestination extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountSource extends string
-        ? WritableAccount<TAccountSource>
-        : TAccountSource,
-      TAccountBaseAccount extends string
-        ? ReadonlySignerAccount<TAccountBaseAccount> &
-            AccountSignerMeta<TAccountBaseAccount>
-        : TAccountBaseAccount,
-      TAccountDestination extends string
-        ? WritableAccount<TAccountDestination>
-        : TAccountDestination,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountSource extends string ? WritableAccount<TAccountSource> : TAccountSource,
+            TAccountBaseAccount extends string
+                ? ReadonlySignerAccount<TAccountBaseAccount> & AccountSignerMeta<TAccountBaseAccount>
+                : TAccountBaseAccount,
+            TAccountDestination extends string ? WritableAccount<TAccountDestination> : TAccountDestination,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type TransferSolWithSeedInstructionData = {
-  discriminator: number;
-  amount: bigint;
-  fromSeed: string;
-  fromOwner: Address;
+    discriminator: number;
+    amount: bigint;
+    fromSeed: string;
+    fromOwner: Address;
 };
 
-export type TransferSolWithSeedInstructionDataArgs = {
-  amount: number | bigint;
-  fromSeed: string;
-  fromOwner: Address;
-};
+export type TransferSolWithSeedInstructionDataArgs = { amount: number | bigint; fromSeed: string; fromOwner: Address };
 
 export function getTransferSolWithSeedInstructionDataEncoder(): Encoder<TransferSolWithSeedInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', getU32Encoder()],
-      ['amount', getU64Encoder()],
-      ['fromSeed', addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
-      ['fromOwner', getAddressEncoder()],
-    ]),
-    (value) => ({
-      ...value,
-      discriminator: TRANSFER_SOL_WITH_SEED_DISCRIMINATOR,
-    })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', getU32Encoder()],
+            ['amount', getU64Encoder()],
+            ['fromSeed', addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
+            ['fromOwner', getAddressEncoder()],
+        ]),
+        value => ({ ...value, discriminator: TRANSFER_SOL_WITH_SEED_DISCRIMINATOR })
+    );
 }
 
 export function getTransferSolWithSeedInstructionDataDecoder(): Decoder<TransferSolWithSeedInstructionData> {
-  return getStructDecoder([
-    ['discriminator', getU32Decoder()],
-    ['amount', getU64Decoder()],
-    ['fromSeed', addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())],
-    ['fromOwner', getAddressDecoder()],
-  ]);
+    return getStructDecoder([
+        ['discriminator', getU32Decoder()],
+        ['amount', getU64Decoder()],
+        ['fromSeed', addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())],
+        ['fromOwner', getAddressDecoder()],
+    ]);
 }
 
 export function getTransferSolWithSeedInstructionDataCodec(): Codec<
-  TransferSolWithSeedInstructionDataArgs,
-  TransferSolWithSeedInstructionData
+    TransferSolWithSeedInstructionDataArgs,
+    TransferSolWithSeedInstructionData
 > {
-  return combineCodec(
-    getTransferSolWithSeedInstructionDataEncoder(),
-    getTransferSolWithSeedInstructionDataDecoder()
-  );
+    return combineCodec(getTransferSolWithSeedInstructionDataEncoder(), getTransferSolWithSeedInstructionDataDecoder());
 }
 
 export type TransferSolWithSeedInput<
-  TAccountSource extends string = string,
-  TAccountBaseAccount extends string = string,
-  TAccountDestination extends string = string,
+    TAccountSource extends string = string,
+    TAccountBaseAccount extends string = string,
+    TAccountDestination extends string = string,
 > = {
-  source: Address<TAccountSource>;
-  baseAccount: TransactionSigner<TAccountBaseAccount>;
-  destination: Address<TAccountDestination>;
-  amount: TransferSolWithSeedInstructionDataArgs['amount'];
-  fromSeed: TransferSolWithSeedInstructionDataArgs['fromSeed'];
-  fromOwner: TransferSolWithSeedInstructionDataArgs['fromOwner'];
+    source: Address<TAccountSource>;
+    baseAccount: TransactionSigner<TAccountBaseAccount>;
+    destination: Address<TAccountDestination>;
+    amount: TransferSolWithSeedInstructionDataArgs['amount'];
+    fromSeed: TransferSolWithSeedInstructionDataArgs['fromSeed'];
+    fromOwner: TransferSolWithSeedInstructionDataArgs['fromOwner'];
 };
 
 export function getTransferSolWithSeedInstruction<
-  TAccountSource extends string,
-  TAccountBaseAccount extends string,
-  TAccountDestination extends string,
-  TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountSource extends string,
+    TAccountBaseAccount extends string,
+    TAccountDestination extends string,
+    TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
 >(
-  input: TransferSolWithSeedInput<
-    TAccountSource,
-    TAccountBaseAccount,
-    TAccountDestination
-  >,
-  config?: { programAddress?: TProgramAddress }
-): TransferSolWithSeedInstruction<
-  TProgramAddress,
-  TAccountSource,
-  TAccountBaseAccount,
-  TAccountDestination
-> {
-  // Program address.
-  const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
+    input: TransferSolWithSeedInput<TAccountSource, TAccountBaseAccount, TAccountDestination>,
+    config?: { programAddress?: TProgramAddress }
+): TransferSolWithSeedInstruction<TProgramAddress, TAccountSource, TAccountBaseAccount, TAccountDestination> {
+    // Program address.
+    const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
 
-  // Original accounts.
-  const originalAccounts = {
-    source: { value: input.source ?? null, isWritable: true },
-    baseAccount: { value: input.baseAccount ?? null, isWritable: false },
-    destination: { value: input.destination ?? null, isWritable: true },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
+    // Original accounts.
+    const originalAccounts = {
+        source: { value: input.source ?? null, isWritable: true },
+        baseAccount: { value: input.baseAccount ?? null, isWritable: false },
+        destination: { value: input.destination ?? null, isWritable: true },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
 
-  // Original args.
-  const args = { ...input };
+    // Original args.
+    const args = { ...input };
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.source),
-      getAccountMeta(accounts.baseAccount),
-      getAccountMeta(accounts.destination),
-    ],
-    data: getTransferSolWithSeedInstructionDataEncoder().encode(
-      args as TransferSolWithSeedInstructionDataArgs
-    ),
-    programAddress,
-  } as TransferSolWithSeedInstruction<
-    TProgramAddress,
-    TAccountSource,
-    TAccountBaseAccount,
-    TAccountDestination
-  >);
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [
+            getAccountMeta(accounts.source),
+            getAccountMeta(accounts.baseAccount),
+            getAccountMeta(accounts.destination),
+        ],
+        data: getTransferSolWithSeedInstructionDataEncoder().encode(args as TransferSolWithSeedInstructionDataArgs),
+        programAddress,
+    } as TransferSolWithSeedInstruction<TProgramAddress, TAccountSource, TAccountBaseAccount, TAccountDestination>);
 }
 
 export type ParsedTransferSolWithSeedInstruction<
-  TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    source: TAccountMetas[0];
-    baseAccount: TAccountMetas[1];
-    destination: TAccountMetas[2];
-  };
-  data: TransferSolWithSeedInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        source: TAccountMetas[0];
+        baseAccount: TAccountMetas[1];
+        destination: TAccountMetas[2];
+    };
+    data: TransferSolWithSeedInstructionData;
 };
 
 export function parseTransferSolWithSeedInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
+    TProgram extends string,
+    TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedTransferSolWithSeedInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 3) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: {
-      source: getNextAccount(),
-      baseAccount: getNextAccount(),
-      destination: getNextAccount(),
-    },
-    data: getTransferSolWithSeedInstructionDataDecoder().decode(
-      instruction.data
-    ),
-  };
+    if (instruction.accounts.length < 3) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { source: getNextAccount(), baseAccount: getNextAccount(), destination: getNextAccount() },
+        data: getTransferSolWithSeedInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/system/src/generated/instructions/upgradeNonceAccount.ts
+++ b/test/e2e/system/src/generated/instructions/upgradeNonceAccount.ts
@@ -7,22 +7,22 @@
  */
 
 import {
-  combineCodec,
-  getStructDecoder,
-  getStructEncoder,
-  getU32Decoder,
-  getU32Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyUint8Array,
-  type WritableAccount,
+    combineCodec,
+    getStructDecoder,
+    getStructEncoder,
+    getU32Decoder,
+    getU32Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyUint8Array,
+    type WritableAccount,
 } from '@solana/kit';
 import { SYSTEM_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -30,119 +30,102 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const UPGRADE_NONCE_ACCOUNT_DISCRIMINATOR = 12;
 
 export function getUpgradeNonceAccountDiscriminatorBytes() {
-  return getU32Encoder().encode(UPGRADE_NONCE_ACCOUNT_DISCRIMINATOR);
+    return getU32Encoder().encode(UPGRADE_NONCE_ACCOUNT_DISCRIMINATOR);
 }
 
 export type UpgradeNonceAccountInstruction<
-  TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountNonceAccount extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountNonceAccount extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountNonceAccount extends string
-        ? WritableAccount<TAccountNonceAccount>
-        : TAccountNonceAccount,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountNonceAccount extends string ? WritableAccount<TAccountNonceAccount> : TAccountNonceAccount,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type UpgradeNonceAccountInstructionData = { discriminator: number };
 
 export type UpgradeNonceAccountInstructionDataArgs = {};
 
 export function getUpgradeNonceAccountInstructionDataEncoder(): FixedSizeEncoder<UpgradeNonceAccountInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([['discriminator', getU32Encoder()]]),
-    (value) => ({
-      ...value,
-      discriminator: UPGRADE_NONCE_ACCOUNT_DISCRIMINATOR,
-    })
-  );
+    return transformEncoder(getStructEncoder([['discriminator', getU32Encoder()]]), value => ({
+        ...value,
+        discriminator: UPGRADE_NONCE_ACCOUNT_DISCRIMINATOR,
+    }));
 }
 
 export function getUpgradeNonceAccountInstructionDataDecoder(): FixedSizeDecoder<UpgradeNonceAccountInstructionData> {
-  return getStructDecoder([['discriminator', getU32Decoder()]]);
+    return getStructDecoder([['discriminator', getU32Decoder()]]);
 }
 
 export function getUpgradeNonceAccountInstructionDataCodec(): FixedSizeCodec<
-  UpgradeNonceAccountInstructionDataArgs,
-  UpgradeNonceAccountInstructionData
+    UpgradeNonceAccountInstructionDataArgs,
+    UpgradeNonceAccountInstructionData
 > {
-  return combineCodec(
-    getUpgradeNonceAccountInstructionDataEncoder(),
-    getUpgradeNonceAccountInstructionDataDecoder()
-  );
+    return combineCodec(getUpgradeNonceAccountInstructionDataEncoder(), getUpgradeNonceAccountInstructionDataDecoder());
 }
 
-export type UpgradeNonceAccountInput<
-  TAccountNonceAccount extends string = string,
-> = {
-  nonceAccount: Address<TAccountNonceAccount>;
+export type UpgradeNonceAccountInput<TAccountNonceAccount extends string = string> = {
+    nonceAccount: Address<TAccountNonceAccount>;
 };
 
 export function getUpgradeNonceAccountInstruction<
-  TAccountNonceAccount extends string,
-  TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountNonceAccount extends string,
+    TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
 >(
-  input: UpgradeNonceAccountInput<TAccountNonceAccount>,
-  config?: { programAddress?: TProgramAddress }
+    input: UpgradeNonceAccountInput<TAccountNonceAccount>,
+    config?: { programAddress?: TProgramAddress }
 ): UpgradeNonceAccountInstruction<TProgramAddress, TAccountNonceAccount> {
-  // Program address.
-  const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
+    // Program address.
+    const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
 
-  // Original accounts.
-  const originalAccounts = {
-    nonceAccount: { value: input.nonceAccount ?? null, isWritable: true },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
+    // Original accounts.
+    const originalAccounts = { nonceAccount: { value: input.nonceAccount ?? null, isWritable: true } };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [getAccountMeta(accounts.nonceAccount)],
-    data: getUpgradeNonceAccountInstructionDataEncoder().encode({}),
-    programAddress,
-  } as UpgradeNonceAccountInstruction<TProgramAddress, TAccountNonceAccount>);
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [getAccountMeta(accounts.nonceAccount)],
+        data: getUpgradeNonceAccountInstructionDataEncoder().encode({}),
+        programAddress,
+    } as UpgradeNonceAccountInstruction<TProgramAddress, TAccountNonceAccount>);
 }
 
 export type ParsedUpgradeNonceAccountInstruction<
-  TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    nonceAccount: TAccountMetas[0];
-  };
-  data: UpgradeNonceAccountInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        nonceAccount: TAccountMetas[0];
+    };
+    data: UpgradeNonceAccountInstructionData;
 };
 
 export function parseUpgradeNonceAccountInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
+    TProgram extends string,
+    TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedUpgradeNonceAccountInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 1) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: { nonceAccount: getNextAccount() },
-    data: getUpgradeNonceAccountInstructionDataDecoder().decode(
-      instruction.data
-    ),
-  };
+    if (instruction.accounts.length < 1) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { nonceAccount: getNextAccount() },
+        data: getUpgradeNonceAccountInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/system/src/generated/instructions/withdrawNonceAccount.ts
+++ b/test/e2e/system/src/generated/instructions/withdrawNonceAccount.ts
@@ -7,28 +7,28 @@
  */
 
 import {
-  combineCodec,
-  getStructDecoder,
-  getStructEncoder,
-  getU32Decoder,
-  getU32Encoder,
-  getU64Decoder,
-  getU64Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyAccount,
-  type ReadonlySignerAccount,
-  type ReadonlyUint8Array,
-  type TransactionSigner,
-  type WritableAccount,
+    combineCodec,
+    getStructDecoder,
+    getStructEncoder,
+    getU32Decoder,
+    getU32Encoder,
+    getU64Decoder,
+    getU64Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyAccount,
+    type ReadonlySignerAccount,
+    type ReadonlyUint8Array,
+    type TransactionSigner,
+    type WritableAccount,
 } from '@solana/kit';
 import { SYSTEM_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -36,223 +36,196 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const WITHDRAW_NONCE_ACCOUNT_DISCRIMINATOR = 5;
 
 export function getWithdrawNonceAccountDiscriminatorBytes() {
-  return getU32Encoder().encode(WITHDRAW_NONCE_ACCOUNT_DISCRIMINATOR);
+    return getU32Encoder().encode(WITHDRAW_NONCE_ACCOUNT_DISCRIMINATOR);
 }
 
 export type WithdrawNonceAccountInstruction<
-  TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountNonceAccount extends string | AccountMeta<string> = string,
-  TAccountRecipientAccount extends string | AccountMeta<string> = string,
-  TAccountRecentBlockhashesSysvar extends string | AccountMeta<string> =
-    'SysvarRecentB1ockHashes11111111111111111111',
-  TAccountRentSysvar extends string | AccountMeta<string> =
-    'SysvarRent111111111111111111111111111111111',
-  TAccountNonceAuthority extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountNonceAccount extends string | AccountMeta<string> = string,
+    TAccountRecipientAccount extends string | AccountMeta<string> = string,
+    TAccountRecentBlockhashesSysvar extends string | AccountMeta<string> =
+        'SysvarRecentB1ockHashes11111111111111111111',
+    TAccountRentSysvar extends string | AccountMeta<string> = 'SysvarRent111111111111111111111111111111111',
+    TAccountNonceAuthority extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountNonceAccount extends string
-        ? WritableAccount<TAccountNonceAccount>
-        : TAccountNonceAccount,
-      TAccountRecipientAccount extends string
-        ? WritableAccount<TAccountRecipientAccount>
-        : TAccountRecipientAccount,
-      TAccountRecentBlockhashesSysvar extends string
-        ? ReadonlyAccount<TAccountRecentBlockhashesSysvar>
-        : TAccountRecentBlockhashesSysvar,
-      TAccountRentSysvar extends string
-        ? ReadonlyAccount<TAccountRentSysvar>
-        : TAccountRentSysvar,
-      TAccountNonceAuthority extends string
-        ? ReadonlySignerAccount<TAccountNonceAuthority> &
-            AccountSignerMeta<TAccountNonceAuthority>
-        : TAccountNonceAuthority,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountNonceAccount extends string ? WritableAccount<TAccountNonceAccount> : TAccountNonceAccount,
+            TAccountRecipientAccount extends string
+                ? WritableAccount<TAccountRecipientAccount>
+                : TAccountRecipientAccount,
+            TAccountRecentBlockhashesSysvar extends string
+                ? ReadonlyAccount<TAccountRecentBlockhashesSysvar>
+                : TAccountRecentBlockhashesSysvar,
+            TAccountRentSysvar extends string ? ReadonlyAccount<TAccountRentSysvar> : TAccountRentSysvar,
+            TAccountNonceAuthority extends string
+                ? ReadonlySignerAccount<TAccountNonceAuthority> & AccountSignerMeta<TAccountNonceAuthority>
+                : TAccountNonceAuthority,
+            ...TRemainingAccounts,
+        ]
+    >;
 
-export type WithdrawNonceAccountInstructionData = {
-  discriminator: number;
-  withdrawAmount: bigint;
-};
+export type WithdrawNonceAccountInstructionData = { discriminator: number; withdrawAmount: bigint };
 
-export type WithdrawNonceAccountInstructionDataArgs = {
-  withdrawAmount: number | bigint;
-};
+export type WithdrawNonceAccountInstructionDataArgs = { withdrawAmount: number | bigint };
 
 export function getWithdrawNonceAccountInstructionDataEncoder(): FixedSizeEncoder<WithdrawNonceAccountInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', getU32Encoder()],
-      ['withdrawAmount', getU64Encoder()],
-    ]),
-    (value) => ({
-      ...value,
-      discriminator: WITHDRAW_NONCE_ACCOUNT_DISCRIMINATOR,
-    })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', getU32Encoder()],
+            ['withdrawAmount', getU64Encoder()],
+        ]),
+        value => ({ ...value, discriminator: WITHDRAW_NONCE_ACCOUNT_DISCRIMINATOR })
+    );
 }
 
 export function getWithdrawNonceAccountInstructionDataDecoder(): FixedSizeDecoder<WithdrawNonceAccountInstructionData> {
-  return getStructDecoder([
-    ['discriminator', getU32Decoder()],
-    ['withdrawAmount', getU64Decoder()],
-  ]);
+    return getStructDecoder([
+        ['discriminator', getU32Decoder()],
+        ['withdrawAmount', getU64Decoder()],
+    ]);
 }
 
 export function getWithdrawNonceAccountInstructionDataCodec(): FixedSizeCodec<
-  WithdrawNonceAccountInstructionDataArgs,
-  WithdrawNonceAccountInstructionData
+    WithdrawNonceAccountInstructionDataArgs,
+    WithdrawNonceAccountInstructionData
 > {
-  return combineCodec(
-    getWithdrawNonceAccountInstructionDataEncoder(),
-    getWithdrawNonceAccountInstructionDataDecoder()
-  );
+    return combineCodec(
+        getWithdrawNonceAccountInstructionDataEncoder(),
+        getWithdrawNonceAccountInstructionDataDecoder()
+    );
 }
 
 export type WithdrawNonceAccountInput<
-  TAccountNonceAccount extends string = string,
-  TAccountRecipientAccount extends string = string,
-  TAccountRecentBlockhashesSysvar extends string = string,
-  TAccountRentSysvar extends string = string,
-  TAccountNonceAuthority extends string = string,
+    TAccountNonceAccount extends string = string,
+    TAccountRecipientAccount extends string = string,
+    TAccountRecentBlockhashesSysvar extends string = string,
+    TAccountRentSysvar extends string = string,
+    TAccountNonceAuthority extends string = string,
 > = {
-  nonceAccount: Address<TAccountNonceAccount>;
-  recipientAccount: Address<TAccountRecipientAccount>;
-  recentBlockhashesSysvar?: Address<TAccountRecentBlockhashesSysvar>;
-  rentSysvar?: Address<TAccountRentSysvar>;
-  nonceAuthority: TransactionSigner<TAccountNonceAuthority>;
-  withdrawAmount: WithdrawNonceAccountInstructionDataArgs['withdrawAmount'];
+    nonceAccount: Address<TAccountNonceAccount>;
+    recipientAccount: Address<TAccountRecipientAccount>;
+    recentBlockhashesSysvar?: Address<TAccountRecentBlockhashesSysvar>;
+    rentSysvar?: Address<TAccountRentSysvar>;
+    nonceAuthority: TransactionSigner<TAccountNonceAuthority>;
+    withdrawAmount: WithdrawNonceAccountInstructionDataArgs['withdrawAmount'];
 };
 
 export function getWithdrawNonceAccountInstruction<
-  TAccountNonceAccount extends string,
-  TAccountRecipientAccount extends string,
-  TAccountRecentBlockhashesSysvar extends string,
-  TAccountRentSysvar extends string,
-  TAccountNonceAuthority extends string,
-  TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountNonceAccount extends string,
+    TAccountRecipientAccount extends string,
+    TAccountRecentBlockhashesSysvar extends string,
+    TAccountRentSysvar extends string,
+    TAccountNonceAuthority extends string,
+    TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
 >(
-  input: WithdrawNonceAccountInput<
-    TAccountNonceAccount,
-    TAccountRecipientAccount,
-    TAccountRecentBlockhashesSysvar,
-    TAccountRentSysvar,
-    TAccountNonceAuthority
-  >,
-  config?: { programAddress?: TProgramAddress }
+    input: WithdrawNonceAccountInput<
+        TAccountNonceAccount,
+        TAccountRecipientAccount,
+        TAccountRecentBlockhashesSysvar,
+        TAccountRentSysvar,
+        TAccountNonceAuthority
+    >,
+    config?: { programAddress?: TProgramAddress }
 ): WithdrawNonceAccountInstruction<
-  TProgramAddress,
-  TAccountNonceAccount,
-  TAccountRecipientAccount,
-  TAccountRecentBlockhashesSysvar,
-  TAccountRentSysvar,
-  TAccountNonceAuthority
-> {
-  // Program address.
-  const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
-
-  // Original accounts.
-  const originalAccounts = {
-    nonceAccount: { value: input.nonceAccount ?? null, isWritable: true },
-    recipientAccount: {
-      value: input.recipientAccount ?? null,
-      isWritable: true,
-    },
-    recentBlockhashesSysvar: {
-      value: input.recentBlockhashesSysvar ?? null,
-      isWritable: false,
-    },
-    rentSysvar: { value: input.rentSysvar ?? null, isWritable: false },
-    nonceAuthority: { value: input.nonceAuthority ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
-
-  // Original args.
-  const args = { ...input };
-
-  // Resolve default values.
-  if (!accounts.recentBlockhashesSysvar.value) {
-    accounts.recentBlockhashesSysvar.value =
-      'SysvarRecentB1ockHashes11111111111111111111' as Address<'SysvarRecentB1ockHashes11111111111111111111'>;
-  }
-  if (!accounts.rentSysvar.value) {
-    accounts.rentSysvar.value =
-      'SysvarRent111111111111111111111111111111111' as Address<'SysvarRent111111111111111111111111111111111'>;
-  }
-
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.nonceAccount),
-      getAccountMeta(accounts.recipientAccount),
-      getAccountMeta(accounts.recentBlockhashesSysvar),
-      getAccountMeta(accounts.rentSysvar),
-      getAccountMeta(accounts.nonceAuthority),
-    ],
-    data: getWithdrawNonceAccountInstructionDataEncoder().encode(
-      args as WithdrawNonceAccountInstructionDataArgs
-    ),
-    programAddress,
-  } as WithdrawNonceAccountInstruction<
     TProgramAddress,
     TAccountNonceAccount,
     TAccountRecipientAccount,
     TAccountRecentBlockhashesSysvar,
     TAccountRentSysvar,
     TAccountNonceAuthority
-  >);
+> {
+    // Program address.
+    const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
+
+    // Original accounts.
+    const originalAccounts = {
+        nonceAccount: { value: input.nonceAccount ?? null, isWritable: true },
+        recipientAccount: { value: input.recipientAccount ?? null, isWritable: true },
+        recentBlockhashesSysvar: { value: input.recentBlockhashesSysvar ?? null, isWritable: false },
+        rentSysvar: { value: input.rentSysvar ?? null, isWritable: false },
+        nonceAuthority: { value: input.nonceAuthority ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
+
+    // Original args.
+    const args = { ...input };
+
+    // Resolve default values.
+    if (!accounts.recentBlockhashesSysvar.value) {
+        accounts.recentBlockhashesSysvar.value =
+            'SysvarRecentB1ockHashes11111111111111111111' as Address<'SysvarRecentB1ockHashes11111111111111111111'>;
+    }
+    if (!accounts.rentSysvar.value) {
+        accounts.rentSysvar.value =
+            'SysvarRent111111111111111111111111111111111' as Address<'SysvarRent111111111111111111111111111111111'>;
+    }
+
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [
+            getAccountMeta(accounts.nonceAccount),
+            getAccountMeta(accounts.recipientAccount),
+            getAccountMeta(accounts.recentBlockhashesSysvar),
+            getAccountMeta(accounts.rentSysvar),
+            getAccountMeta(accounts.nonceAuthority),
+        ],
+        data: getWithdrawNonceAccountInstructionDataEncoder().encode(args as WithdrawNonceAccountInstructionDataArgs),
+        programAddress,
+    } as WithdrawNonceAccountInstruction<
+        TProgramAddress,
+        TAccountNonceAccount,
+        TAccountRecipientAccount,
+        TAccountRecentBlockhashesSysvar,
+        TAccountRentSysvar,
+        TAccountNonceAuthority
+    >);
 }
 
 export type ParsedWithdrawNonceAccountInstruction<
-  TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    nonceAccount: TAccountMetas[0];
-    recipientAccount: TAccountMetas[1];
-    recentBlockhashesSysvar: TAccountMetas[2];
-    rentSysvar: TAccountMetas[3];
-    nonceAuthority: TAccountMetas[4];
-  };
-  data: WithdrawNonceAccountInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        nonceAccount: TAccountMetas[0];
+        recipientAccount: TAccountMetas[1];
+        recentBlockhashesSysvar: TAccountMetas[2];
+        rentSysvar: TAccountMetas[3];
+        nonceAuthority: TAccountMetas[4];
+    };
+    data: WithdrawNonceAccountInstructionData;
 };
 
 export function parseWithdrawNonceAccountInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
+    TProgram extends string,
+    TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedWithdrawNonceAccountInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 5) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: {
-      nonceAccount: getNextAccount(),
-      recipientAccount: getNextAccount(),
-      recentBlockhashesSysvar: getNextAccount(),
-      rentSysvar: getNextAccount(),
-      nonceAuthority: getNextAccount(),
-    },
-    data: getWithdrawNonceAccountInstructionDataDecoder().decode(
-      instruction.data
-    ),
-  };
+    if (instruction.accounts.length < 5) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: {
+            nonceAccount: getNextAccount(),
+            recipientAccount: getNextAccount(),
+            recentBlockhashesSysvar: getNextAccount(),
+            rentSysvar: getNextAccount(),
+            nonceAuthority: getNextAccount(),
+        },
+        data: getWithdrawNonceAccountInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/system/src/generated/programs/system.ts
+++ b/test/e2e/system/src/generated/programs/system.ts
@@ -6,138 +6,104 @@
  * @see https://github.com/codama-idl/codama
  */
 
+import { containsBytes, getU32Encoder, type Address, type ReadonlyUint8Array } from '@solana/kit';
 import {
-  containsBytes,
-  getU32Encoder,
-  type Address,
-  type ReadonlyUint8Array,
-} from '@solana/kit';
-import {
-  type ParsedAdvanceNonceAccountInstruction,
-  type ParsedAllocateInstruction,
-  type ParsedAllocateWithSeedInstruction,
-  type ParsedAssignInstruction,
-  type ParsedAssignWithSeedInstruction,
-  type ParsedAuthorizeNonceAccountInstruction,
-  type ParsedCreateAccountInstruction,
-  type ParsedCreateAccountWithSeedInstruction,
-  type ParsedInitializeNonceAccountInstruction,
-  type ParsedTransferSolInstruction,
-  type ParsedTransferSolWithSeedInstruction,
-  type ParsedUpgradeNonceAccountInstruction,
-  type ParsedWithdrawNonceAccountInstruction,
+    type ParsedAdvanceNonceAccountInstruction,
+    type ParsedAllocateInstruction,
+    type ParsedAllocateWithSeedInstruction,
+    type ParsedAssignInstruction,
+    type ParsedAssignWithSeedInstruction,
+    type ParsedAuthorizeNonceAccountInstruction,
+    type ParsedCreateAccountInstruction,
+    type ParsedCreateAccountWithSeedInstruction,
+    type ParsedInitializeNonceAccountInstruction,
+    type ParsedTransferSolInstruction,
+    type ParsedTransferSolWithSeedInstruction,
+    type ParsedUpgradeNonceAccountInstruction,
+    type ParsedWithdrawNonceAccountInstruction,
 } from '../instructions';
 
-export const SYSTEM_PROGRAM_ADDRESS =
-  '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
+export const SYSTEM_PROGRAM_ADDRESS = '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
 
 export enum SystemAccount {
-  Nonce,
+    Nonce,
 }
 
 export enum SystemInstruction {
-  CreateAccount,
-  Assign,
-  TransferSol,
-  CreateAccountWithSeed,
-  AdvanceNonceAccount,
-  WithdrawNonceAccount,
-  InitializeNonceAccount,
-  AuthorizeNonceAccount,
-  Allocate,
-  AllocateWithSeed,
-  AssignWithSeed,
-  TransferSolWithSeed,
-  UpgradeNonceAccount,
+    CreateAccount,
+    Assign,
+    TransferSol,
+    CreateAccountWithSeed,
+    AdvanceNonceAccount,
+    WithdrawNonceAccount,
+    InitializeNonceAccount,
+    AuthorizeNonceAccount,
+    Allocate,
+    AllocateWithSeed,
+    AssignWithSeed,
+    TransferSolWithSeed,
+    UpgradeNonceAccount,
 }
 
 export function identifySystemInstruction(
-  instruction: { data: ReadonlyUint8Array } | ReadonlyUint8Array
+    instruction: { data: ReadonlyUint8Array } | ReadonlyUint8Array
 ): SystemInstruction {
-  const data = 'data' in instruction ? instruction.data : instruction;
-  if (containsBytes(data, getU32Encoder().encode(0), 0)) {
-    return SystemInstruction.CreateAccount;
-  }
-  if (containsBytes(data, getU32Encoder().encode(1), 0)) {
-    return SystemInstruction.Assign;
-  }
-  if (containsBytes(data, getU32Encoder().encode(2), 0)) {
-    return SystemInstruction.TransferSol;
-  }
-  if (containsBytes(data, getU32Encoder().encode(3), 0)) {
-    return SystemInstruction.CreateAccountWithSeed;
-  }
-  if (containsBytes(data, getU32Encoder().encode(4), 0)) {
-    return SystemInstruction.AdvanceNonceAccount;
-  }
-  if (containsBytes(data, getU32Encoder().encode(5), 0)) {
-    return SystemInstruction.WithdrawNonceAccount;
-  }
-  if (containsBytes(data, getU32Encoder().encode(6), 0)) {
-    return SystemInstruction.InitializeNonceAccount;
-  }
-  if (containsBytes(data, getU32Encoder().encode(7), 0)) {
-    return SystemInstruction.AuthorizeNonceAccount;
-  }
-  if (containsBytes(data, getU32Encoder().encode(8), 0)) {
-    return SystemInstruction.Allocate;
-  }
-  if (containsBytes(data, getU32Encoder().encode(9), 0)) {
-    return SystemInstruction.AllocateWithSeed;
-  }
-  if (containsBytes(data, getU32Encoder().encode(10), 0)) {
-    return SystemInstruction.AssignWithSeed;
-  }
-  if (containsBytes(data, getU32Encoder().encode(11), 0)) {
-    return SystemInstruction.TransferSolWithSeed;
-  }
-  if (containsBytes(data, getU32Encoder().encode(12), 0)) {
-    return SystemInstruction.UpgradeNonceAccount;
-  }
-  throw new Error(
-    'The provided instruction could not be identified as a system instruction.'
-  );
+    const data = 'data' in instruction ? instruction.data : instruction;
+    if (containsBytes(data, getU32Encoder().encode(0), 0)) {
+        return SystemInstruction.CreateAccount;
+    }
+    if (containsBytes(data, getU32Encoder().encode(1), 0)) {
+        return SystemInstruction.Assign;
+    }
+    if (containsBytes(data, getU32Encoder().encode(2), 0)) {
+        return SystemInstruction.TransferSol;
+    }
+    if (containsBytes(data, getU32Encoder().encode(3), 0)) {
+        return SystemInstruction.CreateAccountWithSeed;
+    }
+    if (containsBytes(data, getU32Encoder().encode(4), 0)) {
+        return SystemInstruction.AdvanceNonceAccount;
+    }
+    if (containsBytes(data, getU32Encoder().encode(5), 0)) {
+        return SystemInstruction.WithdrawNonceAccount;
+    }
+    if (containsBytes(data, getU32Encoder().encode(6), 0)) {
+        return SystemInstruction.InitializeNonceAccount;
+    }
+    if (containsBytes(data, getU32Encoder().encode(7), 0)) {
+        return SystemInstruction.AuthorizeNonceAccount;
+    }
+    if (containsBytes(data, getU32Encoder().encode(8), 0)) {
+        return SystemInstruction.Allocate;
+    }
+    if (containsBytes(data, getU32Encoder().encode(9), 0)) {
+        return SystemInstruction.AllocateWithSeed;
+    }
+    if (containsBytes(data, getU32Encoder().encode(10), 0)) {
+        return SystemInstruction.AssignWithSeed;
+    }
+    if (containsBytes(data, getU32Encoder().encode(11), 0)) {
+        return SystemInstruction.TransferSolWithSeed;
+    }
+    if (containsBytes(data, getU32Encoder().encode(12), 0)) {
+        return SystemInstruction.UpgradeNonceAccount;
+    }
+    throw new Error('The provided instruction could not be identified as a system instruction.');
 }
 
-export type ParsedSystemInstruction<
-  TProgram extends string = '11111111111111111111111111111111',
-> =
-  | ({
-      instructionType: SystemInstruction.CreateAccount;
-    } & ParsedCreateAccountInstruction<TProgram>)
-  | ({
-      instructionType: SystemInstruction.Assign;
-    } & ParsedAssignInstruction<TProgram>)
-  | ({
-      instructionType: SystemInstruction.TransferSol;
-    } & ParsedTransferSolInstruction<TProgram>)
-  | ({
-      instructionType: SystemInstruction.CreateAccountWithSeed;
-    } & ParsedCreateAccountWithSeedInstruction<TProgram>)
-  | ({
-      instructionType: SystemInstruction.AdvanceNonceAccount;
-    } & ParsedAdvanceNonceAccountInstruction<TProgram>)
-  | ({
-      instructionType: SystemInstruction.WithdrawNonceAccount;
-    } & ParsedWithdrawNonceAccountInstruction<TProgram>)
-  | ({
-      instructionType: SystemInstruction.InitializeNonceAccount;
-    } & ParsedInitializeNonceAccountInstruction<TProgram>)
-  | ({
-      instructionType: SystemInstruction.AuthorizeNonceAccount;
-    } & ParsedAuthorizeNonceAccountInstruction<TProgram>)
-  | ({
-      instructionType: SystemInstruction.Allocate;
-    } & ParsedAllocateInstruction<TProgram>)
-  | ({
-      instructionType: SystemInstruction.AllocateWithSeed;
-    } & ParsedAllocateWithSeedInstruction<TProgram>)
-  | ({
-      instructionType: SystemInstruction.AssignWithSeed;
-    } & ParsedAssignWithSeedInstruction<TProgram>)
-  | ({
-      instructionType: SystemInstruction.TransferSolWithSeed;
-    } & ParsedTransferSolWithSeedInstruction<TProgram>)
-  | ({
-      instructionType: SystemInstruction.UpgradeNonceAccount;
-    } & ParsedUpgradeNonceAccountInstruction<TProgram>);
+export type ParsedSystemInstruction<TProgram extends string = '11111111111111111111111111111111'> =
+    | ({ instructionType: SystemInstruction.CreateAccount } & ParsedCreateAccountInstruction<TProgram>)
+    | ({ instructionType: SystemInstruction.Assign } & ParsedAssignInstruction<TProgram>)
+    | ({ instructionType: SystemInstruction.TransferSol } & ParsedTransferSolInstruction<TProgram>)
+    | ({ instructionType: SystemInstruction.CreateAccountWithSeed } & ParsedCreateAccountWithSeedInstruction<TProgram>)
+    | ({ instructionType: SystemInstruction.AdvanceNonceAccount } & ParsedAdvanceNonceAccountInstruction<TProgram>)
+    | ({ instructionType: SystemInstruction.WithdrawNonceAccount } & ParsedWithdrawNonceAccountInstruction<TProgram>)
+    | ({
+          instructionType: SystemInstruction.InitializeNonceAccount;
+      } & ParsedInitializeNonceAccountInstruction<TProgram>)
+    | ({ instructionType: SystemInstruction.AuthorizeNonceAccount } & ParsedAuthorizeNonceAccountInstruction<TProgram>)
+    | ({ instructionType: SystemInstruction.Allocate } & ParsedAllocateInstruction<TProgram>)
+    | ({ instructionType: SystemInstruction.AllocateWithSeed } & ParsedAllocateWithSeedInstruction<TProgram>)
+    | ({ instructionType: SystemInstruction.AssignWithSeed } & ParsedAssignWithSeedInstruction<TProgram>)
+    | ({ instructionType: SystemInstruction.TransferSolWithSeed } & ParsedTransferSolWithSeedInstruction<TProgram>)
+    | ({ instructionType: SystemInstruction.UpgradeNonceAccount } & ParsedUpgradeNonceAccountInstruction<TProgram>);

--- a/test/e2e/system/src/generated/shared/index.ts
+++ b/test/e2e/system/src/generated/shared/index.ts
@@ -7,15 +7,15 @@
  */
 
 import {
-  AccountRole,
-  isProgramDerivedAddress,
-  isTransactionSigner as kitIsTransactionSigner,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type ProgramDerivedAddress,
-  type TransactionSigner,
-  upgradeRoleToSigner,
+    AccountRole,
+    isProgramDerivedAddress,
+    isTransactionSigner as kitIsTransactionSigner,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type ProgramDerivedAddress,
+    type TransactionSigner,
+    upgradeRoleToSigner,
 } from '@solana/kit';
 
 /**
@@ -23,10 +23,10 @@ import {
  * @internal
  */
 export function expectSome<T>(value: T | null | undefined): T {
-  if (value === null || value === undefined) {
-    throw new Error('Expected a value but received null or undefined.');
-  }
-  return value;
+    if (value === null || value === undefined) {
+        throw new Error('Expected a value but received null or undefined.');
+    }
+    return value;
 }
 
 /**
@@ -34,23 +34,18 @@ export function expectSome<T>(value: T | null | undefined): T {
  * @internal
  */
 export function expectAddress<T extends string = string>(
-  value:
-    | Address<T>
-    | ProgramDerivedAddress<T>
-    | TransactionSigner<T>
-    | null
-    | undefined
+    value: Address<T> | ProgramDerivedAddress<T> | TransactionSigner<T> | null | undefined
 ): Address<T> {
-  if (!value) {
-    throw new Error('Expected a Address.');
-  }
-  if (typeof value === 'object' && 'address' in value) {
-    return value.address;
-  }
-  if (Array.isArray(value)) {
-    return value[0] as Address<T>;
-  }
-  return value as Address<T>;
+    if (!value) {
+        throw new Error('Expected a Address.');
+    }
+    if (typeof value === 'object' && 'address' in value) {
+        return value.address;
+    }
+    if (Array.isArray(value)) {
+        return value[0] as Address<T>;
+    }
+    return value as Address<T>;
 }
 
 /**
@@ -58,17 +53,12 @@ export function expectAddress<T extends string = string>(
  * @internal
  */
 export function expectProgramDerivedAddress<T extends string = string>(
-  value:
-    | Address<T>
-    | ProgramDerivedAddress<T>
-    | TransactionSigner<T>
-    | null
-    | undefined
+    value: Address<T> | ProgramDerivedAddress<T> | TransactionSigner<T> | null | undefined
 ): ProgramDerivedAddress<T> {
-  if (!value || !Array.isArray(value) || !isProgramDerivedAddress(value)) {
-    throw new Error('Expected a ProgramDerivedAddress.');
-  }
-  return value;
+    if (!value || !Array.isArray(value) || !isProgramDerivedAddress(value)) {
+        throw new Error('Expected a ProgramDerivedAddress.');
+    }
+    return value;
 }
 
 /**
@@ -76,17 +66,12 @@ export function expectProgramDerivedAddress<T extends string = string>(
  * @internal
  */
 export function expectTransactionSigner<T extends string = string>(
-  value:
-    | Address<T>
-    | ProgramDerivedAddress<T>
-    | TransactionSigner<T>
-    | null
-    | undefined
+    value: Address<T> | ProgramDerivedAddress<T> | TransactionSigner<T> | null | undefined
 ): TransactionSigner<T> {
-  if (!value || !isTransactionSigner(value)) {
-    throw new Error('Expected a TransactionSigner.');
-  }
-  return value;
+    if (!value || !isTransactionSigner(value)) {
+        throw new Error('Expected a TransactionSigner.');
+    }
+    return value;
 }
 
 /**
@@ -94,19 +79,15 @@ export function expectTransactionSigner<T extends string = string>(
  * @internal
  */
 export type ResolvedAccount<
-  T extends string = string,
-  U extends
-    | Address<T>
-    | ProgramDerivedAddress<T>
-    | TransactionSigner<T>
-    | null =
-    | Address<T>
-    | ProgramDerivedAddress<T>
-    | TransactionSigner<T>
-    | null,
+    T extends string = string,
+    U extends Address<T> | ProgramDerivedAddress<T> | TransactionSigner<T> | null =
+        | Address<T>
+        | ProgramDerivedAddress<T>
+        | TransactionSigner<T>
+        | null,
 > = {
-  isWritable: boolean;
-  value: U;
+    isWritable: boolean;
+    value: U;
 };
 
 /**
@@ -114,51 +95,31 @@ export type ResolvedAccount<
  * @internal
  */
 export type InstructionWithByteDelta = {
-  byteDelta: number;
+    byteDelta: number;
 };
 
 /**
  * Get account metas and signers from resolved accounts.
  * @internal
  */
-export function getAccountMetaFactory(
-  programAddress: Address,
-  optionalAccountStrategy: 'omitted' | 'programId'
-) {
-  return (
-    account: ResolvedAccount
-  ): AccountMeta | AccountSignerMeta | undefined => {
-    if (!account.value) {
-      if (optionalAccountStrategy === 'omitted') return;
-      return Object.freeze({
-        address: programAddress,
-        role: AccountRole.READONLY,
-      });
-    }
+export function getAccountMetaFactory(programAddress: Address, optionalAccountStrategy: 'omitted' | 'programId') {
+    return (account: ResolvedAccount): AccountMeta | AccountSignerMeta | undefined => {
+        if (!account.value) {
+            if (optionalAccountStrategy === 'omitted') return;
+            return Object.freeze({ address: programAddress, role: AccountRole.READONLY });
+        }
 
-    const writableRole = account.isWritable
-      ? AccountRole.WRITABLE
-      : AccountRole.READONLY;
-    return Object.freeze({
-      address: expectAddress(account.value),
-      role: isTransactionSigner(account.value)
-        ? upgradeRoleToSigner(writableRole)
-        : writableRole,
-      ...(isTransactionSigner(account.value) ? { signer: account.value } : {}),
-    });
-  };
+        const writableRole = account.isWritable ? AccountRole.WRITABLE : AccountRole.READONLY;
+        return Object.freeze({
+            address: expectAddress(account.value),
+            role: isTransactionSigner(account.value) ? upgradeRoleToSigner(writableRole) : writableRole,
+            ...(isTransactionSigner(account.value) ? { signer: account.value } : {}),
+        });
+    };
 }
 
 export function isTransactionSigner<TAddress extends string = string>(
-  value:
-    | Address<TAddress>
-    | ProgramDerivedAddress<TAddress>
-    | TransactionSigner<TAddress>
+    value: Address<TAddress> | ProgramDerivedAddress<TAddress> | TransactionSigner<TAddress>
 ): value is TransactionSigner<TAddress> {
-  return (
-    !!value &&
-    typeof value === 'object' &&
-    'address' in value &&
-    kitIsTransactionSigner(value)
-  );
+    return !!value && typeof value === 'object' && 'address' in value && kitIsTransactionSigner(value);
 }

--- a/test/e2e/system/src/generated/types/nonceState.ts
+++ b/test/e2e/system/src/generated/types/nonceState.ts
@@ -7,34 +7,31 @@
  */
 
 import {
-  combineCodec,
-  getEnumDecoder,
-  getEnumEncoder,
-  getU32Decoder,
-  getU32Encoder,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
+    combineCodec,
+    getEnumDecoder,
+    getEnumEncoder,
+    getU32Decoder,
+    getU32Encoder,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
 } from '@solana/kit';
 
 export enum NonceState {
-  Uninitialized,
-  Initialized,
+    Uninitialized,
+    Initialized,
 }
 
 export type NonceStateArgs = NonceState;
 
 export function getNonceStateEncoder(): FixedSizeEncoder<NonceStateArgs> {
-  return getEnumEncoder(NonceState, { size: getU32Encoder() });
+    return getEnumEncoder(NonceState, { size: getU32Encoder() });
 }
 
 export function getNonceStateDecoder(): FixedSizeDecoder<NonceState> {
-  return getEnumDecoder(NonceState, { size: getU32Decoder() });
+    return getEnumDecoder(NonceState, { size: getU32Decoder() });
 }
 
-export function getNonceStateCodec(): FixedSizeCodec<
-  NonceStateArgs,
-  NonceState
-> {
-  return combineCodec(getNonceStateEncoder(), getNonceStateDecoder());
+export function getNonceStateCodec(): FixedSizeCodec<NonceStateArgs, NonceState> {
+    return combineCodec(getNonceStateEncoder(), getNonceStateDecoder());
 }

--- a/test/e2e/system/src/generated/types/nonceVersion.ts
+++ b/test/e2e/system/src/generated/types/nonceVersion.ts
@@ -7,34 +7,31 @@
  */
 
 import {
-  combineCodec,
-  getEnumDecoder,
-  getEnumEncoder,
-  getU32Decoder,
-  getU32Encoder,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
+    combineCodec,
+    getEnumDecoder,
+    getEnumEncoder,
+    getU32Decoder,
+    getU32Encoder,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
 } from '@solana/kit';
 
 export enum NonceVersion {
-  Legacy,
-  Current,
+    Legacy,
+    Current,
 }
 
 export type NonceVersionArgs = NonceVersion;
 
 export function getNonceVersionEncoder(): FixedSizeEncoder<NonceVersionArgs> {
-  return getEnumEncoder(NonceVersion, { size: getU32Encoder() });
+    return getEnumEncoder(NonceVersion, { size: getU32Encoder() });
 }
 
 export function getNonceVersionDecoder(): FixedSizeDecoder<NonceVersion> {
-  return getEnumDecoder(NonceVersion, { size: getU32Decoder() });
+    return getEnumDecoder(NonceVersion, { size: getU32Decoder() });
 }
 
-export function getNonceVersionCodec(): FixedSizeCodec<
-  NonceVersionArgs,
-  NonceVersion
-> {
-  return combineCodec(getNonceVersionEncoder(), getNonceVersionDecoder());
+export function getNonceVersionCodec(): FixedSizeCodec<NonceVersionArgs, NonceVersion> {
+    return combineCodec(getNonceVersionEncoder(), getNonceVersionDecoder());
 }

--- a/test/e2e/system/test/_setup.ts
+++ b/test/e2e/system/test/_setup.ts
@@ -12,6 +12,7 @@ import {
   airdropFactory,
   appendTransactionMessageInstruction,
   assertIsSendableTransaction,
+  assertIsTransactionWithBlockhashLifetime,
   createSolanaRpc,
   createSolanaRpcSubscriptions,
   createTransactionMessage,
@@ -84,6 +85,7 @@ export const signAndSendTransaction = async (
     await signTransactionMessageWithSigners(transactionMessage);
   const signature = getSignatureFromTransaction(signedTransaction);
   assertIsSendableTransaction(signedTransaction);
+  assertIsTransactionWithBlockhashLifetime(signedTransaction);
   await sendAndConfirmTransactionFactory(client)(signedTransaction, {
     commitment,
   });

--- a/test/e2e/token/.prettierrc.json
+++ b/test/e2e/token/.prettierrc.json
@@ -1,9 +1,0 @@
-{
-  "semi": true,
-  "singleQuote": true,
-  "trailingComma": "es5",
-  "useTabs": false,
-  "tabWidth": 2,
-  "arrowParens": "always",
-  "printWidth": 80
-}

--- a/test/e2e/token/package.json
+++ b/test/e2e/token/package.json
@@ -10,6 +10,9 @@
     "lint": "eslint --ext js,ts,tsx src && prettier --check src test",
     "lint:fix": "eslint --fix --ext js,ts,tsx src && prettier --write src test"
   },
+  "dependencies": {
+    "@solana/kit": "^5.0.0"
+  },
   "license": "MIT",
   "ava": {
     "typescript": {
@@ -18,6 +21,5 @@
         "test/": "dist/test/"
       }
     }
-  },
-  "packageManager": "pnpm@9.1.0"
+  }
 }

--- a/test/e2e/token/src/generated/accounts/mint.ts
+++ b/test/e2e/token/src/generated/accounts/mint.ts
@@ -7,179 +7,152 @@
  */
 
 import {
-  assertAccountExists,
-  assertAccountsExist,
-  combineCodec,
-  decodeAccount,
-  fetchEncodedAccount,
-  fetchEncodedAccounts,
-  getAddressDecoder,
-  getAddressEncoder,
-  getBooleanDecoder,
-  getBooleanEncoder,
-  getOptionDecoder,
-  getOptionEncoder,
-  getStructDecoder,
-  getStructEncoder,
-  getU32Decoder,
-  getU32Encoder,
-  getU64Decoder,
-  getU64Encoder,
-  getU8Decoder,
-  getU8Encoder,
-  type Account,
-  type Address,
-  type EncodedAccount,
-  type FetchAccountConfig,
-  type FetchAccountsConfig,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type MaybeAccount,
-  type MaybeEncodedAccount,
-  type Option,
-  type OptionOrNullable,
+    assertAccountExists,
+    assertAccountsExist,
+    combineCodec,
+    decodeAccount,
+    fetchEncodedAccount,
+    fetchEncodedAccounts,
+    getAddressDecoder,
+    getAddressEncoder,
+    getBooleanDecoder,
+    getBooleanEncoder,
+    getOptionDecoder,
+    getOptionEncoder,
+    getStructDecoder,
+    getStructEncoder,
+    getU32Decoder,
+    getU32Encoder,
+    getU64Decoder,
+    getU64Encoder,
+    getU8Decoder,
+    getU8Encoder,
+    type Account,
+    type Address,
+    type EncodedAccount,
+    type FetchAccountConfig,
+    type FetchAccountsConfig,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type MaybeAccount,
+    type MaybeEncodedAccount,
+    type Option,
+    type OptionOrNullable,
 } from '@solana/kit';
 
 /** Uniquely represents a token on the network and stores global metadata about the token. */
 export type Mint = {
-  /**
-   * Optional authority used to mint new tokens. The mint authority may only
-   * be provided during mint creation. If no mint authority is present
-   * then the mint has a fixed supply and no further tokens may be minted.
-   */
-  mintAuthority: Option<Address>;
-  /** Total supply of tokens. */
-  supply: bigint;
-  /** Number of base 10 digits to the right of the decimal place. */
-  decimals: number;
-  /** Is `true` if this structure has been initialized. */
-  isInitialized: boolean;
-  /** Optional authority to freeze token accounts. */
-  freezeAuthority: Option<Address>;
+    /**
+     * Optional authority used to mint new tokens. The mint authority may only
+     * be provided during mint creation. If no mint authority is present
+     * then the mint has a fixed supply and no further tokens may be minted.
+     */
+    mintAuthority: Option<Address>;
+    /** Total supply of tokens. */
+    supply: bigint;
+    /** Number of base 10 digits to the right of the decimal place. */
+    decimals: number;
+    /** Is `true` if this structure has been initialized. */
+    isInitialized: boolean;
+    /** Optional authority to freeze token accounts. */
+    freezeAuthority: Option<Address>;
 };
 
 export type MintArgs = {
-  /**
-   * Optional authority used to mint new tokens. The mint authority may only
-   * be provided during mint creation. If no mint authority is present
-   * then the mint has a fixed supply and no further tokens may be minted.
-   */
-  mintAuthority: OptionOrNullable<Address>;
-  /** Total supply of tokens. */
-  supply: number | bigint;
-  /** Number of base 10 digits to the right of the decimal place. */
-  decimals: number;
-  /** Is `true` if this structure has been initialized. */
-  isInitialized: boolean;
-  /** Optional authority to freeze token accounts. */
-  freezeAuthority: OptionOrNullable<Address>;
+    /**
+     * Optional authority used to mint new tokens. The mint authority may only
+     * be provided during mint creation. If no mint authority is present
+     * then the mint has a fixed supply and no further tokens may be minted.
+     */
+    mintAuthority: OptionOrNullable<Address>;
+    /** Total supply of tokens. */
+    supply: number | bigint;
+    /** Number of base 10 digits to the right of the decimal place. */
+    decimals: number;
+    /** Is `true` if this structure has been initialized. */
+    isInitialized: boolean;
+    /** Optional authority to freeze token accounts. */
+    freezeAuthority: OptionOrNullable<Address>;
 };
 
 /** Gets the encoder for {@link MintArgs} account data. */
 export function getMintEncoder(): FixedSizeEncoder<MintArgs> {
-  return getStructEncoder([
-    [
-      'mintAuthority',
-      getOptionEncoder(getAddressEncoder(), {
-        prefix: getU32Encoder(),
-        noneValue: 'zeroes',
-      }),
-    ],
-    ['supply', getU64Encoder()],
-    ['decimals', getU8Encoder()],
-    ['isInitialized', getBooleanEncoder()],
-    [
-      'freezeAuthority',
-      getOptionEncoder(getAddressEncoder(), {
-        prefix: getU32Encoder(),
-        noneValue: 'zeroes',
-      }),
-    ],
-  ]);
+    return getStructEncoder([
+        ['mintAuthority', getOptionEncoder(getAddressEncoder(), { prefix: getU32Encoder(), noneValue: 'zeroes' })],
+        ['supply', getU64Encoder()],
+        ['decimals', getU8Encoder()],
+        ['isInitialized', getBooleanEncoder()],
+        ['freezeAuthority', getOptionEncoder(getAddressEncoder(), { prefix: getU32Encoder(), noneValue: 'zeroes' })],
+    ]);
 }
 
 /** Gets the decoder for {@link Mint} account data. */
 export function getMintDecoder(): FixedSizeDecoder<Mint> {
-  return getStructDecoder([
-    [
-      'mintAuthority',
-      getOptionDecoder(getAddressDecoder(), {
-        prefix: getU32Decoder(),
-        noneValue: 'zeroes',
-      }),
-    ],
-    ['supply', getU64Decoder()],
-    ['decimals', getU8Decoder()],
-    ['isInitialized', getBooleanDecoder()],
-    [
-      'freezeAuthority',
-      getOptionDecoder(getAddressDecoder(), {
-        prefix: getU32Decoder(),
-        noneValue: 'zeroes',
-      }),
-    ],
-  ]);
+    return getStructDecoder([
+        ['mintAuthority', getOptionDecoder(getAddressDecoder(), { prefix: getU32Decoder(), noneValue: 'zeroes' })],
+        ['supply', getU64Decoder()],
+        ['decimals', getU8Decoder()],
+        ['isInitialized', getBooleanDecoder()],
+        ['freezeAuthority', getOptionDecoder(getAddressDecoder(), { prefix: getU32Decoder(), noneValue: 'zeroes' })],
+    ]);
 }
 
 /** Gets the codec for {@link Mint} account data. */
 export function getMintCodec(): FixedSizeCodec<MintArgs, Mint> {
-  return combineCodec(getMintEncoder(), getMintDecoder());
+    return combineCodec(getMintEncoder(), getMintDecoder());
 }
 
 export function decodeMint<TAddress extends string = string>(
-  encodedAccount: EncodedAccount<TAddress>
+    encodedAccount: EncodedAccount<TAddress>
 ): Account<Mint, TAddress>;
 export function decodeMint<TAddress extends string = string>(
-  encodedAccount: MaybeEncodedAccount<TAddress>
+    encodedAccount: MaybeEncodedAccount<TAddress>
 ): MaybeAccount<Mint, TAddress>;
 export function decodeMint<TAddress extends string = string>(
-  encodedAccount: EncodedAccount<TAddress> | MaybeEncodedAccount<TAddress>
+    encodedAccount: EncodedAccount<TAddress> | MaybeEncodedAccount<TAddress>
 ): Account<Mint, TAddress> | MaybeAccount<Mint, TAddress> {
-  return decodeAccount(
-    encodedAccount as MaybeEncodedAccount<TAddress>,
-    getMintDecoder()
-  );
+    return decodeAccount(encodedAccount as MaybeEncodedAccount<TAddress>, getMintDecoder());
 }
 
 export async function fetchMint<TAddress extends string = string>(
-  rpc: Parameters<typeof fetchEncodedAccount>[0],
-  address: Address<TAddress>,
-  config?: FetchAccountConfig
+    rpc: Parameters<typeof fetchEncodedAccount>[0],
+    address: Address<TAddress>,
+    config?: FetchAccountConfig
 ): Promise<Account<Mint, TAddress>> {
-  const maybeAccount = await fetchMaybeMint(rpc, address, config);
-  assertAccountExists(maybeAccount);
-  return maybeAccount;
+    const maybeAccount = await fetchMaybeMint(rpc, address, config);
+    assertAccountExists(maybeAccount);
+    return maybeAccount;
 }
 
 export async function fetchMaybeMint<TAddress extends string = string>(
-  rpc: Parameters<typeof fetchEncodedAccount>[0],
-  address: Address<TAddress>,
-  config?: FetchAccountConfig
+    rpc: Parameters<typeof fetchEncodedAccount>[0],
+    address: Address<TAddress>,
+    config?: FetchAccountConfig
 ): Promise<MaybeAccount<Mint, TAddress>> {
-  const maybeAccount = await fetchEncodedAccount(rpc, address, config);
-  return decodeMint(maybeAccount);
+    const maybeAccount = await fetchEncodedAccount(rpc, address, config);
+    return decodeMint(maybeAccount);
 }
 
 export async function fetchAllMint(
-  rpc: Parameters<typeof fetchEncodedAccounts>[0],
-  addresses: Array<Address>,
-  config?: FetchAccountsConfig
+    rpc: Parameters<typeof fetchEncodedAccounts>[0],
+    addresses: Array<Address>,
+    config?: FetchAccountsConfig
 ): Promise<Account<Mint>[]> {
-  const maybeAccounts = await fetchAllMaybeMint(rpc, addresses, config);
-  assertAccountsExist(maybeAccounts);
-  return maybeAccounts;
+    const maybeAccounts = await fetchAllMaybeMint(rpc, addresses, config);
+    assertAccountsExist(maybeAccounts);
+    return maybeAccounts;
 }
 
 export async function fetchAllMaybeMint(
-  rpc: Parameters<typeof fetchEncodedAccounts>[0],
-  addresses: Array<Address>,
-  config?: FetchAccountsConfig
+    rpc: Parameters<typeof fetchEncodedAccounts>[0],
+    addresses: Array<Address>,
+    config?: FetchAccountsConfig
 ): Promise<MaybeAccount<Mint>[]> {
-  const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
-  return maybeAccounts.map((maybeAccount) => decodeMint(maybeAccount));
+    const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
+    return maybeAccounts.map(maybeAccount => decodeMint(maybeAccount));
 }
 
 export function getMintSize(): number {
-  return 82;
+    return 82;
 }

--- a/test/e2e/token/src/generated/accounts/multisig.ts
+++ b/test/e2e/token/src/generated/accounts/multisig.ts
@@ -7,125 +7,122 @@
  */
 
 import {
-  assertAccountExists,
-  assertAccountsExist,
-  combineCodec,
-  decodeAccount,
-  fetchEncodedAccount,
-  fetchEncodedAccounts,
-  getAddressDecoder,
-  getAddressEncoder,
-  getArrayDecoder,
-  getArrayEncoder,
-  getBooleanDecoder,
-  getBooleanEncoder,
-  getStructDecoder,
-  getStructEncoder,
-  getU8Decoder,
-  getU8Encoder,
-  type Account,
-  type Address,
-  type EncodedAccount,
-  type FetchAccountConfig,
-  type FetchAccountsConfig,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type MaybeAccount,
-  type MaybeEncodedAccount,
+    assertAccountExists,
+    assertAccountsExist,
+    combineCodec,
+    decodeAccount,
+    fetchEncodedAccount,
+    fetchEncodedAccounts,
+    getAddressDecoder,
+    getAddressEncoder,
+    getArrayDecoder,
+    getArrayEncoder,
+    getBooleanDecoder,
+    getBooleanEncoder,
+    getStructDecoder,
+    getStructEncoder,
+    getU8Decoder,
+    getU8Encoder,
+    type Account,
+    type Address,
+    type EncodedAccount,
+    type FetchAccountConfig,
+    type FetchAccountsConfig,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type MaybeAccount,
+    type MaybeEncodedAccount,
 } from '@solana/kit';
 
 export type Multisig = {
-  /** Number of signers required. */
-  m: number;
-  /** Number of valid signers. */
-  n: number;
-  /** Is `true` if this structure has been initialized. */
-  isInitialized: boolean;
-  /** Signer public keys. */
-  signers: Array<Address>;
+    /** Number of signers required. */
+    m: number;
+    /** Number of valid signers. */
+    n: number;
+    /** Is `true` if this structure has been initialized. */
+    isInitialized: boolean;
+    /** Signer public keys. */
+    signers: Array<Address>;
 };
 
 export type MultisigArgs = Multisig;
 
 /** Gets the encoder for {@link MultisigArgs} account data. */
 export function getMultisigEncoder(): FixedSizeEncoder<MultisigArgs> {
-  return getStructEncoder([
-    ['m', getU8Encoder()],
-    ['n', getU8Encoder()],
-    ['isInitialized', getBooleanEncoder()],
-    ['signers', getArrayEncoder(getAddressEncoder(), { size: 11 })],
-  ]);
+    return getStructEncoder([
+        ['m', getU8Encoder()],
+        ['n', getU8Encoder()],
+        ['isInitialized', getBooleanEncoder()],
+        ['signers', getArrayEncoder(getAddressEncoder(), { size: 11 })],
+    ]);
 }
 
 /** Gets the decoder for {@link Multisig} account data. */
 export function getMultisigDecoder(): FixedSizeDecoder<Multisig> {
-  return getStructDecoder([
-    ['m', getU8Decoder()],
-    ['n', getU8Decoder()],
-    ['isInitialized', getBooleanDecoder()],
-    ['signers', getArrayDecoder(getAddressDecoder(), { size: 11 })],
-  ]);
+    return getStructDecoder([
+        ['m', getU8Decoder()],
+        ['n', getU8Decoder()],
+        ['isInitialized', getBooleanDecoder()],
+        ['signers', getArrayDecoder(getAddressDecoder(), { size: 11 })],
+    ]);
 }
 
 /** Gets the codec for {@link Multisig} account data. */
 export function getMultisigCodec(): FixedSizeCodec<MultisigArgs, Multisig> {
-  return combineCodec(getMultisigEncoder(), getMultisigDecoder());
+    return combineCodec(getMultisigEncoder(), getMultisigDecoder());
 }
 
 export function decodeMultisig<TAddress extends string = string>(
-  encodedAccount: EncodedAccount<TAddress>
+    encodedAccount: EncodedAccount<TAddress>
 ): Account<Multisig, TAddress>;
 export function decodeMultisig<TAddress extends string = string>(
-  encodedAccount: MaybeEncodedAccount<TAddress>
+    encodedAccount: MaybeEncodedAccount<TAddress>
 ): MaybeAccount<Multisig, TAddress>;
 export function decodeMultisig<TAddress extends string = string>(
-  encodedAccount: EncodedAccount<TAddress> | MaybeEncodedAccount<TAddress>
+    encodedAccount: EncodedAccount<TAddress> | MaybeEncodedAccount<TAddress>
 ): Account<Multisig, TAddress> | MaybeAccount<Multisig, TAddress> {
-  return decodeAccount(
-    encodedAccount as MaybeEncodedAccount<TAddress>,
-    getMultisigDecoder()
-  );
+    return decodeAccount(encodedAccount as MaybeEncodedAccount<TAddress>, getMultisigDecoder());
 }
 
 export async function fetchMultisig<TAddress extends string = string>(
-  rpc: Parameters<typeof fetchEncodedAccount>[0],
-  address: Address<TAddress>,
-  config?: FetchAccountConfig
+    rpc: Parameters<typeof fetchEncodedAccount>[0],
+    address: Address<TAddress>,
+    config?: FetchAccountConfig
 ): Promise<Account<Multisig, TAddress>> {
-  const maybeAccount = await fetchMaybeMultisig(rpc, address, config);
-  assertAccountExists(maybeAccount);
-  return maybeAccount;
+    const maybeAccount = await fetchMaybeMultisig(rpc, address, config);
+    assertAccountExists(maybeAccount);
+    return maybeAccount;
 }
 
 export async function fetchMaybeMultisig<TAddress extends string = string>(
-  rpc: Parameters<typeof fetchEncodedAccount>[0],
-  address: Address<TAddress>,
-  config?: FetchAccountConfig
+    rpc: Parameters<typeof fetchEncodedAccount>[0],
+    address: Address<TAddress>,
+    config?: FetchAccountConfig
 ): Promise<MaybeAccount<Multisig, TAddress>> {
-  const maybeAccount = await fetchEncodedAccount(rpc, address, config);
-  return decodeMultisig(maybeAccount);
+    const maybeAccount = await fetchEncodedAccount(rpc, address, config);
+    return decodeMultisig(maybeAccount);
 }
 
 export async function fetchAllMultisig(
-  rpc: Parameters<typeof fetchEncodedAccounts>[0],
-  addresses: Array<Address>,
-  config?: FetchAccountsConfig
+    rpc: Parameters<typeof fetchEncodedAccounts>[0],
+    addresses: Array<Address>,
+    config?: FetchAccountsConfig
 ): Promise<Account<Multisig>[]> {
-  const maybeAccounts = await fetchAllMaybeMultisig(rpc, addresses, config);
-  assertAccountsExist(maybeAccounts);
-  return maybeAccounts;
+    const maybeAccounts = await fetchAllMaybeMultisig(rpc, addresses, config);
+    assertAccountsExist(maybeAccounts);
+    return maybeAccounts;
 }
 
 export async function fetchAllMaybeMultisig(
-  rpc: Parameters<typeof fetchEncodedAccounts>[0],
-  addresses: Array<Address>,
-  config?: FetchAccountsConfig
+    rpc: Parameters<typeof fetchEncodedAccounts>[0],
+    addresses: Array<Address>,
+    config?: FetchAccountsConfig
 ): Promise<MaybeAccount<Multisig>[]> {
-  const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
-  return maybeAccounts.map((maybeAccount) => decodeMultisig(maybeAccount));
+    const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
+    return maybeAccounts.map(maybeAccount => decodeMultisig(maybeAccount));
 }
 
 export function getMultisigSize(): number {
-  return 355;
+    return 355;
 }

--- a/test/e2e/token/src/generated/accounts/token.ts
+++ b/test/e2e/token/src/generated/accounts/token.ts
@@ -7,219 +7,175 @@
  */
 
 import {
-  assertAccountExists,
-  assertAccountsExist,
-  combineCodec,
-  decodeAccount,
-  fetchEncodedAccount,
-  fetchEncodedAccounts,
-  getAddressDecoder,
-  getAddressEncoder,
-  getOptionDecoder,
-  getOptionEncoder,
-  getStructDecoder,
-  getStructEncoder,
-  getU32Decoder,
-  getU32Encoder,
-  getU64Decoder,
-  getU64Encoder,
-  type Account,
-  type Address,
-  type EncodedAccount,
-  type FetchAccountConfig,
-  type FetchAccountsConfig,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type MaybeAccount,
-  type MaybeEncodedAccount,
-  type Option,
-  type OptionOrNullable,
+    assertAccountExists,
+    assertAccountsExist,
+    combineCodec,
+    decodeAccount,
+    fetchEncodedAccount,
+    fetchEncodedAccounts,
+    getAddressDecoder,
+    getAddressEncoder,
+    getOptionDecoder,
+    getOptionEncoder,
+    getStructDecoder,
+    getStructEncoder,
+    getU32Decoder,
+    getU32Encoder,
+    getU64Decoder,
+    getU64Encoder,
+    type Account,
+    type Address,
+    type EncodedAccount,
+    type FetchAccountConfig,
+    type FetchAccountsConfig,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type MaybeAccount,
+    type MaybeEncodedAccount,
+    type Option,
+    type OptionOrNullable,
 } from '@solana/kit';
-import {
-  getAccountStateDecoder,
-  getAccountStateEncoder,
-  type AccountState,
-  type AccountStateArgs,
-} from '../types';
+import { getAccountStateDecoder, getAccountStateEncoder, type AccountState, type AccountStateArgs } from '../types';
 
 /** Stores information about an individual's ownership of a specific token (mint). Each token account is associated with a single mint and tracks details like the token balance and owner. */
 export type Token = {
-  /** The mint associated with this account. */
-  mint: Address;
-  /** The owner of this account. */
-  owner: Address;
-  /** The amount of tokens this account holds. */
-  amount: bigint;
-  /**
-   * If `delegate` is `Some` then `delegated_amount` represents
-   * the amount authorized by the delegate.
-   */
-  delegate: Option<Address>;
-  /** The account's state. */
-  state: AccountState;
-  /**
-   * If is_native.is_some, this is a native token, and the value logs the
-   * rent-exempt reserve. An Account is required to be rent-exempt, so
-   * the value is used by the Processor to ensure that wrapped SOL
-   * accounts do not drop below this threshold.
-   */
-  isNative: Option<bigint>;
-  /** The amount delegated. */
-  delegatedAmount: bigint;
-  /** Optional authority to close the account. */
-  closeAuthority: Option<Address>;
+    /** The mint associated with this account. */
+    mint: Address;
+    /** The owner of this account. */
+    owner: Address;
+    /** The amount of tokens this account holds. */
+    amount: bigint;
+    /**
+     * If `delegate` is `Some` then `delegated_amount` represents
+     * the amount authorized by the delegate.
+     */
+    delegate: Option<Address>;
+    /** The account's state. */
+    state: AccountState;
+    /**
+     * If is_native.is_some, this is a native token, and the value logs the
+     * rent-exempt reserve. An Account is required to be rent-exempt, so
+     * the value is used by the Processor to ensure that wrapped SOL
+     * accounts do not drop below this threshold.
+     */
+    isNative: Option<bigint>;
+    /** The amount delegated. */
+    delegatedAmount: bigint;
+    /** Optional authority to close the account. */
+    closeAuthority: Option<Address>;
 };
 
 export type TokenArgs = {
-  /** The mint associated with this account. */
-  mint: Address;
-  /** The owner of this account. */
-  owner: Address;
-  /** The amount of tokens this account holds. */
-  amount: number | bigint;
-  /**
-   * If `delegate` is `Some` then `delegated_amount` represents
-   * the amount authorized by the delegate.
-   */
-  delegate: OptionOrNullable<Address>;
-  /** The account's state. */
-  state: AccountStateArgs;
-  /**
-   * If is_native.is_some, this is a native token, and the value logs the
-   * rent-exempt reserve. An Account is required to be rent-exempt, so
-   * the value is used by the Processor to ensure that wrapped SOL
-   * accounts do not drop below this threshold.
-   */
-  isNative: OptionOrNullable<number | bigint>;
-  /** The amount delegated. */
-  delegatedAmount: number | bigint;
-  /** Optional authority to close the account. */
-  closeAuthority: OptionOrNullable<Address>;
+    /** The mint associated with this account. */
+    mint: Address;
+    /** The owner of this account. */
+    owner: Address;
+    /** The amount of tokens this account holds. */
+    amount: number | bigint;
+    /**
+     * If `delegate` is `Some` then `delegated_amount` represents
+     * the amount authorized by the delegate.
+     */
+    delegate: OptionOrNullable<Address>;
+    /** The account's state. */
+    state: AccountStateArgs;
+    /**
+     * If is_native.is_some, this is a native token, and the value logs the
+     * rent-exempt reserve. An Account is required to be rent-exempt, so
+     * the value is used by the Processor to ensure that wrapped SOL
+     * accounts do not drop below this threshold.
+     */
+    isNative: OptionOrNullable<number | bigint>;
+    /** The amount delegated. */
+    delegatedAmount: number | bigint;
+    /** Optional authority to close the account. */
+    closeAuthority: OptionOrNullable<Address>;
 };
 
 /** Gets the encoder for {@link TokenArgs} account data. */
 export function getTokenEncoder(): FixedSizeEncoder<TokenArgs> {
-  return getStructEncoder([
-    ['mint', getAddressEncoder()],
-    ['owner', getAddressEncoder()],
-    ['amount', getU64Encoder()],
-    [
-      'delegate',
-      getOptionEncoder(getAddressEncoder(), {
-        prefix: getU32Encoder(),
-        noneValue: 'zeroes',
-      }),
-    ],
-    ['state', getAccountStateEncoder()],
-    [
-      'isNative',
-      getOptionEncoder(getU64Encoder(), {
-        prefix: getU32Encoder(),
-        noneValue: 'zeroes',
-      }),
-    ],
-    ['delegatedAmount', getU64Encoder()],
-    [
-      'closeAuthority',
-      getOptionEncoder(getAddressEncoder(), {
-        prefix: getU32Encoder(),
-        noneValue: 'zeroes',
-      }),
-    ],
-  ]);
+    return getStructEncoder([
+        ['mint', getAddressEncoder()],
+        ['owner', getAddressEncoder()],
+        ['amount', getU64Encoder()],
+        ['delegate', getOptionEncoder(getAddressEncoder(), { prefix: getU32Encoder(), noneValue: 'zeroes' })],
+        ['state', getAccountStateEncoder()],
+        ['isNative', getOptionEncoder(getU64Encoder(), { prefix: getU32Encoder(), noneValue: 'zeroes' })],
+        ['delegatedAmount', getU64Encoder()],
+        ['closeAuthority', getOptionEncoder(getAddressEncoder(), { prefix: getU32Encoder(), noneValue: 'zeroes' })],
+    ]);
 }
 
 /** Gets the decoder for {@link Token} account data. */
 export function getTokenDecoder(): FixedSizeDecoder<Token> {
-  return getStructDecoder([
-    ['mint', getAddressDecoder()],
-    ['owner', getAddressDecoder()],
-    ['amount', getU64Decoder()],
-    [
-      'delegate',
-      getOptionDecoder(getAddressDecoder(), {
-        prefix: getU32Decoder(),
-        noneValue: 'zeroes',
-      }),
-    ],
-    ['state', getAccountStateDecoder()],
-    [
-      'isNative',
-      getOptionDecoder(getU64Decoder(), {
-        prefix: getU32Decoder(),
-        noneValue: 'zeroes',
-      }),
-    ],
-    ['delegatedAmount', getU64Decoder()],
-    [
-      'closeAuthority',
-      getOptionDecoder(getAddressDecoder(), {
-        prefix: getU32Decoder(),
-        noneValue: 'zeroes',
-      }),
-    ],
-  ]);
+    return getStructDecoder([
+        ['mint', getAddressDecoder()],
+        ['owner', getAddressDecoder()],
+        ['amount', getU64Decoder()],
+        ['delegate', getOptionDecoder(getAddressDecoder(), { prefix: getU32Decoder(), noneValue: 'zeroes' })],
+        ['state', getAccountStateDecoder()],
+        ['isNative', getOptionDecoder(getU64Decoder(), { prefix: getU32Decoder(), noneValue: 'zeroes' })],
+        ['delegatedAmount', getU64Decoder()],
+        ['closeAuthority', getOptionDecoder(getAddressDecoder(), { prefix: getU32Decoder(), noneValue: 'zeroes' })],
+    ]);
 }
 
 /** Gets the codec for {@link Token} account data. */
 export function getTokenCodec(): FixedSizeCodec<TokenArgs, Token> {
-  return combineCodec(getTokenEncoder(), getTokenDecoder());
+    return combineCodec(getTokenEncoder(), getTokenDecoder());
 }
 
 export function decodeToken<TAddress extends string = string>(
-  encodedAccount: EncodedAccount<TAddress>
+    encodedAccount: EncodedAccount<TAddress>
 ): Account<Token, TAddress>;
 export function decodeToken<TAddress extends string = string>(
-  encodedAccount: MaybeEncodedAccount<TAddress>
+    encodedAccount: MaybeEncodedAccount<TAddress>
 ): MaybeAccount<Token, TAddress>;
 export function decodeToken<TAddress extends string = string>(
-  encodedAccount: EncodedAccount<TAddress> | MaybeEncodedAccount<TAddress>
+    encodedAccount: EncodedAccount<TAddress> | MaybeEncodedAccount<TAddress>
 ): Account<Token, TAddress> | MaybeAccount<Token, TAddress> {
-  return decodeAccount(
-    encodedAccount as MaybeEncodedAccount<TAddress>,
-    getTokenDecoder()
-  );
+    return decodeAccount(encodedAccount as MaybeEncodedAccount<TAddress>, getTokenDecoder());
 }
 
 export async function fetchToken<TAddress extends string = string>(
-  rpc: Parameters<typeof fetchEncodedAccount>[0],
-  address: Address<TAddress>,
-  config?: FetchAccountConfig
+    rpc: Parameters<typeof fetchEncodedAccount>[0],
+    address: Address<TAddress>,
+    config?: FetchAccountConfig
 ): Promise<Account<Token, TAddress>> {
-  const maybeAccount = await fetchMaybeToken(rpc, address, config);
-  assertAccountExists(maybeAccount);
-  return maybeAccount;
+    const maybeAccount = await fetchMaybeToken(rpc, address, config);
+    assertAccountExists(maybeAccount);
+    return maybeAccount;
 }
 
 export async function fetchMaybeToken<TAddress extends string = string>(
-  rpc: Parameters<typeof fetchEncodedAccount>[0],
-  address: Address<TAddress>,
-  config?: FetchAccountConfig
+    rpc: Parameters<typeof fetchEncodedAccount>[0],
+    address: Address<TAddress>,
+    config?: FetchAccountConfig
 ): Promise<MaybeAccount<Token, TAddress>> {
-  const maybeAccount = await fetchEncodedAccount(rpc, address, config);
-  return decodeToken(maybeAccount);
+    const maybeAccount = await fetchEncodedAccount(rpc, address, config);
+    return decodeToken(maybeAccount);
 }
 
 export async function fetchAllToken(
-  rpc: Parameters<typeof fetchEncodedAccounts>[0],
-  addresses: Array<Address>,
-  config?: FetchAccountsConfig
+    rpc: Parameters<typeof fetchEncodedAccounts>[0],
+    addresses: Array<Address>,
+    config?: FetchAccountsConfig
 ): Promise<Account<Token>[]> {
-  const maybeAccounts = await fetchAllMaybeToken(rpc, addresses, config);
-  assertAccountsExist(maybeAccounts);
-  return maybeAccounts;
+    const maybeAccounts = await fetchAllMaybeToken(rpc, addresses, config);
+    assertAccountsExist(maybeAccounts);
+    return maybeAccounts;
 }
 
 export async function fetchAllMaybeToken(
-  rpc: Parameters<typeof fetchEncodedAccounts>[0],
-  addresses: Array<Address>,
-  config?: FetchAccountsConfig
+    rpc: Parameters<typeof fetchEncodedAccounts>[0],
+    addresses: Array<Address>,
+    config?: FetchAccountsConfig
 ): Promise<MaybeAccount<Token>[]> {
-  const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
-  return maybeAccounts.map((maybeAccount) => decodeToken(maybeAccount));
+    const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
+    return maybeAccounts.map(maybeAccount => decodeToken(maybeAccount));
 }
 
 export function getTokenSize(): number {
-  return 165;
+    return 165;
 }

--- a/test/e2e/token/src/generated/errors/associatedToken.ts
+++ b/test/e2e/token/src/generated/errors/associatedToken.ts
@@ -7,10 +7,10 @@
  */
 
 import {
-  isProgramError,
-  type Address,
-  type SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM,
-  type SolanaError,
+    isProgramError,
+    type Address,
+    type SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM,
+    type SolanaError,
 } from '@solana/kit';
 import { ASSOCIATED_TOKEN_PROGRAM_ADDRESS } from '../programs';
 
@@ -19,41 +19,26 @@ export const ASSOCIATED_TOKEN_ERROR__INVALID_OWNER = 0x0; // 0
 
 export type AssociatedTokenError = typeof ASSOCIATED_TOKEN_ERROR__INVALID_OWNER;
 
-let associatedTokenErrorMessages:
-  | Record<AssociatedTokenError, string>
-  | undefined;
+let associatedTokenErrorMessages: Record<AssociatedTokenError, string> | undefined;
 if (process.env.NODE_ENV !== 'production') {
-  associatedTokenErrorMessages = {
-    [ASSOCIATED_TOKEN_ERROR__INVALID_OWNER]: `Associated token account owner does not match address derivation`,
-  };
+    associatedTokenErrorMessages = {
+        [ASSOCIATED_TOKEN_ERROR__INVALID_OWNER]: `Associated token account owner does not match address derivation`,
+    };
 }
 
-export function getAssociatedTokenErrorMessage(
-  code: AssociatedTokenError
-): string {
-  if (process.env.NODE_ENV !== 'production') {
-    return (
-      associatedTokenErrorMessages as Record<AssociatedTokenError, string>
-    )[code];
-  }
+export function getAssociatedTokenErrorMessage(code: AssociatedTokenError): string {
+    if (process.env.NODE_ENV !== 'production') {
+        return (associatedTokenErrorMessages as Record<AssociatedTokenError, string>)[code];
+    }
 
-  return 'Error message not available in production bundles.';
+    return 'Error message not available in production bundles.';
 }
 
-export function isAssociatedTokenError<
-  TProgramErrorCode extends AssociatedTokenError,
->(
-  error: unknown,
-  transactionMessage: {
-    instructions: Record<number, { programAddress: Address }>;
-  },
-  code?: TProgramErrorCode
+export function isAssociatedTokenError<TProgramErrorCode extends AssociatedTokenError>(
+    error: unknown,
+    transactionMessage: { instructions: Record<number, { programAddress: Address }> },
+    code?: TProgramErrorCode
 ): error is SolanaError<typeof SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM> &
-  Readonly<{ context: Readonly<{ code: TProgramErrorCode }> }> {
-  return isProgramError<TProgramErrorCode>(
-    error,
-    transactionMessage,
-    ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
-    code
-  );
+    Readonly<{ context: Readonly<{ code: TProgramErrorCode }> }> {
+    return isProgramError<TProgramErrorCode>(error, transactionMessage, ASSOCIATED_TOKEN_PROGRAM_ADDRESS, code);
 }

--- a/test/e2e/token/src/generated/errors/token.ts
+++ b/test/e2e/token/src/generated/errors/token.ts
@@ -7,10 +7,10 @@
  */
 
 import {
-  isProgramError,
-  type Address,
-  type SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM,
-  type SolanaError,
+    isProgramError,
+    type Address,
+    type SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM,
+    type SolanaError,
 } from '@solana/kit';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 
@@ -56,73 +56,66 @@ export const TOKEN_ERROR__MINT_DECIMALS_MISMATCH = 0x12; // 18
 export const TOKEN_ERROR__NON_NATIVE_NOT_SUPPORTED = 0x13; // 19
 
 export type TokenError =
-  | typeof TOKEN_ERROR__ACCOUNT_FROZEN
-  | typeof TOKEN_ERROR__ALREADY_IN_USE
-  | typeof TOKEN_ERROR__AUTHORITY_TYPE_NOT_SUPPORTED
-  | typeof TOKEN_ERROR__FIXED_SUPPLY
-  | typeof TOKEN_ERROR__INSUFFICIENT_FUNDS
-  | typeof TOKEN_ERROR__INVALID_INSTRUCTION
-  | typeof TOKEN_ERROR__INVALID_MINT
-  | typeof TOKEN_ERROR__INVALID_NUMBER_OF_PROVIDED_SIGNERS
-  | typeof TOKEN_ERROR__INVALID_NUMBER_OF_REQUIRED_SIGNERS
-  | typeof TOKEN_ERROR__INVALID_STATE
-  | typeof TOKEN_ERROR__MINT_CANNOT_FREEZE
-  | typeof TOKEN_ERROR__MINT_DECIMALS_MISMATCH
-  | typeof TOKEN_ERROR__MINT_MISMATCH
-  | typeof TOKEN_ERROR__NATIVE_NOT_SUPPORTED
-  | typeof TOKEN_ERROR__NON_NATIVE_HAS_BALANCE
-  | typeof TOKEN_ERROR__NON_NATIVE_NOT_SUPPORTED
-  | typeof TOKEN_ERROR__NOT_RENT_EXEMPT
-  | typeof TOKEN_ERROR__OVERFLOW
-  | typeof TOKEN_ERROR__OWNER_MISMATCH
-  | typeof TOKEN_ERROR__UNINITIALIZED_STATE;
+    | typeof TOKEN_ERROR__ACCOUNT_FROZEN
+    | typeof TOKEN_ERROR__ALREADY_IN_USE
+    | typeof TOKEN_ERROR__AUTHORITY_TYPE_NOT_SUPPORTED
+    | typeof TOKEN_ERROR__FIXED_SUPPLY
+    | typeof TOKEN_ERROR__INSUFFICIENT_FUNDS
+    | typeof TOKEN_ERROR__INVALID_INSTRUCTION
+    | typeof TOKEN_ERROR__INVALID_MINT
+    | typeof TOKEN_ERROR__INVALID_NUMBER_OF_PROVIDED_SIGNERS
+    | typeof TOKEN_ERROR__INVALID_NUMBER_OF_REQUIRED_SIGNERS
+    | typeof TOKEN_ERROR__INVALID_STATE
+    | typeof TOKEN_ERROR__MINT_CANNOT_FREEZE
+    | typeof TOKEN_ERROR__MINT_DECIMALS_MISMATCH
+    | typeof TOKEN_ERROR__MINT_MISMATCH
+    | typeof TOKEN_ERROR__NATIVE_NOT_SUPPORTED
+    | typeof TOKEN_ERROR__NON_NATIVE_HAS_BALANCE
+    | typeof TOKEN_ERROR__NON_NATIVE_NOT_SUPPORTED
+    | typeof TOKEN_ERROR__NOT_RENT_EXEMPT
+    | typeof TOKEN_ERROR__OVERFLOW
+    | typeof TOKEN_ERROR__OWNER_MISMATCH
+    | typeof TOKEN_ERROR__UNINITIALIZED_STATE;
 
 let tokenErrorMessages: Record<TokenError, string> | undefined;
 if (process.env.NODE_ENV !== 'production') {
-  tokenErrorMessages = {
-    [TOKEN_ERROR__ACCOUNT_FROZEN]: `Account is frozen`,
-    [TOKEN_ERROR__ALREADY_IN_USE]: `Already in use`,
-    [TOKEN_ERROR__AUTHORITY_TYPE_NOT_SUPPORTED]: `Account does not support specified authority type`,
-    [TOKEN_ERROR__FIXED_SUPPLY]: `Fixed supply`,
-    [TOKEN_ERROR__INSUFFICIENT_FUNDS]: `Insufficient funds`,
-    [TOKEN_ERROR__INVALID_INSTRUCTION]: `Invalid instruction`,
-    [TOKEN_ERROR__INVALID_MINT]: `Invalid Mint`,
-    [TOKEN_ERROR__INVALID_NUMBER_OF_PROVIDED_SIGNERS]: `Invalid number of provided signers`,
-    [TOKEN_ERROR__INVALID_NUMBER_OF_REQUIRED_SIGNERS]: `Invalid number of required signers`,
-    [TOKEN_ERROR__INVALID_STATE]: `State is invalid for requested operation`,
-    [TOKEN_ERROR__MINT_CANNOT_FREEZE]: `This token mint cannot freeze accounts`,
-    [TOKEN_ERROR__MINT_DECIMALS_MISMATCH]: `The provided decimals value different from the Mint decimals`,
-    [TOKEN_ERROR__MINT_MISMATCH]: `Account not associated with this Mint`,
-    [TOKEN_ERROR__NATIVE_NOT_SUPPORTED]: `Instruction does not support native tokens`,
-    [TOKEN_ERROR__NON_NATIVE_HAS_BALANCE]: `Non-native account can only be closed if its balance is zero`,
-    [TOKEN_ERROR__NON_NATIVE_NOT_SUPPORTED]: `Instruction does not support non-native tokens`,
-    [TOKEN_ERROR__NOT_RENT_EXEMPT]: `Lamport balance below rent-exempt threshold`,
-    [TOKEN_ERROR__OVERFLOW]: `Operation overflowed`,
-    [TOKEN_ERROR__OWNER_MISMATCH]: `Owner does not match`,
-    [TOKEN_ERROR__UNINITIALIZED_STATE]: `State is unititialized`,
-  };
+    tokenErrorMessages = {
+        [TOKEN_ERROR__ACCOUNT_FROZEN]: `Account is frozen`,
+        [TOKEN_ERROR__ALREADY_IN_USE]: `Already in use`,
+        [TOKEN_ERROR__AUTHORITY_TYPE_NOT_SUPPORTED]: `Account does not support specified authority type`,
+        [TOKEN_ERROR__FIXED_SUPPLY]: `Fixed supply`,
+        [TOKEN_ERROR__INSUFFICIENT_FUNDS]: `Insufficient funds`,
+        [TOKEN_ERROR__INVALID_INSTRUCTION]: `Invalid instruction`,
+        [TOKEN_ERROR__INVALID_MINT]: `Invalid Mint`,
+        [TOKEN_ERROR__INVALID_NUMBER_OF_PROVIDED_SIGNERS]: `Invalid number of provided signers`,
+        [TOKEN_ERROR__INVALID_NUMBER_OF_REQUIRED_SIGNERS]: `Invalid number of required signers`,
+        [TOKEN_ERROR__INVALID_STATE]: `State is invalid for requested operation`,
+        [TOKEN_ERROR__MINT_CANNOT_FREEZE]: `This token mint cannot freeze accounts`,
+        [TOKEN_ERROR__MINT_DECIMALS_MISMATCH]: `The provided decimals value different from the Mint decimals`,
+        [TOKEN_ERROR__MINT_MISMATCH]: `Account not associated with this Mint`,
+        [TOKEN_ERROR__NATIVE_NOT_SUPPORTED]: `Instruction does not support native tokens`,
+        [TOKEN_ERROR__NON_NATIVE_HAS_BALANCE]: `Non-native account can only be closed if its balance is zero`,
+        [TOKEN_ERROR__NON_NATIVE_NOT_SUPPORTED]: `Instruction does not support non-native tokens`,
+        [TOKEN_ERROR__NOT_RENT_EXEMPT]: `Lamport balance below rent-exempt threshold`,
+        [TOKEN_ERROR__OVERFLOW]: `Operation overflowed`,
+        [TOKEN_ERROR__OWNER_MISMATCH]: `Owner does not match`,
+        [TOKEN_ERROR__UNINITIALIZED_STATE]: `State is unititialized`,
+    };
 }
 
 export function getTokenErrorMessage(code: TokenError): string {
-  if (process.env.NODE_ENV !== 'production') {
-    return (tokenErrorMessages as Record<TokenError, string>)[code];
-  }
+    if (process.env.NODE_ENV !== 'production') {
+        return (tokenErrorMessages as Record<TokenError, string>)[code];
+    }
 
-  return 'Error message not available in production bundles.';
+    return 'Error message not available in production bundles.';
 }
 
 export function isTokenError<TProgramErrorCode extends TokenError>(
-  error: unknown,
-  transactionMessage: {
-    instructions: Record<number, { programAddress: Address }>;
-  },
-  code?: TProgramErrorCode
+    error: unknown,
+    transactionMessage: { instructions: Record<number, { programAddress: Address }> },
+    code?: TProgramErrorCode
 ): error is SolanaError<typeof SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM> &
-  Readonly<{ context: Readonly<{ code: TProgramErrorCode }> }> {
-  return isProgramError<TProgramErrorCode>(
-    error,
-    transactionMessage,
-    TOKEN_PROGRAM_ADDRESS,
-    code
-  );
+    Readonly<{ context: Readonly<{ code: TProgramErrorCode }> }> {
+    return isProgramError<TProgramErrorCode>(error, transactionMessage, TOKEN_PROGRAM_ADDRESS, code);
 }

--- a/test/e2e/token/src/generated/instructions/amountToUiAmount.ts
+++ b/test/e2e/token/src/generated/instructions/amountToUiAmount.ts
@@ -7,24 +7,24 @@
  */
 
 import {
-  combineCodec,
-  getStructDecoder,
-  getStructEncoder,
-  getU64Decoder,
-  getU64Encoder,
-  getU8Decoder,
-  getU8Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyAccount,
-  type ReadonlyUint8Array,
+    combineCodec,
+    getStructDecoder,
+    getStructEncoder,
+    getU64Decoder,
+    getU64Encoder,
+    getU8Decoder,
+    getU8Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyAccount,
+    type ReadonlyUint8Array,
 } from '@solana/kit';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -32,133 +32,115 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const AMOUNT_TO_UI_AMOUNT_DISCRIMINATOR = 23;
 
 export function getAmountToUiAmountDiscriminatorBytes() {
-  return getU8Encoder().encode(AMOUNT_TO_UI_AMOUNT_DISCRIMINATOR);
+    return getU8Encoder().encode(AMOUNT_TO_UI_AMOUNT_DISCRIMINATOR);
 }
 
 export type AmountToUiAmountInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMint extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMint extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountMint extends string
-        ? ReadonlyAccount<TAccountMint>
-        : TAccountMint,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [TAccountMint extends string ? ReadonlyAccount<TAccountMint> : TAccountMint, ...TRemainingAccounts]
+    >;
 
 export type AmountToUiAmountInstructionData = {
-  discriminator: number;
-  /** The amount of tokens to reformat. */
-  amount: bigint;
+    discriminator: number;
+    /** The amount of tokens to reformat. */
+    amount: bigint;
 };
 
 export type AmountToUiAmountInstructionDataArgs = {
-  /** The amount of tokens to reformat. */
-  amount: number | bigint;
+    /** The amount of tokens to reformat. */
+    amount: number | bigint;
 };
 
 export function getAmountToUiAmountInstructionDataEncoder(): FixedSizeEncoder<AmountToUiAmountInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', getU8Encoder()],
-      ['amount', getU64Encoder()],
-    ]),
-    (value) => ({ ...value, discriminator: AMOUNT_TO_UI_AMOUNT_DISCRIMINATOR })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', getU8Encoder()],
+            ['amount', getU64Encoder()],
+        ]),
+        value => ({ ...value, discriminator: AMOUNT_TO_UI_AMOUNT_DISCRIMINATOR })
+    );
 }
 
 export function getAmountToUiAmountInstructionDataDecoder(): FixedSizeDecoder<AmountToUiAmountInstructionData> {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-    ['amount', getU64Decoder()],
-  ]);
+    return getStructDecoder([
+        ['discriminator', getU8Decoder()],
+        ['amount', getU64Decoder()],
+    ]);
 }
 
 export function getAmountToUiAmountInstructionDataCodec(): FixedSizeCodec<
-  AmountToUiAmountInstructionDataArgs,
-  AmountToUiAmountInstructionData
+    AmountToUiAmountInstructionDataArgs,
+    AmountToUiAmountInstructionData
 > {
-  return combineCodec(
-    getAmountToUiAmountInstructionDataEncoder(),
-    getAmountToUiAmountInstructionDataDecoder()
-  );
+    return combineCodec(getAmountToUiAmountInstructionDataEncoder(), getAmountToUiAmountInstructionDataDecoder());
 }
 
 export type AmountToUiAmountInput<TAccountMint extends string = string> = {
-  /** The mint to calculate for. */
-  mint: Address<TAccountMint>;
-  amount: AmountToUiAmountInstructionDataArgs['amount'];
+    /** The mint to calculate for. */
+    mint: Address<TAccountMint>;
+    amount: AmountToUiAmountInstructionDataArgs['amount'];
 };
 
 export function getAmountToUiAmountInstruction<
-  TAccountMint extends string,
-  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMint extends string,
+    TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: AmountToUiAmountInput<TAccountMint>,
-  config?: { programAddress?: TProgramAddress }
+    input: AmountToUiAmountInput<TAccountMint>,
+    config?: { programAddress?: TProgramAddress }
 ): AmountToUiAmountInstruction<TProgramAddress, TAccountMint> {
-  // Program address.
-  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
+    // Program address.
+    const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
-  // Original accounts.
-  const originalAccounts = {
-    mint: { value: input.mint ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
+    // Original accounts.
+    const originalAccounts = { mint: { value: input.mint ?? null, isWritable: false } };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
 
-  // Original args.
-  const args = { ...input };
+    // Original args.
+    const args = { ...input };
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [getAccountMeta(accounts.mint)],
-    data: getAmountToUiAmountInstructionDataEncoder().encode(
-      args as AmountToUiAmountInstructionDataArgs
-    ),
-    programAddress,
-  } as AmountToUiAmountInstruction<TProgramAddress, TAccountMint>);
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [getAccountMeta(accounts.mint)],
+        data: getAmountToUiAmountInstructionDataEncoder().encode(args as AmountToUiAmountInstructionDataArgs),
+        programAddress,
+    } as AmountToUiAmountInstruction<TProgramAddress, TAccountMint>);
 }
 
 export type ParsedAmountToUiAmountInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    /** The mint to calculate for. */
-    mint: TAccountMetas[0];
-  };
-  data: AmountToUiAmountInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        /** The mint to calculate for. */
+        mint: TAccountMetas[0];
+    };
+    data: AmountToUiAmountInstructionData;
 };
 
-export function parseAmountToUiAmountInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
->(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+export function parseAmountToUiAmountInstruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedAmountToUiAmountInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 1) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: { mint: getNextAccount() },
-    data: getAmountToUiAmountInstructionDataDecoder().decode(instruction.data),
-  };
+    if (instruction.accounts.length < 1) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { mint: getNextAccount() },
+        data: getAmountToUiAmountInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/token/src/generated/instructions/approve.ts
+++ b/test/e2e/token/src/generated/instructions/approve.ts
@@ -7,29 +7,29 @@
  */
 
 import {
-  AccountRole,
-  combineCodec,
-  getStructDecoder,
-  getStructEncoder,
-  getU64Decoder,
-  getU64Encoder,
-  getU8Decoder,
-  getU8Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyAccount,
-  type ReadonlySignerAccount,
-  type ReadonlyUint8Array,
-  type TransactionSigner,
-  type WritableAccount,
+    AccountRole,
+    combineCodec,
+    getStructDecoder,
+    getStructEncoder,
+    getU64Decoder,
+    getU64Encoder,
+    getU8Decoder,
+    getU8Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyAccount,
+    type ReadonlySignerAccount,
+    type ReadonlyUint8Array,
+    type TransactionSigner,
+    type WritableAccount,
 } from '@solana/kit';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -37,190 +37,164 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const APPROVE_DISCRIMINATOR = 4;
 
 export function getApproveDiscriminatorBytes() {
-  return getU8Encoder().encode(APPROVE_DISCRIMINATOR);
+    return getU8Encoder().encode(APPROVE_DISCRIMINATOR);
 }
 
 export type ApproveInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountSource extends string | AccountMeta<string> = string,
-  TAccountDelegate extends string | AccountMeta<string> = string,
-  TAccountOwner extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountSource extends string | AccountMeta<string> = string,
+    TAccountDelegate extends string | AccountMeta<string> = string,
+    TAccountOwner extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountSource extends string
-        ? WritableAccount<TAccountSource>
-        : TAccountSource,
-      TAccountDelegate extends string
-        ? ReadonlyAccount<TAccountDelegate>
-        : TAccountDelegate,
-      TAccountOwner extends string
-        ? ReadonlyAccount<TAccountOwner>
-        : TAccountOwner,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountSource extends string ? WritableAccount<TAccountSource> : TAccountSource,
+            TAccountDelegate extends string ? ReadonlyAccount<TAccountDelegate> : TAccountDelegate,
+            TAccountOwner extends string ? ReadonlyAccount<TAccountOwner> : TAccountOwner,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type ApproveInstructionData = {
-  discriminator: number;
-  /** The amount of tokens the delegate is approved for. */
-  amount: bigint;
+    discriminator: number;
+    /** The amount of tokens the delegate is approved for. */
+    amount: bigint;
 };
 
 export type ApproveInstructionDataArgs = {
-  /** The amount of tokens the delegate is approved for. */
-  amount: number | bigint;
+    /** The amount of tokens the delegate is approved for. */
+    amount: number | bigint;
 };
 
 export function getApproveInstructionDataEncoder(): FixedSizeEncoder<ApproveInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', getU8Encoder()],
-      ['amount', getU64Encoder()],
-    ]),
-    (value) => ({ ...value, discriminator: APPROVE_DISCRIMINATOR })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', getU8Encoder()],
+            ['amount', getU64Encoder()],
+        ]),
+        value => ({ ...value, discriminator: APPROVE_DISCRIMINATOR })
+    );
 }
 
 export function getApproveInstructionDataDecoder(): FixedSizeDecoder<ApproveInstructionData> {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-    ['amount', getU64Decoder()],
-  ]);
+    return getStructDecoder([
+        ['discriminator', getU8Decoder()],
+        ['amount', getU64Decoder()],
+    ]);
 }
 
-export function getApproveInstructionDataCodec(): FixedSizeCodec<
-  ApproveInstructionDataArgs,
-  ApproveInstructionData
-> {
-  return combineCodec(
-    getApproveInstructionDataEncoder(),
-    getApproveInstructionDataDecoder()
-  );
+export function getApproveInstructionDataCodec(): FixedSizeCodec<ApproveInstructionDataArgs, ApproveInstructionData> {
+    return combineCodec(getApproveInstructionDataEncoder(), getApproveInstructionDataDecoder());
 }
 
 export type ApproveInput<
-  TAccountSource extends string = string,
-  TAccountDelegate extends string = string,
-  TAccountOwner extends string = string,
+    TAccountSource extends string = string,
+    TAccountDelegate extends string = string,
+    TAccountOwner extends string = string,
 > = {
-  /** The source account. */
-  source: Address<TAccountSource>;
-  /** The delegate. */
-  delegate: Address<TAccountDelegate>;
-  /** The source account owner or its multisignature account. */
-  owner: Address<TAccountOwner> | TransactionSigner<TAccountOwner>;
-  amount: ApproveInstructionDataArgs['amount'];
-  multiSigners?: Array<TransactionSigner>;
+    /** The source account. */
+    source: Address<TAccountSource>;
+    /** The delegate. */
+    delegate: Address<TAccountDelegate>;
+    /** The source account owner or its multisignature account. */
+    owner: Address<TAccountOwner> | TransactionSigner<TAccountOwner>;
+    amount: ApproveInstructionDataArgs['amount'];
+    multiSigners?: Array<TransactionSigner>;
 };
 
 export function getApproveInstruction<
-  TAccountSource extends string,
-  TAccountDelegate extends string,
-  TAccountOwner extends string,
-  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountSource extends string,
+    TAccountDelegate extends string,
+    TAccountOwner extends string,
+    TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: ApproveInput<TAccountSource, TAccountDelegate, TAccountOwner>,
-  config?: { programAddress?: TProgramAddress }
+    input: ApproveInput<TAccountSource, TAccountDelegate, TAccountOwner>,
+    config?: { programAddress?: TProgramAddress }
 ): ApproveInstruction<
-  TProgramAddress,
-  TAccountSource,
-  TAccountDelegate,
-  (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
-    ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
-    : TAccountOwner
-> {
-  // Program address.
-  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
-
-  // Original accounts.
-  const originalAccounts = {
-    source: { value: input.source ?? null, isWritable: true },
-    delegate: { value: input.delegate ?? null, isWritable: false },
-    owner: { value: input.owner ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
-
-  // Original args.
-  const args = { ...input };
-
-  // Remaining accounts.
-  const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(
-    (signer) => ({
-      address: signer.address,
-      role: AccountRole.READONLY_SIGNER,
-      signer,
-    })
-  );
-
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.source),
-      getAccountMeta(accounts.delegate),
-      getAccountMeta(accounts.owner),
-      ...remainingAccounts,
-    ],
-    data: getApproveInstructionDataEncoder().encode(
-      args as ApproveInstructionDataArgs
-    ),
-    programAddress,
-  } as ApproveInstruction<
     TProgramAddress,
     TAccountSource,
     TAccountDelegate,
     (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
-      ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
-      : TAccountOwner
-  >);
+        ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
+        : TAccountOwner
+> {
+    // Program address.
+    const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
+
+    // Original accounts.
+    const originalAccounts = {
+        source: { value: input.source ?? null, isWritable: true },
+        delegate: { value: input.delegate ?? null, isWritable: false },
+        owner: { value: input.owner ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
+
+    // Original args.
+    const args = { ...input };
+
+    // Remaining accounts.
+    const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(signer => ({
+        address: signer.address,
+        role: AccountRole.READONLY_SIGNER,
+        signer,
+    }));
+
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [
+            getAccountMeta(accounts.source),
+            getAccountMeta(accounts.delegate),
+            getAccountMeta(accounts.owner),
+            ...remainingAccounts,
+        ],
+        data: getApproveInstructionDataEncoder().encode(args as ApproveInstructionDataArgs),
+        programAddress,
+    } as ApproveInstruction<
+        TProgramAddress,
+        TAccountSource,
+        TAccountDelegate,
+        (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
+            ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
+            : TAccountOwner
+    >);
 }
 
 export type ParsedApproveInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    /** The source account. */
-    source: TAccountMetas[0];
-    /** The delegate. */
-    delegate: TAccountMetas[1];
-    /** The source account owner or its multisignature account. */
-    owner: TAccountMetas[2];
-  };
-  data: ApproveInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        /** The source account. */
+        source: TAccountMetas[0];
+        /** The delegate. */
+        delegate: TAccountMetas[1];
+        /** The source account owner or its multisignature account. */
+        owner: TAccountMetas[2];
+    };
+    data: ApproveInstructionData;
 };
 
-export function parseApproveInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
->(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+export function parseApproveInstruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedApproveInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 3) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: {
-      source: getNextAccount(),
-      delegate: getNextAccount(),
-      owner: getNextAccount(),
-    },
-    data: getApproveInstructionDataDecoder().decode(instruction.data),
-  };
+    if (instruction.accounts.length < 3) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { source: getNextAccount(), delegate: getNextAccount(), owner: getNextAccount() },
+        data: getApproveInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/token/src/generated/instructions/approveChecked.ts
+++ b/test/e2e/token/src/generated/instructions/approveChecked.ts
@@ -7,29 +7,29 @@
  */
 
 import {
-  AccountRole,
-  combineCodec,
-  getStructDecoder,
-  getStructEncoder,
-  getU64Decoder,
-  getU64Encoder,
-  getU8Decoder,
-  getU8Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyAccount,
-  type ReadonlySignerAccount,
-  type ReadonlyUint8Array,
-  type TransactionSigner,
-  type WritableAccount,
+    AccountRole,
+    combineCodec,
+    getStructDecoder,
+    getStructEncoder,
+    getU64Decoder,
+    getU64Encoder,
+    getU8Decoder,
+    getU8Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyAccount,
+    type ReadonlySignerAccount,
+    type ReadonlyUint8Array,
+    type TransactionSigner,
+    type WritableAccount,
 } from '@solana/kit';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -37,217 +37,191 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const APPROVE_CHECKED_DISCRIMINATOR = 13;
 
 export function getApproveCheckedDiscriminatorBytes() {
-  return getU8Encoder().encode(APPROVE_CHECKED_DISCRIMINATOR);
+    return getU8Encoder().encode(APPROVE_CHECKED_DISCRIMINATOR);
 }
 
 export type ApproveCheckedInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountSource extends string | AccountMeta<string> = string,
-  TAccountMint extends string | AccountMeta<string> = string,
-  TAccountDelegate extends string | AccountMeta<string> = string,
-  TAccountOwner extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountSource extends string | AccountMeta<string> = string,
+    TAccountMint extends string | AccountMeta<string> = string,
+    TAccountDelegate extends string | AccountMeta<string> = string,
+    TAccountOwner extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountSource extends string
-        ? WritableAccount<TAccountSource>
-        : TAccountSource,
-      TAccountMint extends string
-        ? ReadonlyAccount<TAccountMint>
-        : TAccountMint,
-      TAccountDelegate extends string
-        ? ReadonlyAccount<TAccountDelegate>
-        : TAccountDelegate,
-      TAccountOwner extends string
-        ? ReadonlyAccount<TAccountOwner>
-        : TAccountOwner,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountSource extends string ? WritableAccount<TAccountSource> : TAccountSource,
+            TAccountMint extends string ? ReadonlyAccount<TAccountMint> : TAccountMint,
+            TAccountDelegate extends string ? ReadonlyAccount<TAccountDelegate> : TAccountDelegate,
+            TAccountOwner extends string ? ReadonlyAccount<TAccountOwner> : TAccountOwner,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type ApproveCheckedInstructionData = {
-  discriminator: number;
-  /** The amount of tokens the delegate is approved for. */
-  amount: bigint;
-  /** Expected number of base 10 digits to the right of the decimal place. */
-  decimals: number;
+    discriminator: number;
+    /** The amount of tokens the delegate is approved for. */
+    amount: bigint;
+    /** Expected number of base 10 digits to the right of the decimal place. */
+    decimals: number;
 };
 
 export type ApproveCheckedInstructionDataArgs = {
-  /** The amount of tokens the delegate is approved for. */
-  amount: number | bigint;
-  /** Expected number of base 10 digits to the right of the decimal place. */
-  decimals: number;
+    /** The amount of tokens the delegate is approved for. */
+    amount: number | bigint;
+    /** Expected number of base 10 digits to the right of the decimal place. */
+    decimals: number;
 };
 
 export function getApproveCheckedInstructionDataEncoder(): FixedSizeEncoder<ApproveCheckedInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', getU8Encoder()],
-      ['amount', getU64Encoder()],
-      ['decimals', getU8Encoder()],
-    ]),
-    (value) => ({ ...value, discriminator: APPROVE_CHECKED_DISCRIMINATOR })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', getU8Encoder()],
+            ['amount', getU64Encoder()],
+            ['decimals', getU8Encoder()],
+        ]),
+        value => ({ ...value, discriminator: APPROVE_CHECKED_DISCRIMINATOR })
+    );
 }
 
 export function getApproveCheckedInstructionDataDecoder(): FixedSizeDecoder<ApproveCheckedInstructionData> {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-    ['amount', getU64Decoder()],
-    ['decimals', getU8Decoder()],
-  ]);
+    return getStructDecoder([
+        ['discriminator', getU8Decoder()],
+        ['amount', getU64Decoder()],
+        ['decimals', getU8Decoder()],
+    ]);
 }
 
 export function getApproveCheckedInstructionDataCodec(): FixedSizeCodec<
-  ApproveCheckedInstructionDataArgs,
-  ApproveCheckedInstructionData
+    ApproveCheckedInstructionDataArgs,
+    ApproveCheckedInstructionData
 > {
-  return combineCodec(
-    getApproveCheckedInstructionDataEncoder(),
-    getApproveCheckedInstructionDataDecoder()
-  );
+    return combineCodec(getApproveCheckedInstructionDataEncoder(), getApproveCheckedInstructionDataDecoder());
 }
 
 export type ApproveCheckedInput<
-  TAccountSource extends string = string,
-  TAccountMint extends string = string,
-  TAccountDelegate extends string = string,
-  TAccountOwner extends string = string,
+    TAccountSource extends string = string,
+    TAccountMint extends string = string,
+    TAccountDelegate extends string = string,
+    TAccountOwner extends string = string,
 > = {
-  /** The source account. */
-  source: Address<TAccountSource>;
-  /** The token mint. */
-  mint: Address<TAccountMint>;
-  /** The delegate. */
-  delegate: Address<TAccountDelegate>;
-  /** The source account owner or its multisignature account. */
-  owner: Address<TAccountOwner> | TransactionSigner<TAccountOwner>;
-  amount: ApproveCheckedInstructionDataArgs['amount'];
-  decimals: ApproveCheckedInstructionDataArgs['decimals'];
-  multiSigners?: Array<TransactionSigner>;
+    /** The source account. */
+    source: Address<TAccountSource>;
+    /** The token mint. */
+    mint: Address<TAccountMint>;
+    /** The delegate. */
+    delegate: Address<TAccountDelegate>;
+    /** The source account owner or its multisignature account. */
+    owner: Address<TAccountOwner> | TransactionSigner<TAccountOwner>;
+    amount: ApproveCheckedInstructionDataArgs['amount'];
+    decimals: ApproveCheckedInstructionDataArgs['decimals'];
+    multiSigners?: Array<TransactionSigner>;
 };
 
 export function getApproveCheckedInstruction<
-  TAccountSource extends string,
-  TAccountMint extends string,
-  TAccountDelegate extends string,
-  TAccountOwner extends string,
-  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountSource extends string,
+    TAccountMint extends string,
+    TAccountDelegate extends string,
+    TAccountOwner extends string,
+    TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: ApproveCheckedInput<
-    TAccountSource,
-    TAccountMint,
-    TAccountDelegate,
-    TAccountOwner
-  >,
-  config?: { programAddress?: TProgramAddress }
+    input: ApproveCheckedInput<TAccountSource, TAccountMint, TAccountDelegate, TAccountOwner>,
+    config?: { programAddress?: TProgramAddress }
 ): ApproveCheckedInstruction<
-  TProgramAddress,
-  TAccountSource,
-  TAccountMint,
-  TAccountDelegate,
-  (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
-    ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
-    : TAccountOwner
-> {
-  // Program address.
-  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
-
-  // Original accounts.
-  const originalAccounts = {
-    source: { value: input.source ?? null, isWritable: true },
-    mint: { value: input.mint ?? null, isWritable: false },
-    delegate: { value: input.delegate ?? null, isWritable: false },
-    owner: { value: input.owner ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
-
-  // Original args.
-  const args = { ...input };
-
-  // Remaining accounts.
-  const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(
-    (signer) => ({
-      address: signer.address,
-      role: AccountRole.READONLY_SIGNER,
-      signer,
-    })
-  );
-
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.source),
-      getAccountMeta(accounts.mint),
-      getAccountMeta(accounts.delegate),
-      getAccountMeta(accounts.owner),
-      ...remainingAccounts,
-    ],
-    data: getApproveCheckedInstructionDataEncoder().encode(
-      args as ApproveCheckedInstructionDataArgs
-    ),
-    programAddress,
-  } as ApproveCheckedInstruction<
     TProgramAddress,
     TAccountSource,
     TAccountMint,
     TAccountDelegate,
     (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
-      ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
-      : TAccountOwner
-  >);
+        ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
+        : TAccountOwner
+> {
+    // Program address.
+    const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
+
+    // Original accounts.
+    const originalAccounts = {
+        source: { value: input.source ?? null, isWritable: true },
+        mint: { value: input.mint ?? null, isWritable: false },
+        delegate: { value: input.delegate ?? null, isWritable: false },
+        owner: { value: input.owner ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
+
+    // Original args.
+    const args = { ...input };
+
+    // Remaining accounts.
+    const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(signer => ({
+        address: signer.address,
+        role: AccountRole.READONLY_SIGNER,
+        signer,
+    }));
+
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [
+            getAccountMeta(accounts.source),
+            getAccountMeta(accounts.mint),
+            getAccountMeta(accounts.delegate),
+            getAccountMeta(accounts.owner),
+            ...remainingAccounts,
+        ],
+        data: getApproveCheckedInstructionDataEncoder().encode(args as ApproveCheckedInstructionDataArgs),
+        programAddress,
+    } as ApproveCheckedInstruction<
+        TProgramAddress,
+        TAccountSource,
+        TAccountMint,
+        TAccountDelegate,
+        (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
+            ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
+            : TAccountOwner
+    >);
 }
 
 export type ParsedApproveCheckedInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    /** The source account. */
-    source: TAccountMetas[0];
-    /** The token mint. */
-    mint: TAccountMetas[1];
-    /** The delegate. */
-    delegate: TAccountMetas[2];
-    /** The source account owner or its multisignature account. */
-    owner: TAccountMetas[3];
-  };
-  data: ApproveCheckedInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        /** The source account. */
+        source: TAccountMetas[0];
+        /** The token mint. */
+        mint: TAccountMetas[1];
+        /** The delegate. */
+        delegate: TAccountMetas[2];
+        /** The source account owner or its multisignature account. */
+        owner: TAccountMetas[3];
+    };
+    data: ApproveCheckedInstructionData;
 };
 
-export function parseApproveCheckedInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
->(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+export function parseApproveCheckedInstruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedApproveCheckedInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 4) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: {
-      source: getNextAccount(),
-      mint: getNextAccount(),
-      delegate: getNextAccount(),
-      owner: getNextAccount(),
-    },
-    data: getApproveCheckedInstructionDataDecoder().decode(instruction.data),
-  };
+    if (instruction.accounts.length < 4) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: {
+            source: getNextAccount(),
+            mint: getNextAccount(),
+            delegate: getNextAccount(),
+            owner: getNextAccount(),
+        },
+        data: getApproveCheckedInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/token/src/generated/instructions/burn.ts
+++ b/test/e2e/token/src/generated/instructions/burn.ts
@@ -7,29 +7,29 @@
  */
 
 import {
-  AccountRole,
-  combineCodec,
-  getStructDecoder,
-  getStructEncoder,
-  getU64Decoder,
-  getU64Encoder,
-  getU8Decoder,
-  getU8Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyAccount,
-  type ReadonlySignerAccount,
-  type ReadonlyUint8Array,
-  type TransactionSigner,
-  type WritableAccount,
+    AccountRole,
+    combineCodec,
+    getStructDecoder,
+    getStructEncoder,
+    getU64Decoder,
+    getU64Encoder,
+    getU8Decoder,
+    getU8Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyAccount,
+    type ReadonlySignerAccount,
+    type ReadonlyUint8Array,
+    type TransactionSigner,
+    type WritableAccount,
 } from '@solana/kit';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -37,189 +37,161 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const BURN_DISCRIMINATOR = 8;
 
 export function getBurnDiscriminatorBytes() {
-  return getU8Encoder().encode(BURN_DISCRIMINATOR);
+    return getU8Encoder().encode(BURN_DISCRIMINATOR);
 }
 
 export type BurnInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountAccount extends string | AccountMeta<string> = string,
-  TAccountMint extends string | AccountMeta<string> = string,
-  TAccountAuthority extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountAccount extends string | AccountMeta<string> = string,
+    TAccountMint extends string | AccountMeta<string> = string,
+    TAccountAuthority extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountAccount extends string
-        ? WritableAccount<TAccountAccount>
-        : TAccountAccount,
-      TAccountMint extends string
-        ? WritableAccount<TAccountMint>
-        : TAccountMint,
-      TAccountAuthority extends string
-        ? ReadonlyAccount<TAccountAuthority>
-        : TAccountAuthority,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountAccount extends string ? WritableAccount<TAccountAccount> : TAccountAccount,
+            TAccountMint extends string ? WritableAccount<TAccountMint> : TAccountMint,
+            TAccountAuthority extends string ? ReadonlyAccount<TAccountAuthority> : TAccountAuthority,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type BurnInstructionData = {
-  /** The amount of tokens to burn. */
-  discriminator: number;
-  amount: bigint;
+    /** The amount of tokens to burn. */
+    discriminator: number;
+    amount: bigint;
 };
 
 export type BurnInstructionDataArgs = { amount: number | bigint };
 
 export function getBurnInstructionDataEncoder(): FixedSizeEncoder<BurnInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', getU8Encoder()],
-      ['amount', getU64Encoder()],
-    ]),
-    (value) => ({ ...value, discriminator: BURN_DISCRIMINATOR })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', getU8Encoder()],
+            ['amount', getU64Encoder()],
+        ]),
+        value => ({ ...value, discriminator: BURN_DISCRIMINATOR })
+    );
 }
 
 export function getBurnInstructionDataDecoder(): FixedSizeDecoder<BurnInstructionData> {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-    ['amount', getU64Decoder()],
-  ]);
+    return getStructDecoder([
+        ['discriminator', getU8Decoder()],
+        ['amount', getU64Decoder()],
+    ]);
 }
 
-export function getBurnInstructionDataCodec(): FixedSizeCodec<
-  BurnInstructionDataArgs,
-  BurnInstructionData
-> {
-  return combineCodec(
-    getBurnInstructionDataEncoder(),
-    getBurnInstructionDataDecoder()
-  );
+export function getBurnInstructionDataCodec(): FixedSizeCodec<BurnInstructionDataArgs, BurnInstructionData> {
+    return combineCodec(getBurnInstructionDataEncoder(), getBurnInstructionDataDecoder());
 }
 
 export type BurnInput<
-  TAccountAccount extends string = string,
-  TAccountMint extends string = string,
-  TAccountAuthority extends string = string,
+    TAccountAccount extends string = string,
+    TAccountMint extends string = string,
+    TAccountAuthority extends string = string,
 > = {
-  /** The account to burn from. */
-  account: Address<TAccountAccount>;
-  /** The token mint. */
-  mint: Address<TAccountMint>;
-  /** The account's owner/delegate or its multisignature account. */
-  authority: Address<TAccountAuthority> | TransactionSigner<TAccountAuthority>;
-  amount: BurnInstructionDataArgs['amount'];
-  multiSigners?: Array<TransactionSigner>;
+    /** The account to burn from. */
+    account: Address<TAccountAccount>;
+    /** The token mint. */
+    mint: Address<TAccountMint>;
+    /** The account's owner/delegate or its multisignature account. */
+    authority: Address<TAccountAuthority> | TransactionSigner<TAccountAuthority>;
+    amount: BurnInstructionDataArgs['amount'];
+    multiSigners?: Array<TransactionSigner>;
 };
 
 export function getBurnInstruction<
-  TAccountAccount extends string,
-  TAccountMint extends string,
-  TAccountAuthority extends string,
-  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountAccount extends string,
+    TAccountMint extends string,
+    TAccountAuthority extends string,
+    TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: BurnInput<TAccountAccount, TAccountMint, TAccountAuthority>,
-  config?: { programAddress?: TProgramAddress }
+    input: BurnInput<TAccountAccount, TAccountMint, TAccountAuthority>,
+    config?: { programAddress?: TProgramAddress }
 ): BurnInstruction<
-  TProgramAddress,
-  TAccountAccount,
-  TAccountMint,
-  (typeof input)['authority'] extends TransactionSigner<TAccountAuthority>
-    ? ReadonlySignerAccount<TAccountAuthority> &
-        AccountSignerMeta<TAccountAuthority>
-    : TAccountAuthority
-> {
-  // Program address.
-  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
-
-  // Original accounts.
-  const originalAccounts = {
-    account: { value: input.account ?? null, isWritable: true },
-    mint: { value: input.mint ?? null, isWritable: true },
-    authority: { value: input.authority ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
-
-  // Original args.
-  const args = { ...input };
-
-  // Remaining accounts.
-  const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(
-    (signer) => ({
-      address: signer.address,
-      role: AccountRole.READONLY_SIGNER,
-      signer,
-    })
-  );
-
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.account),
-      getAccountMeta(accounts.mint),
-      getAccountMeta(accounts.authority),
-      ...remainingAccounts,
-    ],
-    data: getBurnInstructionDataEncoder().encode(
-      args as BurnInstructionDataArgs
-    ),
-    programAddress,
-  } as BurnInstruction<
     TProgramAddress,
     TAccountAccount,
     TAccountMint,
     (typeof input)['authority'] extends TransactionSigner<TAccountAuthority>
-      ? ReadonlySignerAccount<TAccountAuthority> &
-          AccountSignerMeta<TAccountAuthority>
-      : TAccountAuthority
-  >);
+        ? ReadonlySignerAccount<TAccountAuthority> & AccountSignerMeta<TAccountAuthority>
+        : TAccountAuthority
+> {
+    // Program address.
+    const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
+
+    // Original accounts.
+    const originalAccounts = {
+        account: { value: input.account ?? null, isWritable: true },
+        mint: { value: input.mint ?? null, isWritable: true },
+        authority: { value: input.authority ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
+
+    // Original args.
+    const args = { ...input };
+
+    // Remaining accounts.
+    const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(signer => ({
+        address: signer.address,
+        role: AccountRole.READONLY_SIGNER,
+        signer,
+    }));
+
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [
+            getAccountMeta(accounts.account),
+            getAccountMeta(accounts.mint),
+            getAccountMeta(accounts.authority),
+            ...remainingAccounts,
+        ],
+        data: getBurnInstructionDataEncoder().encode(args as BurnInstructionDataArgs),
+        programAddress,
+    } as BurnInstruction<
+        TProgramAddress,
+        TAccountAccount,
+        TAccountMint,
+        (typeof input)['authority'] extends TransactionSigner<TAccountAuthority>
+            ? ReadonlySignerAccount<TAccountAuthority> & AccountSignerMeta<TAccountAuthority>
+            : TAccountAuthority
+    >);
 }
 
 export type ParsedBurnInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    /** The account to burn from. */
-    account: TAccountMetas[0];
-    /** The token mint. */
-    mint: TAccountMetas[1];
-    /** The account's owner/delegate or its multisignature account. */
-    authority: TAccountMetas[2];
-  };
-  data: BurnInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        /** The account to burn from. */
+        account: TAccountMetas[0];
+        /** The token mint. */
+        mint: TAccountMetas[1];
+        /** The account's owner/delegate or its multisignature account. */
+        authority: TAccountMetas[2];
+    };
+    data: BurnInstructionData;
 };
 
-export function parseBurnInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
->(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+export function parseBurnInstruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedBurnInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 3) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: {
-      account: getNextAccount(),
-      mint: getNextAccount(),
-      authority: getNextAccount(),
-    },
-    data: getBurnInstructionDataDecoder().decode(instruction.data),
-  };
+    if (instruction.accounts.length < 3) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { account: getNextAccount(), mint: getNextAccount(), authority: getNextAccount() },
+        data: getBurnInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/token/src/generated/instructions/burnChecked.ts
+++ b/test/e2e/token/src/generated/instructions/burnChecked.ts
@@ -7,29 +7,29 @@
  */
 
 import {
-  AccountRole,
-  combineCodec,
-  getStructDecoder,
-  getStructEncoder,
-  getU64Decoder,
-  getU64Encoder,
-  getU8Decoder,
-  getU8Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyAccount,
-  type ReadonlySignerAccount,
-  type ReadonlyUint8Array,
-  type TransactionSigner,
-  type WritableAccount,
+    AccountRole,
+    combineCodec,
+    getStructDecoder,
+    getStructEncoder,
+    getU64Decoder,
+    getU64Encoder,
+    getU8Decoder,
+    getU8Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyAccount,
+    type ReadonlySignerAccount,
+    type ReadonlyUint8Array,
+    type TransactionSigner,
+    type WritableAccount,
 } from '@solana/kit';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -37,199 +37,174 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const BURN_CHECKED_DISCRIMINATOR = 15;
 
 export function getBurnCheckedDiscriminatorBytes() {
-  return getU8Encoder().encode(BURN_CHECKED_DISCRIMINATOR);
+    return getU8Encoder().encode(BURN_CHECKED_DISCRIMINATOR);
 }
 
 export type BurnCheckedInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountAccount extends string | AccountMeta<string> = string,
-  TAccountMint extends string | AccountMeta<string> = string,
-  TAccountAuthority extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountAccount extends string | AccountMeta<string> = string,
+    TAccountMint extends string | AccountMeta<string> = string,
+    TAccountAuthority extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountAccount extends string
-        ? WritableAccount<TAccountAccount>
-        : TAccountAccount,
-      TAccountMint extends string
-        ? WritableAccount<TAccountMint>
-        : TAccountMint,
-      TAccountAuthority extends string
-        ? ReadonlyAccount<TAccountAuthority>
-        : TAccountAuthority,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountAccount extends string ? WritableAccount<TAccountAccount> : TAccountAccount,
+            TAccountMint extends string ? WritableAccount<TAccountMint> : TAccountMint,
+            TAccountAuthority extends string ? ReadonlyAccount<TAccountAuthority> : TAccountAuthority,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type BurnCheckedInstructionData = {
-  discriminator: number;
-  /** The amount of tokens to burn. */
-  amount: bigint;
-  /** Expected number of base 10 digits to the right of the decimal place. */
-  decimals: number;
+    discriminator: number;
+    /** The amount of tokens to burn. */
+    amount: bigint;
+    /** Expected number of base 10 digits to the right of the decimal place. */
+    decimals: number;
 };
 
 export type BurnCheckedInstructionDataArgs = {
-  /** The amount of tokens to burn. */
-  amount: number | bigint;
-  /** Expected number of base 10 digits to the right of the decimal place. */
-  decimals: number;
+    /** The amount of tokens to burn. */
+    amount: number | bigint;
+    /** Expected number of base 10 digits to the right of the decimal place. */
+    decimals: number;
 };
 
 export function getBurnCheckedInstructionDataEncoder(): FixedSizeEncoder<BurnCheckedInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', getU8Encoder()],
-      ['amount', getU64Encoder()],
-      ['decimals', getU8Encoder()],
-    ]),
-    (value) => ({ ...value, discriminator: BURN_CHECKED_DISCRIMINATOR })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', getU8Encoder()],
+            ['amount', getU64Encoder()],
+            ['decimals', getU8Encoder()],
+        ]),
+        value => ({ ...value, discriminator: BURN_CHECKED_DISCRIMINATOR })
+    );
 }
 
 export function getBurnCheckedInstructionDataDecoder(): FixedSizeDecoder<BurnCheckedInstructionData> {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-    ['amount', getU64Decoder()],
-    ['decimals', getU8Decoder()],
-  ]);
+    return getStructDecoder([
+        ['discriminator', getU8Decoder()],
+        ['amount', getU64Decoder()],
+        ['decimals', getU8Decoder()],
+    ]);
 }
 
 export function getBurnCheckedInstructionDataCodec(): FixedSizeCodec<
-  BurnCheckedInstructionDataArgs,
-  BurnCheckedInstructionData
+    BurnCheckedInstructionDataArgs,
+    BurnCheckedInstructionData
 > {
-  return combineCodec(
-    getBurnCheckedInstructionDataEncoder(),
-    getBurnCheckedInstructionDataDecoder()
-  );
+    return combineCodec(getBurnCheckedInstructionDataEncoder(), getBurnCheckedInstructionDataDecoder());
 }
 
 export type BurnCheckedInput<
-  TAccountAccount extends string = string,
-  TAccountMint extends string = string,
-  TAccountAuthority extends string = string,
+    TAccountAccount extends string = string,
+    TAccountMint extends string = string,
+    TAccountAuthority extends string = string,
 > = {
-  /** The account to burn from. */
-  account: Address<TAccountAccount>;
-  /** The token mint. */
-  mint: Address<TAccountMint>;
-  /** The account's owner/delegate or its multisignature account. */
-  authority: Address<TAccountAuthority> | TransactionSigner<TAccountAuthority>;
-  amount: BurnCheckedInstructionDataArgs['amount'];
-  decimals: BurnCheckedInstructionDataArgs['decimals'];
-  multiSigners?: Array<TransactionSigner>;
+    /** The account to burn from. */
+    account: Address<TAccountAccount>;
+    /** The token mint. */
+    mint: Address<TAccountMint>;
+    /** The account's owner/delegate or its multisignature account. */
+    authority: Address<TAccountAuthority> | TransactionSigner<TAccountAuthority>;
+    amount: BurnCheckedInstructionDataArgs['amount'];
+    decimals: BurnCheckedInstructionDataArgs['decimals'];
+    multiSigners?: Array<TransactionSigner>;
 };
 
 export function getBurnCheckedInstruction<
-  TAccountAccount extends string,
-  TAccountMint extends string,
-  TAccountAuthority extends string,
-  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountAccount extends string,
+    TAccountMint extends string,
+    TAccountAuthority extends string,
+    TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: BurnCheckedInput<TAccountAccount, TAccountMint, TAccountAuthority>,
-  config?: { programAddress?: TProgramAddress }
+    input: BurnCheckedInput<TAccountAccount, TAccountMint, TAccountAuthority>,
+    config?: { programAddress?: TProgramAddress }
 ): BurnCheckedInstruction<
-  TProgramAddress,
-  TAccountAccount,
-  TAccountMint,
-  (typeof input)['authority'] extends TransactionSigner<TAccountAuthority>
-    ? ReadonlySignerAccount<TAccountAuthority> &
-        AccountSignerMeta<TAccountAuthority>
-    : TAccountAuthority
-> {
-  // Program address.
-  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
-
-  // Original accounts.
-  const originalAccounts = {
-    account: { value: input.account ?? null, isWritable: true },
-    mint: { value: input.mint ?? null, isWritable: true },
-    authority: { value: input.authority ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
-
-  // Original args.
-  const args = { ...input };
-
-  // Remaining accounts.
-  const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(
-    (signer) => ({
-      address: signer.address,
-      role: AccountRole.READONLY_SIGNER,
-      signer,
-    })
-  );
-
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.account),
-      getAccountMeta(accounts.mint),
-      getAccountMeta(accounts.authority),
-      ...remainingAccounts,
-    ],
-    data: getBurnCheckedInstructionDataEncoder().encode(
-      args as BurnCheckedInstructionDataArgs
-    ),
-    programAddress,
-  } as BurnCheckedInstruction<
     TProgramAddress,
     TAccountAccount,
     TAccountMint,
     (typeof input)['authority'] extends TransactionSigner<TAccountAuthority>
-      ? ReadonlySignerAccount<TAccountAuthority> &
-          AccountSignerMeta<TAccountAuthority>
-      : TAccountAuthority
-  >);
+        ? ReadonlySignerAccount<TAccountAuthority> & AccountSignerMeta<TAccountAuthority>
+        : TAccountAuthority
+> {
+    // Program address.
+    const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
+
+    // Original accounts.
+    const originalAccounts = {
+        account: { value: input.account ?? null, isWritable: true },
+        mint: { value: input.mint ?? null, isWritable: true },
+        authority: { value: input.authority ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
+
+    // Original args.
+    const args = { ...input };
+
+    // Remaining accounts.
+    const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(signer => ({
+        address: signer.address,
+        role: AccountRole.READONLY_SIGNER,
+        signer,
+    }));
+
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [
+            getAccountMeta(accounts.account),
+            getAccountMeta(accounts.mint),
+            getAccountMeta(accounts.authority),
+            ...remainingAccounts,
+        ],
+        data: getBurnCheckedInstructionDataEncoder().encode(args as BurnCheckedInstructionDataArgs),
+        programAddress,
+    } as BurnCheckedInstruction<
+        TProgramAddress,
+        TAccountAccount,
+        TAccountMint,
+        (typeof input)['authority'] extends TransactionSigner<TAccountAuthority>
+            ? ReadonlySignerAccount<TAccountAuthority> & AccountSignerMeta<TAccountAuthority>
+            : TAccountAuthority
+    >);
 }
 
 export type ParsedBurnCheckedInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    /** The account to burn from. */
-    account: TAccountMetas[0];
-    /** The token mint. */
-    mint: TAccountMetas[1];
-    /** The account's owner/delegate or its multisignature account. */
-    authority: TAccountMetas[2];
-  };
-  data: BurnCheckedInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        /** The account to burn from. */
+        account: TAccountMetas[0];
+        /** The token mint. */
+        mint: TAccountMetas[1];
+        /** The account's owner/delegate or its multisignature account. */
+        authority: TAccountMetas[2];
+    };
+    data: BurnCheckedInstructionData;
 };
 
-export function parseBurnCheckedInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
->(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+export function parseBurnCheckedInstruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedBurnCheckedInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 3) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: {
-      account: getNextAccount(),
-      mint: getNextAccount(),
-      authority: getNextAccount(),
-    },
-    data: getBurnCheckedInstructionDataDecoder().decode(instruction.data),
-  };
+    if (instruction.accounts.length < 3) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { account: getNextAccount(), mint: getNextAccount(), authority: getNextAccount() },
+        data: getBurnCheckedInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/token/src/generated/instructions/closeAccount.ts
+++ b/test/e2e/token/src/generated/instructions/closeAccount.ts
@@ -7,27 +7,27 @@
  */
 
 import {
-  AccountRole,
-  combineCodec,
-  getStructDecoder,
-  getStructEncoder,
-  getU8Decoder,
-  getU8Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyAccount,
-  type ReadonlySignerAccount,
-  type ReadonlyUint8Array,
-  type TransactionSigner,
-  type WritableAccount,
+    AccountRole,
+    combineCodec,
+    getStructDecoder,
+    getStructEncoder,
+    getU8Decoder,
+    getU8Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyAccount,
+    type ReadonlySignerAccount,
+    type ReadonlyUint8Array,
+    type TransactionSigner,
+    type WritableAccount,
 } from '@solana/kit';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -35,174 +35,153 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const CLOSE_ACCOUNT_DISCRIMINATOR = 9;
 
 export function getCloseAccountDiscriminatorBytes() {
-  return getU8Encoder().encode(CLOSE_ACCOUNT_DISCRIMINATOR);
+    return getU8Encoder().encode(CLOSE_ACCOUNT_DISCRIMINATOR);
 }
 
 export type CloseAccountInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountAccount extends string | AccountMeta<string> = string,
-  TAccountDestination extends string | AccountMeta<string> = string,
-  TAccountOwner extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountAccount extends string | AccountMeta<string> = string,
+    TAccountDestination extends string | AccountMeta<string> = string,
+    TAccountOwner extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountAccount extends string
-        ? WritableAccount<TAccountAccount>
-        : TAccountAccount,
-      TAccountDestination extends string
-        ? WritableAccount<TAccountDestination>
-        : TAccountDestination,
-      TAccountOwner extends string
-        ? ReadonlyAccount<TAccountOwner>
-        : TAccountOwner,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountAccount extends string ? WritableAccount<TAccountAccount> : TAccountAccount,
+            TAccountDestination extends string ? WritableAccount<TAccountDestination> : TAccountDestination,
+            TAccountOwner extends string ? ReadonlyAccount<TAccountOwner> : TAccountOwner,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type CloseAccountInstructionData = { discriminator: number };
 
 export type CloseAccountInstructionDataArgs = {};
 
 export function getCloseAccountInstructionDataEncoder(): FixedSizeEncoder<CloseAccountInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([['discriminator', getU8Encoder()]]),
-    (value) => ({ ...value, discriminator: CLOSE_ACCOUNT_DISCRIMINATOR })
-  );
+    return transformEncoder(getStructEncoder([['discriminator', getU8Encoder()]]), value => ({
+        ...value,
+        discriminator: CLOSE_ACCOUNT_DISCRIMINATOR,
+    }));
 }
 
 export function getCloseAccountInstructionDataDecoder(): FixedSizeDecoder<CloseAccountInstructionData> {
-  return getStructDecoder([['discriminator', getU8Decoder()]]);
+    return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getCloseAccountInstructionDataCodec(): FixedSizeCodec<
-  CloseAccountInstructionDataArgs,
-  CloseAccountInstructionData
+    CloseAccountInstructionDataArgs,
+    CloseAccountInstructionData
 > {
-  return combineCodec(
-    getCloseAccountInstructionDataEncoder(),
-    getCloseAccountInstructionDataDecoder()
-  );
+    return combineCodec(getCloseAccountInstructionDataEncoder(), getCloseAccountInstructionDataDecoder());
 }
 
 export type CloseAccountInput<
-  TAccountAccount extends string = string,
-  TAccountDestination extends string = string,
-  TAccountOwner extends string = string,
+    TAccountAccount extends string = string,
+    TAccountDestination extends string = string,
+    TAccountOwner extends string = string,
 > = {
-  /** The account to close. */
-  account: Address<TAccountAccount>;
-  /** The destination account. */
-  destination: Address<TAccountDestination>;
-  /** The account's owner or its multisignature account. */
-  owner: Address<TAccountOwner> | TransactionSigner<TAccountOwner>;
-  multiSigners?: Array<TransactionSigner>;
+    /** The account to close. */
+    account: Address<TAccountAccount>;
+    /** The destination account. */
+    destination: Address<TAccountDestination>;
+    /** The account's owner or its multisignature account. */
+    owner: Address<TAccountOwner> | TransactionSigner<TAccountOwner>;
+    multiSigners?: Array<TransactionSigner>;
 };
 
 export function getCloseAccountInstruction<
-  TAccountAccount extends string,
-  TAccountDestination extends string,
-  TAccountOwner extends string,
-  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountAccount extends string,
+    TAccountDestination extends string,
+    TAccountOwner extends string,
+    TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: CloseAccountInput<TAccountAccount, TAccountDestination, TAccountOwner>,
-  config?: { programAddress?: TProgramAddress }
+    input: CloseAccountInput<TAccountAccount, TAccountDestination, TAccountOwner>,
+    config?: { programAddress?: TProgramAddress }
 ): CloseAccountInstruction<
-  TProgramAddress,
-  TAccountAccount,
-  TAccountDestination,
-  (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
-    ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
-    : TAccountOwner
-> {
-  // Program address.
-  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
-
-  // Original accounts.
-  const originalAccounts = {
-    account: { value: input.account ?? null, isWritable: true },
-    destination: { value: input.destination ?? null, isWritable: true },
-    owner: { value: input.owner ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
-
-  // Original args.
-  const args = { ...input };
-
-  // Remaining accounts.
-  const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(
-    (signer) => ({
-      address: signer.address,
-      role: AccountRole.READONLY_SIGNER,
-      signer,
-    })
-  );
-
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.account),
-      getAccountMeta(accounts.destination),
-      getAccountMeta(accounts.owner),
-      ...remainingAccounts,
-    ],
-    data: getCloseAccountInstructionDataEncoder().encode({}),
-    programAddress,
-  } as CloseAccountInstruction<
     TProgramAddress,
     TAccountAccount,
     TAccountDestination,
     (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
-      ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
-      : TAccountOwner
-  >);
+        ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
+        : TAccountOwner
+> {
+    // Program address.
+    const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
+
+    // Original accounts.
+    const originalAccounts = {
+        account: { value: input.account ?? null, isWritable: true },
+        destination: { value: input.destination ?? null, isWritable: true },
+        owner: { value: input.owner ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
+
+    // Original args.
+    const args = { ...input };
+
+    // Remaining accounts.
+    const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(signer => ({
+        address: signer.address,
+        role: AccountRole.READONLY_SIGNER,
+        signer,
+    }));
+
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [
+            getAccountMeta(accounts.account),
+            getAccountMeta(accounts.destination),
+            getAccountMeta(accounts.owner),
+            ...remainingAccounts,
+        ],
+        data: getCloseAccountInstructionDataEncoder().encode({}),
+        programAddress,
+    } as CloseAccountInstruction<
+        TProgramAddress,
+        TAccountAccount,
+        TAccountDestination,
+        (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
+            ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
+            : TAccountOwner
+    >);
 }
 
 export type ParsedCloseAccountInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    /** The account to close. */
-    account: TAccountMetas[0];
-    /** The destination account. */
-    destination: TAccountMetas[1];
-    /** The account's owner or its multisignature account. */
-    owner: TAccountMetas[2];
-  };
-  data: CloseAccountInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        /** The account to close. */
+        account: TAccountMetas[0];
+        /** The destination account. */
+        destination: TAccountMetas[1];
+        /** The account's owner or its multisignature account. */
+        owner: TAccountMetas[2];
+    };
+    data: CloseAccountInstructionData;
 };
 
-export function parseCloseAccountInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
->(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+export function parseCloseAccountInstruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedCloseAccountInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 3) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: {
-      account: getNextAccount(),
-      destination: getNextAccount(),
-      owner: getNextAccount(),
-    },
-    data: getCloseAccountInstructionDataDecoder().decode(instruction.data),
-  };
+    if (instruction.accounts.length < 3) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { account: getNextAccount(), destination: getNextAccount(), owner: getNextAccount() },
+        data: getCloseAccountInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/token/src/generated/instructions/createAccount.ts
+++ b/test/e2e/token/src/generated/instructions/createAccount.ts
@@ -7,209 +7,169 @@
  */
 
 import {
-  BASE_ACCOUNT_SIZE,
-  combineCodec,
-  getAddressDecoder,
-  getAddressEncoder,
-  getLamportsDecoder,
-  getLamportsEncoder,
-  getStructDecoder,
-  getStructEncoder,
-  getU32Decoder,
-  getU32Encoder,
-  getU64Decoder,
-  getU64Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type Lamports,
-  type ReadonlyUint8Array,
-  type TransactionSigner,
-  type WritableSignerAccount,
+    BASE_ACCOUNT_SIZE,
+    combineCodec,
+    getAddressDecoder,
+    getAddressEncoder,
+    getLamportsDecoder,
+    getLamportsEncoder,
+    getStructDecoder,
+    getStructEncoder,
+    getU32Decoder,
+    getU32Encoder,
+    getU64Decoder,
+    getU64Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type Lamports,
+    type ReadonlyUint8Array,
+    type TransactionSigner,
+    type WritableSignerAccount,
 } from '@solana/kit';
 import { SYSTEM_PROGRAM_ADDRESS } from '../programs';
-import {
-  getAccountMetaFactory,
-  type InstructionWithByteDelta,
-  type ResolvedAccount,
-} from '../shared';
+import { getAccountMetaFactory, type InstructionWithByteDelta, type ResolvedAccount } from '../shared';
 
 export const CREATE_ACCOUNT_DISCRIMINATOR = 0;
 
 export function getCreateAccountDiscriminatorBytes() {
-  return getU32Encoder().encode(CREATE_ACCOUNT_DISCRIMINATOR);
+    return getU32Encoder().encode(CREATE_ACCOUNT_DISCRIMINATOR);
 }
 
 export type CreateAccountInstruction<
-  TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountPayer extends string | AccountMeta<string> = string,
-  TAccountNewAccount extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountPayer extends string | AccountMeta<string> = string,
+    TAccountNewAccount extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountPayer extends string
-        ? WritableSignerAccount<TAccountPayer> &
-            AccountSignerMeta<TAccountPayer>
-        : TAccountPayer,
-      TAccountNewAccount extends string
-        ? WritableSignerAccount<TAccountNewAccount> &
-            AccountSignerMeta<TAccountNewAccount>
-        : TAccountNewAccount,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountPayer extends string
+                ? WritableSignerAccount<TAccountPayer> & AccountSignerMeta<TAccountPayer>
+                : TAccountPayer,
+            TAccountNewAccount extends string
+                ? WritableSignerAccount<TAccountNewAccount> & AccountSignerMeta<TAccountNewAccount>
+                : TAccountNewAccount,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type CreateAccountInstructionData = {
-  discriminator: number;
-  lamports: Lamports;
-  space: bigint;
-  programAddress: Address;
+    discriminator: number;
+    lamports: Lamports;
+    space: bigint;
+    programAddress: Address;
 };
 
-export type CreateAccountInstructionDataArgs = {
-  lamports: Lamports;
-  space: number | bigint;
-  programAddress: Address;
-};
+export type CreateAccountInstructionDataArgs = { lamports: Lamports; space: number | bigint; programAddress: Address };
 
 export function getCreateAccountInstructionDataEncoder(): FixedSizeEncoder<CreateAccountInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', getU32Encoder()],
-      ['lamports', getLamportsEncoder(getU64Encoder())],
-      ['space', getU64Encoder()],
-      ['programAddress', getAddressEncoder()],
-    ]),
-    (value) => ({ ...value, discriminator: CREATE_ACCOUNT_DISCRIMINATOR })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', getU32Encoder()],
+            ['lamports', getLamportsEncoder(getU64Encoder())],
+            ['space', getU64Encoder()],
+            ['programAddress', getAddressEncoder()],
+        ]),
+        value => ({ ...value, discriminator: CREATE_ACCOUNT_DISCRIMINATOR })
+    );
 }
 
 export function getCreateAccountInstructionDataDecoder(): FixedSizeDecoder<CreateAccountInstructionData> {
-  return getStructDecoder([
-    ['discriminator', getU32Decoder()],
-    ['lamports', getLamportsDecoder(getU64Decoder())],
-    ['space', getU64Decoder()],
-    ['programAddress', getAddressDecoder()],
-  ]);
+    return getStructDecoder([
+        ['discriminator', getU32Decoder()],
+        ['lamports', getLamportsDecoder(getU64Decoder())],
+        ['space', getU64Decoder()],
+        ['programAddress', getAddressDecoder()],
+    ]);
 }
 
 export function getCreateAccountInstructionDataCodec(): FixedSizeCodec<
-  CreateAccountInstructionDataArgs,
-  CreateAccountInstructionData
+    CreateAccountInstructionDataArgs,
+    CreateAccountInstructionData
 > {
-  return combineCodec(
-    getCreateAccountInstructionDataEncoder(),
-    getCreateAccountInstructionDataDecoder()
-  );
+    return combineCodec(getCreateAccountInstructionDataEncoder(), getCreateAccountInstructionDataDecoder());
 }
 
-export type CreateAccountInput<
-  TAccountPayer extends string = string,
-  TAccountNewAccount extends string = string,
-> = {
-  payer: TransactionSigner<TAccountPayer>;
-  newAccount: TransactionSigner<TAccountNewAccount>;
-  lamports: CreateAccountInstructionDataArgs['lamports'];
-  space: CreateAccountInstructionDataArgs['space'];
-  programAddress: CreateAccountInstructionDataArgs['programAddress'];
+export type CreateAccountInput<TAccountPayer extends string = string, TAccountNewAccount extends string = string> = {
+    payer: TransactionSigner<TAccountPayer>;
+    newAccount: TransactionSigner<TAccountNewAccount>;
+    lamports: CreateAccountInstructionDataArgs['lamports'];
+    space: CreateAccountInstructionDataArgs['space'];
+    programAddress: CreateAccountInstructionDataArgs['programAddress'];
 };
 
 export function getCreateAccountInstruction<
-  TAccountPayer extends string,
-  TAccountNewAccount extends string,
-  TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountPayer extends string,
+    TAccountNewAccount extends string,
+    TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
 >(
-  input: CreateAccountInput<TAccountPayer, TAccountNewAccount>,
-  config?: { programAddress?: TProgramAddress }
-): CreateAccountInstruction<
-  TProgramAddress,
-  TAccountPayer,
-  TAccountNewAccount
-> &
-  InstructionWithByteDelta {
-  // Program address.
-  const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
+    input: CreateAccountInput<TAccountPayer, TAccountNewAccount>,
+    config?: { programAddress?: TProgramAddress }
+): CreateAccountInstruction<TProgramAddress, TAccountPayer, TAccountNewAccount> & InstructionWithByteDelta {
+    // Program address.
+    const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
 
-  // Original accounts.
-  const originalAccounts = {
-    payer: { value: input.payer ?? null, isWritable: true },
-    newAccount: { value: input.newAccount ?? null, isWritable: true },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
+    // Original accounts.
+    const originalAccounts = {
+        payer: { value: input.payer ?? null, isWritable: true },
+        newAccount: { value: input.newAccount ?? null, isWritable: true },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
 
-  // Original args.
-  const args = { ...input };
+    // Original args.
+    const args = { ...input };
 
-  // Bytes created or reallocated by the instruction.
-  const byteDelta: number = [Number(args.space) + BASE_ACCOUNT_SIZE].reduce(
-    (a, b) => a + b,
-    0
-  );
+    // Bytes created or reallocated by the instruction.
+    const byteDelta: number = [Number(args.space) + BASE_ACCOUNT_SIZE].reduce((a, b) => a + b, 0);
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.payer),
-      getAccountMeta(accounts.newAccount),
-    ],
-    byteDelta,
-    data: getCreateAccountInstructionDataEncoder().encode(
-      args as CreateAccountInstructionDataArgs
-    ),
-    programAddress,
-  } as CreateAccountInstruction<
-    TProgramAddress,
-    TAccountPayer,
-    TAccountNewAccount
-  > &
-    InstructionWithByteDelta);
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [getAccountMeta(accounts.payer), getAccountMeta(accounts.newAccount)],
+        byteDelta,
+        data: getCreateAccountInstructionDataEncoder().encode(args as CreateAccountInstructionDataArgs),
+        programAddress,
+    } as CreateAccountInstruction<TProgramAddress, TAccountPayer, TAccountNewAccount> & InstructionWithByteDelta);
 }
 
 export type ParsedCreateAccountInstruction<
-  TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    payer: TAccountMetas[0];
-    newAccount: TAccountMetas[1];
-  };
-  data: CreateAccountInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        payer: TAccountMetas[0];
+        newAccount: TAccountMetas[1];
+    };
+    data: CreateAccountInstructionData;
 };
 
-export function parseCreateAccountInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
->(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+export function parseCreateAccountInstruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedCreateAccountInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 2) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: { payer: getNextAccount(), newAccount: getNextAccount() },
-    data: getCreateAccountInstructionDataDecoder().decode(instruction.data),
-  };
+    if (instruction.accounts.length < 2) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { payer: getNextAccount(), newAccount: getNextAccount() },
+        data: getCreateAccountInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/token/src/generated/instructions/createAssociatedToken.ts
+++ b/test/e2e/token/src/generated/instructions/createAssociatedToken.ts
@@ -7,304 +7,233 @@
  */
 
 import {
-  combineCodec,
-  getStructDecoder,
-  getStructEncoder,
-  getU8Decoder,
-  getU8Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyAccount,
-  type ReadonlyUint8Array,
-  type TransactionSigner,
-  type WritableAccount,
-  type WritableSignerAccount,
+    combineCodec,
+    getStructDecoder,
+    getStructEncoder,
+    getU8Decoder,
+    getU8Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyAccount,
+    type ReadonlyUint8Array,
+    type TransactionSigner,
+    type WritableAccount,
+    type WritableSignerAccount,
 } from '@solana/kit';
 import { findAssociatedTokenPda } from '../pdas';
 import { ASSOCIATED_TOKEN_PROGRAM_ADDRESS } from '../programs';
-import {
-  expectAddress,
-  getAccountMetaFactory,
-  type ResolvedAccount,
-} from '../shared';
+import { expectAddress, getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
 export const CREATE_ASSOCIATED_TOKEN_DISCRIMINATOR = 0;
 
 export function getCreateAssociatedTokenDiscriminatorBytes() {
-  return getU8Encoder().encode(CREATE_ASSOCIATED_TOKEN_DISCRIMINATOR);
+    return getU8Encoder().encode(CREATE_ASSOCIATED_TOKEN_DISCRIMINATOR);
 }
 
 export type CreateAssociatedTokenInstruction<
-  TProgram extends string = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
-  TAccountPayer extends string | AccountMeta<string> = string,
-  TAccountAta extends string | AccountMeta<string> = string,
-  TAccountOwner extends string | AccountMeta<string> = string,
-  TAccountMint extends string | AccountMeta<string> = string,
-  TAccountSystemProgram extends string | AccountMeta<string> =
-    '11111111111111111111111111111111',
-  TAccountTokenProgram extends string | AccountMeta<string> =
-    'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    TAccountPayer extends string | AccountMeta<string> = string,
+    TAccountAta extends string | AccountMeta<string> = string,
+    TAccountOwner extends string | AccountMeta<string> = string,
+    TAccountMint extends string | AccountMeta<string> = string,
+    TAccountSystemProgram extends string | AccountMeta<string> = '11111111111111111111111111111111',
+    TAccountTokenProgram extends string | AccountMeta<string> = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountPayer extends string
-        ? WritableSignerAccount<TAccountPayer> &
-            AccountSignerMeta<TAccountPayer>
-        : TAccountPayer,
-      TAccountAta extends string ? WritableAccount<TAccountAta> : TAccountAta,
-      TAccountOwner extends string
-        ? ReadonlyAccount<TAccountOwner>
-        : TAccountOwner,
-      TAccountMint extends string
-        ? ReadonlyAccount<TAccountMint>
-        : TAccountMint,
-      TAccountSystemProgram extends string
-        ? ReadonlyAccount<TAccountSystemProgram>
-        : TAccountSystemProgram,
-      TAccountTokenProgram extends string
-        ? ReadonlyAccount<TAccountTokenProgram>
-        : TAccountTokenProgram,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountPayer extends string
+                ? WritableSignerAccount<TAccountPayer> & AccountSignerMeta<TAccountPayer>
+                : TAccountPayer,
+            TAccountAta extends string ? WritableAccount<TAccountAta> : TAccountAta,
+            TAccountOwner extends string ? ReadonlyAccount<TAccountOwner> : TAccountOwner,
+            TAccountMint extends string ? ReadonlyAccount<TAccountMint> : TAccountMint,
+            TAccountSystemProgram extends string ? ReadonlyAccount<TAccountSystemProgram> : TAccountSystemProgram,
+            TAccountTokenProgram extends string ? ReadonlyAccount<TAccountTokenProgram> : TAccountTokenProgram,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type CreateAssociatedTokenInstructionData = { discriminator: number };
 
 export type CreateAssociatedTokenInstructionDataArgs = {};
 
 export function getCreateAssociatedTokenInstructionDataEncoder(): FixedSizeEncoder<CreateAssociatedTokenInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([['discriminator', getU8Encoder()]]),
-    (value) => ({
-      ...value,
-      discriminator: CREATE_ASSOCIATED_TOKEN_DISCRIMINATOR,
-    })
-  );
+    return transformEncoder(getStructEncoder([['discriminator', getU8Encoder()]]), value => ({
+        ...value,
+        discriminator: CREATE_ASSOCIATED_TOKEN_DISCRIMINATOR,
+    }));
 }
 
 export function getCreateAssociatedTokenInstructionDataDecoder(): FixedSizeDecoder<CreateAssociatedTokenInstructionData> {
-  return getStructDecoder([['discriminator', getU8Decoder()]]);
+    return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getCreateAssociatedTokenInstructionDataCodec(): FixedSizeCodec<
-  CreateAssociatedTokenInstructionDataArgs,
-  CreateAssociatedTokenInstructionData
+    CreateAssociatedTokenInstructionDataArgs,
+    CreateAssociatedTokenInstructionData
 > {
-  return combineCodec(
-    getCreateAssociatedTokenInstructionDataEncoder(),
-    getCreateAssociatedTokenInstructionDataDecoder()
-  );
+    return combineCodec(
+        getCreateAssociatedTokenInstructionDataEncoder(),
+        getCreateAssociatedTokenInstructionDataDecoder()
+    );
 }
 
 export type CreateAssociatedTokenAsyncInput<
-  TAccountPayer extends string = string,
-  TAccountAta extends string = string,
-  TAccountOwner extends string = string,
-  TAccountMint extends string = string,
-  TAccountSystemProgram extends string = string,
-  TAccountTokenProgram extends string = string,
+    TAccountPayer extends string = string,
+    TAccountAta extends string = string,
+    TAccountOwner extends string = string,
+    TAccountMint extends string = string,
+    TAccountSystemProgram extends string = string,
+    TAccountTokenProgram extends string = string,
 > = {
-  /** Funding account (must be a system account). */
-  payer: TransactionSigner<TAccountPayer>;
-  /** Associated token account address to be created. */
-  ata?: Address<TAccountAta>;
-  /** Wallet address for the new associated token account. */
-  owner: Address<TAccountOwner>;
-  /** The token mint for the new associated token account. */
-  mint: Address<TAccountMint>;
-  /** System program. */
-  systemProgram?: Address<TAccountSystemProgram>;
-  /** SPL Token program. */
-  tokenProgram?: Address<TAccountTokenProgram>;
+    /** Funding account (must be a system account). */
+    payer: TransactionSigner<TAccountPayer>;
+    /** Associated token account address to be created. */
+    ata?: Address<TAccountAta>;
+    /** Wallet address for the new associated token account. */
+    owner: Address<TAccountOwner>;
+    /** The token mint for the new associated token account. */
+    mint: Address<TAccountMint>;
+    /** System program. */
+    systemProgram?: Address<TAccountSystemProgram>;
+    /** SPL Token program. */
+    tokenProgram?: Address<TAccountTokenProgram>;
 };
 
 export async function getCreateAssociatedTokenInstructionAsync<
-  TAccountPayer extends string,
-  TAccountAta extends string,
-  TAccountOwner extends string,
-  TAccountMint extends string,
-  TAccountSystemProgram extends string,
-  TAccountTokenProgram extends string,
-  TProgramAddress extends Address = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    TAccountPayer extends string,
+    TAccountAta extends string,
+    TAccountOwner extends string,
+    TAccountMint extends string,
+    TAccountSystemProgram extends string,
+    TAccountTokenProgram extends string,
+    TProgramAddress extends Address = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
 >(
-  input: CreateAssociatedTokenAsyncInput<
-    TAccountPayer,
-    TAccountAta,
-    TAccountOwner,
-    TAccountMint,
-    TAccountSystemProgram,
-    TAccountTokenProgram
-  >,
-  config?: { programAddress?: TProgramAddress }
+    input: CreateAssociatedTokenAsyncInput<
+        TAccountPayer,
+        TAccountAta,
+        TAccountOwner,
+        TAccountMint,
+        TAccountSystemProgram,
+        TAccountTokenProgram
+    >,
+    config?: { programAddress?: TProgramAddress }
 ): Promise<
-  CreateAssociatedTokenInstruction<
-    TProgramAddress,
-    TAccountPayer,
-    TAccountAta,
-    TAccountOwner,
-    TAccountMint,
-    TAccountSystemProgram,
-    TAccountTokenProgram
-  >
+    CreateAssociatedTokenInstruction<
+        TProgramAddress,
+        TAccountPayer,
+        TAccountAta,
+        TAccountOwner,
+        TAccountMint,
+        TAccountSystemProgram,
+        TAccountTokenProgram
+    >
 > {
-  // Program address.
-  const programAddress =
-    config?.programAddress ?? ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
+    // Program address.
+    const programAddress = config?.programAddress ?? ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
 
-  // Original accounts.
-  const originalAccounts = {
-    payer: { value: input.payer ?? null, isWritable: true },
-    ata: { value: input.ata ?? null, isWritable: true },
-    owner: { value: input.owner ?? null, isWritable: false },
-    mint: { value: input.mint ?? null, isWritable: false },
-    systemProgram: { value: input.systemProgram ?? null, isWritable: false },
-    tokenProgram: { value: input.tokenProgram ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
+    // Original accounts.
+    const originalAccounts = {
+        payer: { value: input.payer ?? null, isWritable: true },
+        ata: { value: input.ata ?? null, isWritable: true },
+        owner: { value: input.owner ?? null, isWritable: false },
+        mint: { value: input.mint ?? null, isWritable: false },
+        systemProgram: { value: input.systemProgram ?? null, isWritable: false },
+        tokenProgram: { value: input.tokenProgram ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
 
-  // Resolve default values.
-  if (!accounts.tokenProgram.value) {
-    accounts.tokenProgram.value =
-      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' as Address<'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'>;
-  }
-  if (!accounts.ata.value) {
-    accounts.ata.value = await findAssociatedTokenPda({
-      owner: expectAddress(accounts.owner.value),
-      tokenProgram: expectAddress(accounts.tokenProgram.value),
-      mint: expectAddress(accounts.mint.value),
-    });
-  }
-  if (!accounts.systemProgram.value) {
-    accounts.systemProgram.value =
-      '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
-  }
+    // Resolve default values.
+    if (!accounts.tokenProgram.value) {
+        accounts.tokenProgram.value =
+            'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' as Address<'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'>;
+    }
+    if (!accounts.ata.value) {
+        accounts.ata.value = await findAssociatedTokenPda({
+            owner: expectAddress(accounts.owner.value),
+            tokenProgram: expectAddress(accounts.tokenProgram.value),
+            mint: expectAddress(accounts.mint.value),
+        });
+    }
+    if (!accounts.systemProgram.value) {
+        accounts.systemProgram.value =
+            '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
+    }
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.payer),
-      getAccountMeta(accounts.ata),
-      getAccountMeta(accounts.owner),
-      getAccountMeta(accounts.mint),
-      getAccountMeta(accounts.systemProgram),
-      getAccountMeta(accounts.tokenProgram),
-    ],
-    data: getCreateAssociatedTokenInstructionDataEncoder().encode({}),
-    programAddress,
-  } as CreateAssociatedTokenInstruction<
-    TProgramAddress,
-    TAccountPayer,
-    TAccountAta,
-    TAccountOwner,
-    TAccountMint,
-    TAccountSystemProgram,
-    TAccountTokenProgram
-  >);
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [
+            getAccountMeta(accounts.payer),
+            getAccountMeta(accounts.ata),
+            getAccountMeta(accounts.owner),
+            getAccountMeta(accounts.mint),
+            getAccountMeta(accounts.systemProgram),
+            getAccountMeta(accounts.tokenProgram),
+        ],
+        data: getCreateAssociatedTokenInstructionDataEncoder().encode({}),
+        programAddress,
+    } as CreateAssociatedTokenInstruction<
+        TProgramAddress,
+        TAccountPayer,
+        TAccountAta,
+        TAccountOwner,
+        TAccountMint,
+        TAccountSystemProgram,
+        TAccountTokenProgram
+    >);
 }
 
 export type CreateAssociatedTokenInput<
-  TAccountPayer extends string = string,
-  TAccountAta extends string = string,
-  TAccountOwner extends string = string,
-  TAccountMint extends string = string,
-  TAccountSystemProgram extends string = string,
-  TAccountTokenProgram extends string = string,
+    TAccountPayer extends string = string,
+    TAccountAta extends string = string,
+    TAccountOwner extends string = string,
+    TAccountMint extends string = string,
+    TAccountSystemProgram extends string = string,
+    TAccountTokenProgram extends string = string,
 > = {
-  /** Funding account (must be a system account). */
-  payer: TransactionSigner<TAccountPayer>;
-  /** Associated token account address to be created. */
-  ata: Address<TAccountAta>;
-  /** Wallet address for the new associated token account. */
-  owner: Address<TAccountOwner>;
-  /** The token mint for the new associated token account. */
-  mint: Address<TAccountMint>;
-  /** System program. */
-  systemProgram?: Address<TAccountSystemProgram>;
-  /** SPL Token program. */
-  tokenProgram?: Address<TAccountTokenProgram>;
+    /** Funding account (must be a system account). */
+    payer: TransactionSigner<TAccountPayer>;
+    /** Associated token account address to be created. */
+    ata: Address<TAccountAta>;
+    /** Wallet address for the new associated token account. */
+    owner: Address<TAccountOwner>;
+    /** The token mint for the new associated token account. */
+    mint: Address<TAccountMint>;
+    /** System program. */
+    systemProgram?: Address<TAccountSystemProgram>;
+    /** SPL Token program. */
+    tokenProgram?: Address<TAccountTokenProgram>;
 };
 
 export function getCreateAssociatedTokenInstruction<
-  TAccountPayer extends string,
-  TAccountAta extends string,
-  TAccountOwner extends string,
-  TAccountMint extends string,
-  TAccountSystemProgram extends string,
-  TAccountTokenProgram extends string,
-  TProgramAddress extends Address = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    TAccountPayer extends string,
+    TAccountAta extends string,
+    TAccountOwner extends string,
+    TAccountMint extends string,
+    TAccountSystemProgram extends string,
+    TAccountTokenProgram extends string,
+    TProgramAddress extends Address = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
 >(
-  input: CreateAssociatedTokenInput<
-    TAccountPayer,
-    TAccountAta,
-    TAccountOwner,
-    TAccountMint,
-    TAccountSystemProgram,
-    TAccountTokenProgram
-  >,
-  config?: { programAddress?: TProgramAddress }
+    input: CreateAssociatedTokenInput<
+        TAccountPayer,
+        TAccountAta,
+        TAccountOwner,
+        TAccountMint,
+        TAccountSystemProgram,
+        TAccountTokenProgram
+    >,
+    config?: { programAddress?: TProgramAddress }
 ): CreateAssociatedTokenInstruction<
-  TProgramAddress,
-  TAccountPayer,
-  TAccountAta,
-  TAccountOwner,
-  TAccountMint,
-  TAccountSystemProgram,
-  TAccountTokenProgram
-> {
-  // Program address.
-  const programAddress =
-    config?.programAddress ?? ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
-
-  // Original accounts.
-  const originalAccounts = {
-    payer: { value: input.payer ?? null, isWritable: true },
-    ata: { value: input.ata ?? null, isWritable: true },
-    owner: { value: input.owner ?? null, isWritable: false },
-    mint: { value: input.mint ?? null, isWritable: false },
-    systemProgram: { value: input.systemProgram ?? null, isWritable: false },
-    tokenProgram: { value: input.tokenProgram ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
-
-  // Resolve default values.
-  if (!accounts.tokenProgram.value) {
-    accounts.tokenProgram.value =
-      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' as Address<'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'>;
-  }
-  if (!accounts.systemProgram.value) {
-    accounts.systemProgram.value =
-      '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
-  }
-
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.payer),
-      getAccountMeta(accounts.ata),
-      getAccountMeta(accounts.owner),
-      getAccountMeta(accounts.mint),
-      getAccountMeta(accounts.systemProgram),
-      getAccountMeta(accounts.tokenProgram),
-    ],
-    data: getCreateAssociatedTokenInstructionDataEncoder().encode({}),
-    programAddress,
-  } as CreateAssociatedTokenInstruction<
     TProgramAddress,
     TAccountPayer,
     TAccountAta,
@@ -312,61 +241,104 @@ export function getCreateAssociatedTokenInstruction<
     TAccountMint,
     TAccountSystemProgram,
     TAccountTokenProgram
-  >);
+> {
+    // Program address.
+    const programAddress = config?.programAddress ?? ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
+
+    // Original accounts.
+    const originalAccounts = {
+        payer: { value: input.payer ?? null, isWritable: true },
+        ata: { value: input.ata ?? null, isWritable: true },
+        owner: { value: input.owner ?? null, isWritable: false },
+        mint: { value: input.mint ?? null, isWritable: false },
+        systemProgram: { value: input.systemProgram ?? null, isWritable: false },
+        tokenProgram: { value: input.tokenProgram ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
+
+    // Resolve default values.
+    if (!accounts.tokenProgram.value) {
+        accounts.tokenProgram.value =
+            'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' as Address<'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'>;
+    }
+    if (!accounts.systemProgram.value) {
+        accounts.systemProgram.value =
+            '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
+    }
+
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [
+            getAccountMeta(accounts.payer),
+            getAccountMeta(accounts.ata),
+            getAccountMeta(accounts.owner),
+            getAccountMeta(accounts.mint),
+            getAccountMeta(accounts.systemProgram),
+            getAccountMeta(accounts.tokenProgram),
+        ],
+        data: getCreateAssociatedTokenInstructionDataEncoder().encode({}),
+        programAddress,
+    } as CreateAssociatedTokenInstruction<
+        TProgramAddress,
+        TAccountPayer,
+        TAccountAta,
+        TAccountOwner,
+        TAccountMint,
+        TAccountSystemProgram,
+        TAccountTokenProgram
+    >);
 }
 
 export type ParsedCreateAssociatedTokenInstruction<
-  TProgram extends string = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    /** Funding account (must be a system account). */
-    payer: TAccountMetas[0];
-    /** Associated token account address to be created. */
-    ata: TAccountMetas[1];
-    /** Wallet address for the new associated token account. */
-    owner: TAccountMetas[2];
-    /** The token mint for the new associated token account. */
-    mint: TAccountMetas[3];
-    /** System program. */
-    systemProgram: TAccountMetas[4];
-    /** SPL Token program. */
-    tokenProgram: TAccountMetas[5];
-  };
-  data: CreateAssociatedTokenInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        /** Funding account (must be a system account). */
+        payer: TAccountMetas[0];
+        /** Associated token account address to be created. */
+        ata: TAccountMetas[1];
+        /** Wallet address for the new associated token account. */
+        owner: TAccountMetas[2];
+        /** The token mint for the new associated token account. */
+        mint: TAccountMetas[3];
+        /** System program. */
+        systemProgram: TAccountMetas[4];
+        /** SPL Token program. */
+        tokenProgram: TAccountMetas[5];
+    };
+    data: CreateAssociatedTokenInstructionData;
 };
 
 export function parseCreateAssociatedTokenInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
+    TProgram extends string,
+    TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedCreateAssociatedTokenInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 6) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: {
-      payer: getNextAccount(),
-      ata: getNextAccount(),
-      owner: getNextAccount(),
-      mint: getNextAccount(),
-      systemProgram: getNextAccount(),
-      tokenProgram: getNextAccount(),
-    },
-    data: getCreateAssociatedTokenInstructionDataDecoder().decode(
-      instruction.data
-    ),
-  };
+    if (instruction.accounts.length < 6) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: {
+            payer: getNextAccount(),
+            ata: getNextAccount(),
+            owner: getNextAccount(),
+            mint: getNextAccount(),
+            systemProgram: getNextAccount(),
+            tokenProgram: getNextAccount(),
+        },
+        data: getCreateAssociatedTokenInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/token/src/generated/instructions/createAssociatedTokenIdempotent.ts
+++ b/test/e2e/token/src/generated/instructions/createAssociatedTokenIdempotent.ts
@@ -7,308 +7,233 @@
  */
 
 import {
-  combineCodec,
-  getStructDecoder,
-  getStructEncoder,
-  getU8Decoder,
-  getU8Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyAccount,
-  type ReadonlyUint8Array,
-  type TransactionSigner,
-  type WritableAccount,
-  type WritableSignerAccount,
+    combineCodec,
+    getStructDecoder,
+    getStructEncoder,
+    getU8Decoder,
+    getU8Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyAccount,
+    type ReadonlyUint8Array,
+    type TransactionSigner,
+    type WritableAccount,
+    type WritableSignerAccount,
 } from '@solana/kit';
 import { findAssociatedTokenPda } from '../pdas';
 import { ASSOCIATED_TOKEN_PROGRAM_ADDRESS } from '../programs';
-import {
-  expectAddress,
-  getAccountMetaFactory,
-  type ResolvedAccount,
-} from '../shared';
+import { expectAddress, getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
 export const CREATE_ASSOCIATED_TOKEN_IDEMPOTENT_DISCRIMINATOR = 1;
 
 export function getCreateAssociatedTokenIdempotentDiscriminatorBytes() {
-  return getU8Encoder().encode(
-    CREATE_ASSOCIATED_TOKEN_IDEMPOTENT_DISCRIMINATOR
-  );
+    return getU8Encoder().encode(CREATE_ASSOCIATED_TOKEN_IDEMPOTENT_DISCRIMINATOR);
 }
 
 export type CreateAssociatedTokenIdempotentInstruction<
-  TProgram extends string = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
-  TAccountPayer extends string | AccountMeta<string> = string,
-  TAccountAta extends string | AccountMeta<string> = string,
-  TAccountOwner extends string | AccountMeta<string> = string,
-  TAccountMint extends string | AccountMeta<string> = string,
-  TAccountSystemProgram extends string | AccountMeta<string> =
-    '11111111111111111111111111111111',
-  TAccountTokenProgram extends string | AccountMeta<string> =
-    'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    TAccountPayer extends string | AccountMeta<string> = string,
+    TAccountAta extends string | AccountMeta<string> = string,
+    TAccountOwner extends string | AccountMeta<string> = string,
+    TAccountMint extends string | AccountMeta<string> = string,
+    TAccountSystemProgram extends string | AccountMeta<string> = '11111111111111111111111111111111',
+    TAccountTokenProgram extends string | AccountMeta<string> = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountPayer extends string
-        ? WritableSignerAccount<TAccountPayer> &
-            AccountSignerMeta<TAccountPayer>
-        : TAccountPayer,
-      TAccountAta extends string ? WritableAccount<TAccountAta> : TAccountAta,
-      TAccountOwner extends string
-        ? ReadonlyAccount<TAccountOwner>
-        : TAccountOwner,
-      TAccountMint extends string
-        ? ReadonlyAccount<TAccountMint>
-        : TAccountMint,
-      TAccountSystemProgram extends string
-        ? ReadonlyAccount<TAccountSystemProgram>
-        : TAccountSystemProgram,
-      TAccountTokenProgram extends string
-        ? ReadonlyAccount<TAccountTokenProgram>
-        : TAccountTokenProgram,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountPayer extends string
+                ? WritableSignerAccount<TAccountPayer> & AccountSignerMeta<TAccountPayer>
+                : TAccountPayer,
+            TAccountAta extends string ? WritableAccount<TAccountAta> : TAccountAta,
+            TAccountOwner extends string ? ReadonlyAccount<TAccountOwner> : TAccountOwner,
+            TAccountMint extends string ? ReadonlyAccount<TAccountMint> : TAccountMint,
+            TAccountSystemProgram extends string ? ReadonlyAccount<TAccountSystemProgram> : TAccountSystemProgram,
+            TAccountTokenProgram extends string ? ReadonlyAccount<TAccountTokenProgram> : TAccountTokenProgram,
+            ...TRemainingAccounts,
+        ]
+    >;
 
-export type CreateAssociatedTokenIdempotentInstructionData = {
-  discriminator: number;
-};
+export type CreateAssociatedTokenIdempotentInstructionData = { discriminator: number };
 
 export type CreateAssociatedTokenIdempotentInstructionDataArgs = {};
 
 export function getCreateAssociatedTokenIdempotentInstructionDataEncoder(): FixedSizeEncoder<CreateAssociatedTokenIdempotentInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([['discriminator', getU8Encoder()]]),
-    (value) => ({
-      ...value,
-      discriminator: CREATE_ASSOCIATED_TOKEN_IDEMPOTENT_DISCRIMINATOR,
-    })
-  );
+    return transformEncoder(getStructEncoder([['discriminator', getU8Encoder()]]), value => ({
+        ...value,
+        discriminator: CREATE_ASSOCIATED_TOKEN_IDEMPOTENT_DISCRIMINATOR,
+    }));
 }
 
 export function getCreateAssociatedTokenIdempotentInstructionDataDecoder(): FixedSizeDecoder<CreateAssociatedTokenIdempotentInstructionData> {
-  return getStructDecoder([['discriminator', getU8Decoder()]]);
+    return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getCreateAssociatedTokenIdempotentInstructionDataCodec(): FixedSizeCodec<
-  CreateAssociatedTokenIdempotentInstructionDataArgs,
-  CreateAssociatedTokenIdempotentInstructionData
+    CreateAssociatedTokenIdempotentInstructionDataArgs,
+    CreateAssociatedTokenIdempotentInstructionData
 > {
-  return combineCodec(
-    getCreateAssociatedTokenIdempotentInstructionDataEncoder(),
-    getCreateAssociatedTokenIdempotentInstructionDataDecoder()
-  );
+    return combineCodec(
+        getCreateAssociatedTokenIdempotentInstructionDataEncoder(),
+        getCreateAssociatedTokenIdempotentInstructionDataDecoder()
+    );
 }
 
 export type CreateAssociatedTokenIdempotentAsyncInput<
-  TAccountPayer extends string = string,
-  TAccountAta extends string = string,
-  TAccountOwner extends string = string,
-  TAccountMint extends string = string,
-  TAccountSystemProgram extends string = string,
-  TAccountTokenProgram extends string = string,
+    TAccountPayer extends string = string,
+    TAccountAta extends string = string,
+    TAccountOwner extends string = string,
+    TAccountMint extends string = string,
+    TAccountSystemProgram extends string = string,
+    TAccountTokenProgram extends string = string,
 > = {
-  /** Funding account (must be a system account). */
-  payer: TransactionSigner<TAccountPayer>;
-  /** Associated token account address to be created. */
-  ata?: Address<TAccountAta>;
-  /** Wallet address for the new associated token account. */
-  owner: Address<TAccountOwner>;
-  /** The token mint for the new associated token account. */
-  mint: Address<TAccountMint>;
-  /** System program. */
-  systemProgram?: Address<TAccountSystemProgram>;
-  /** SPL Token program. */
-  tokenProgram?: Address<TAccountTokenProgram>;
+    /** Funding account (must be a system account). */
+    payer: TransactionSigner<TAccountPayer>;
+    /** Associated token account address to be created. */
+    ata?: Address<TAccountAta>;
+    /** Wallet address for the new associated token account. */
+    owner: Address<TAccountOwner>;
+    /** The token mint for the new associated token account. */
+    mint: Address<TAccountMint>;
+    /** System program. */
+    systemProgram?: Address<TAccountSystemProgram>;
+    /** SPL Token program. */
+    tokenProgram?: Address<TAccountTokenProgram>;
 };
 
 export async function getCreateAssociatedTokenIdempotentInstructionAsync<
-  TAccountPayer extends string,
-  TAccountAta extends string,
-  TAccountOwner extends string,
-  TAccountMint extends string,
-  TAccountSystemProgram extends string,
-  TAccountTokenProgram extends string,
-  TProgramAddress extends Address = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    TAccountPayer extends string,
+    TAccountAta extends string,
+    TAccountOwner extends string,
+    TAccountMint extends string,
+    TAccountSystemProgram extends string,
+    TAccountTokenProgram extends string,
+    TProgramAddress extends Address = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
 >(
-  input: CreateAssociatedTokenIdempotentAsyncInput<
-    TAccountPayer,
-    TAccountAta,
-    TAccountOwner,
-    TAccountMint,
-    TAccountSystemProgram,
-    TAccountTokenProgram
-  >,
-  config?: { programAddress?: TProgramAddress }
+    input: CreateAssociatedTokenIdempotentAsyncInput<
+        TAccountPayer,
+        TAccountAta,
+        TAccountOwner,
+        TAccountMint,
+        TAccountSystemProgram,
+        TAccountTokenProgram
+    >,
+    config?: { programAddress?: TProgramAddress }
 ): Promise<
-  CreateAssociatedTokenIdempotentInstruction<
-    TProgramAddress,
-    TAccountPayer,
-    TAccountAta,
-    TAccountOwner,
-    TAccountMint,
-    TAccountSystemProgram,
-    TAccountTokenProgram
-  >
+    CreateAssociatedTokenIdempotentInstruction<
+        TProgramAddress,
+        TAccountPayer,
+        TAccountAta,
+        TAccountOwner,
+        TAccountMint,
+        TAccountSystemProgram,
+        TAccountTokenProgram
+    >
 > {
-  // Program address.
-  const programAddress =
-    config?.programAddress ?? ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
+    // Program address.
+    const programAddress = config?.programAddress ?? ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
 
-  // Original accounts.
-  const originalAccounts = {
-    payer: { value: input.payer ?? null, isWritable: true },
-    ata: { value: input.ata ?? null, isWritable: true },
-    owner: { value: input.owner ?? null, isWritable: false },
-    mint: { value: input.mint ?? null, isWritable: false },
-    systemProgram: { value: input.systemProgram ?? null, isWritable: false },
-    tokenProgram: { value: input.tokenProgram ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
+    // Original accounts.
+    const originalAccounts = {
+        payer: { value: input.payer ?? null, isWritable: true },
+        ata: { value: input.ata ?? null, isWritable: true },
+        owner: { value: input.owner ?? null, isWritable: false },
+        mint: { value: input.mint ?? null, isWritable: false },
+        systemProgram: { value: input.systemProgram ?? null, isWritable: false },
+        tokenProgram: { value: input.tokenProgram ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
 
-  // Resolve default values.
-  if (!accounts.tokenProgram.value) {
-    accounts.tokenProgram.value =
-      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' as Address<'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'>;
-  }
-  if (!accounts.ata.value) {
-    accounts.ata.value = await findAssociatedTokenPda({
-      owner: expectAddress(accounts.owner.value),
-      tokenProgram: expectAddress(accounts.tokenProgram.value),
-      mint: expectAddress(accounts.mint.value),
-    });
-  }
-  if (!accounts.systemProgram.value) {
-    accounts.systemProgram.value =
-      '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
-  }
+    // Resolve default values.
+    if (!accounts.tokenProgram.value) {
+        accounts.tokenProgram.value =
+            'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' as Address<'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'>;
+    }
+    if (!accounts.ata.value) {
+        accounts.ata.value = await findAssociatedTokenPda({
+            owner: expectAddress(accounts.owner.value),
+            tokenProgram: expectAddress(accounts.tokenProgram.value),
+            mint: expectAddress(accounts.mint.value),
+        });
+    }
+    if (!accounts.systemProgram.value) {
+        accounts.systemProgram.value =
+            '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
+    }
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.payer),
-      getAccountMeta(accounts.ata),
-      getAccountMeta(accounts.owner),
-      getAccountMeta(accounts.mint),
-      getAccountMeta(accounts.systemProgram),
-      getAccountMeta(accounts.tokenProgram),
-    ],
-    data: getCreateAssociatedTokenIdempotentInstructionDataEncoder().encode({}),
-    programAddress,
-  } as CreateAssociatedTokenIdempotentInstruction<
-    TProgramAddress,
-    TAccountPayer,
-    TAccountAta,
-    TAccountOwner,
-    TAccountMint,
-    TAccountSystemProgram,
-    TAccountTokenProgram
-  >);
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [
+            getAccountMeta(accounts.payer),
+            getAccountMeta(accounts.ata),
+            getAccountMeta(accounts.owner),
+            getAccountMeta(accounts.mint),
+            getAccountMeta(accounts.systemProgram),
+            getAccountMeta(accounts.tokenProgram),
+        ],
+        data: getCreateAssociatedTokenIdempotentInstructionDataEncoder().encode({}),
+        programAddress,
+    } as CreateAssociatedTokenIdempotentInstruction<
+        TProgramAddress,
+        TAccountPayer,
+        TAccountAta,
+        TAccountOwner,
+        TAccountMint,
+        TAccountSystemProgram,
+        TAccountTokenProgram
+    >);
 }
 
 export type CreateAssociatedTokenIdempotentInput<
-  TAccountPayer extends string = string,
-  TAccountAta extends string = string,
-  TAccountOwner extends string = string,
-  TAccountMint extends string = string,
-  TAccountSystemProgram extends string = string,
-  TAccountTokenProgram extends string = string,
+    TAccountPayer extends string = string,
+    TAccountAta extends string = string,
+    TAccountOwner extends string = string,
+    TAccountMint extends string = string,
+    TAccountSystemProgram extends string = string,
+    TAccountTokenProgram extends string = string,
 > = {
-  /** Funding account (must be a system account). */
-  payer: TransactionSigner<TAccountPayer>;
-  /** Associated token account address to be created. */
-  ata: Address<TAccountAta>;
-  /** Wallet address for the new associated token account. */
-  owner: Address<TAccountOwner>;
-  /** The token mint for the new associated token account. */
-  mint: Address<TAccountMint>;
-  /** System program. */
-  systemProgram?: Address<TAccountSystemProgram>;
-  /** SPL Token program. */
-  tokenProgram?: Address<TAccountTokenProgram>;
+    /** Funding account (must be a system account). */
+    payer: TransactionSigner<TAccountPayer>;
+    /** Associated token account address to be created. */
+    ata: Address<TAccountAta>;
+    /** Wallet address for the new associated token account. */
+    owner: Address<TAccountOwner>;
+    /** The token mint for the new associated token account. */
+    mint: Address<TAccountMint>;
+    /** System program. */
+    systemProgram?: Address<TAccountSystemProgram>;
+    /** SPL Token program. */
+    tokenProgram?: Address<TAccountTokenProgram>;
 };
 
 export function getCreateAssociatedTokenIdempotentInstruction<
-  TAccountPayer extends string,
-  TAccountAta extends string,
-  TAccountOwner extends string,
-  TAccountMint extends string,
-  TAccountSystemProgram extends string,
-  TAccountTokenProgram extends string,
-  TProgramAddress extends Address = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    TAccountPayer extends string,
+    TAccountAta extends string,
+    TAccountOwner extends string,
+    TAccountMint extends string,
+    TAccountSystemProgram extends string,
+    TAccountTokenProgram extends string,
+    TProgramAddress extends Address = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
 >(
-  input: CreateAssociatedTokenIdempotentInput<
-    TAccountPayer,
-    TAccountAta,
-    TAccountOwner,
-    TAccountMint,
-    TAccountSystemProgram,
-    TAccountTokenProgram
-  >,
-  config?: { programAddress?: TProgramAddress }
+    input: CreateAssociatedTokenIdempotentInput<
+        TAccountPayer,
+        TAccountAta,
+        TAccountOwner,
+        TAccountMint,
+        TAccountSystemProgram,
+        TAccountTokenProgram
+    >,
+    config?: { programAddress?: TProgramAddress }
 ): CreateAssociatedTokenIdempotentInstruction<
-  TProgramAddress,
-  TAccountPayer,
-  TAccountAta,
-  TAccountOwner,
-  TAccountMint,
-  TAccountSystemProgram,
-  TAccountTokenProgram
-> {
-  // Program address.
-  const programAddress =
-    config?.programAddress ?? ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
-
-  // Original accounts.
-  const originalAccounts = {
-    payer: { value: input.payer ?? null, isWritable: true },
-    ata: { value: input.ata ?? null, isWritable: true },
-    owner: { value: input.owner ?? null, isWritable: false },
-    mint: { value: input.mint ?? null, isWritable: false },
-    systemProgram: { value: input.systemProgram ?? null, isWritable: false },
-    tokenProgram: { value: input.tokenProgram ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
-
-  // Resolve default values.
-  if (!accounts.tokenProgram.value) {
-    accounts.tokenProgram.value =
-      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' as Address<'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'>;
-  }
-  if (!accounts.systemProgram.value) {
-    accounts.systemProgram.value =
-      '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
-  }
-
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.payer),
-      getAccountMeta(accounts.ata),
-      getAccountMeta(accounts.owner),
-      getAccountMeta(accounts.mint),
-      getAccountMeta(accounts.systemProgram),
-      getAccountMeta(accounts.tokenProgram),
-    ],
-    data: getCreateAssociatedTokenIdempotentInstructionDataEncoder().encode({}),
-    programAddress,
-  } as CreateAssociatedTokenIdempotentInstruction<
     TProgramAddress,
     TAccountPayer,
     TAccountAta,
@@ -316,61 +241,104 @@ export function getCreateAssociatedTokenIdempotentInstruction<
     TAccountMint,
     TAccountSystemProgram,
     TAccountTokenProgram
-  >);
+> {
+    // Program address.
+    const programAddress = config?.programAddress ?? ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
+
+    // Original accounts.
+    const originalAccounts = {
+        payer: { value: input.payer ?? null, isWritable: true },
+        ata: { value: input.ata ?? null, isWritable: true },
+        owner: { value: input.owner ?? null, isWritable: false },
+        mint: { value: input.mint ?? null, isWritable: false },
+        systemProgram: { value: input.systemProgram ?? null, isWritable: false },
+        tokenProgram: { value: input.tokenProgram ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
+
+    // Resolve default values.
+    if (!accounts.tokenProgram.value) {
+        accounts.tokenProgram.value =
+            'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' as Address<'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'>;
+    }
+    if (!accounts.systemProgram.value) {
+        accounts.systemProgram.value =
+            '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
+    }
+
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [
+            getAccountMeta(accounts.payer),
+            getAccountMeta(accounts.ata),
+            getAccountMeta(accounts.owner),
+            getAccountMeta(accounts.mint),
+            getAccountMeta(accounts.systemProgram),
+            getAccountMeta(accounts.tokenProgram),
+        ],
+        data: getCreateAssociatedTokenIdempotentInstructionDataEncoder().encode({}),
+        programAddress,
+    } as CreateAssociatedTokenIdempotentInstruction<
+        TProgramAddress,
+        TAccountPayer,
+        TAccountAta,
+        TAccountOwner,
+        TAccountMint,
+        TAccountSystemProgram,
+        TAccountTokenProgram
+    >);
 }
 
 export type ParsedCreateAssociatedTokenIdempotentInstruction<
-  TProgram extends string = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    /** Funding account (must be a system account). */
-    payer: TAccountMetas[0];
-    /** Associated token account address to be created. */
-    ata: TAccountMetas[1];
-    /** Wallet address for the new associated token account. */
-    owner: TAccountMetas[2];
-    /** The token mint for the new associated token account. */
-    mint: TAccountMetas[3];
-    /** System program. */
-    systemProgram: TAccountMetas[4];
-    /** SPL Token program. */
-    tokenProgram: TAccountMetas[5];
-  };
-  data: CreateAssociatedTokenIdempotentInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        /** Funding account (must be a system account). */
+        payer: TAccountMetas[0];
+        /** Associated token account address to be created. */
+        ata: TAccountMetas[1];
+        /** Wallet address for the new associated token account. */
+        owner: TAccountMetas[2];
+        /** The token mint for the new associated token account. */
+        mint: TAccountMetas[3];
+        /** System program. */
+        systemProgram: TAccountMetas[4];
+        /** SPL Token program. */
+        tokenProgram: TAccountMetas[5];
+    };
+    data: CreateAssociatedTokenIdempotentInstructionData;
 };
 
 export function parseCreateAssociatedTokenIdempotentInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
+    TProgram extends string,
+    TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedCreateAssociatedTokenIdempotentInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 6) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: {
-      payer: getNextAccount(),
-      ata: getNextAccount(),
-      owner: getNextAccount(),
-      mint: getNextAccount(),
-      systemProgram: getNextAccount(),
-      tokenProgram: getNextAccount(),
-    },
-    data: getCreateAssociatedTokenIdempotentInstructionDataDecoder().decode(
-      instruction.data
-    ),
-  };
+    if (instruction.accounts.length < 6) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: {
+            payer: getNextAccount(),
+            ata: getNextAccount(),
+            owner: getNextAccount(),
+            mint: getNextAccount(),
+            systemProgram: getNextAccount(),
+            tokenProgram: getNextAccount(),
+        },
+        data: getCreateAssociatedTokenIdempotentInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/token/src/generated/instructions/freezeAccount.ts
+++ b/test/e2e/token/src/generated/instructions/freezeAccount.ts
@@ -7,27 +7,27 @@
  */
 
 import {
-  AccountRole,
-  combineCodec,
-  getStructDecoder,
-  getStructEncoder,
-  getU8Decoder,
-  getU8Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyAccount,
-  type ReadonlySignerAccount,
-  type ReadonlyUint8Array,
-  type TransactionSigner,
-  type WritableAccount,
+    AccountRole,
+    combineCodec,
+    getStructDecoder,
+    getStructEncoder,
+    getU8Decoder,
+    getU8Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyAccount,
+    type ReadonlySignerAccount,
+    type ReadonlyUint8Array,
+    type TransactionSigner,
+    type WritableAccount,
 } from '@solana/kit';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -35,174 +35,153 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const FREEZE_ACCOUNT_DISCRIMINATOR = 10;
 
 export function getFreezeAccountDiscriminatorBytes() {
-  return getU8Encoder().encode(FREEZE_ACCOUNT_DISCRIMINATOR);
+    return getU8Encoder().encode(FREEZE_ACCOUNT_DISCRIMINATOR);
 }
 
 export type FreezeAccountInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountAccount extends string | AccountMeta<string> = string,
-  TAccountMint extends string | AccountMeta<string> = string,
-  TAccountOwner extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountAccount extends string | AccountMeta<string> = string,
+    TAccountMint extends string | AccountMeta<string> = string,
+    TAccountOwner extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountAccount extends string
-        ? WritableAccount<TAccountAccount>
-        : TAccountAccount,
-      TAccountMint extends string
-        ? ReadonlyAccount<TAccountMint>
-        : TAccountMint,
-      TAccountOwner extends string
-        ? ReadonlyAccount<TAccountOwner>
-        : TAccountOwner,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountAccount extends string ? WritableAccount<TAccountAccount> : TAccountAccount,
+            TAccountMint extends string ? ReadonlyAccount<TAccountMint> : TAccountMint,
+            TAccountOwner extends string ? ReadonlyAccount<TAccountOwner> : TAccountOwner,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type FreezeAccountInstructionData = { discriminator: number };
 
 export type FreezeAccountInstructionDataArgs = {};
 
 export function getFreezeAccountInstructionDataEncoder(): FixedSizeEncoder<FreezeAccountInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([['discriminator', getU8Encoder()]]),
-    (value) => ({ ...value, discriminator: FREEZE_ACCOUNT_DISCRIMINATOR })
-  );
+    return transformEncoder(getStructEncoder([['discriminator', getU8Encoder()]]), value => ({
+        ...value,
+        discriminator: FREEZE_ACCOUNT_DISCRIMINATOR,
+    }));
 }
 
 export function getFreezeAccountInstructionDataDecoder(): FixedSizeDecoder<FreezeAccountInstructionData> {
-  return getStructDecoder([['discriminator', getU8Decoder()]]);
+    return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getFreezeAccountInstructionDataCodec(): FixedSizeCodec<
-  FreezeAccountInstructionDataArgs,
-  FreezeAccountInstructionData
+    FreezeAccountInstructionDataArgs,
+    FreezeAccountInstructionData
 > {
-  return combineCodec(
-    getFreezeAccountInstructionDataEncoder(),
-    getFreezeAccountInstructionDataDecoder()
-  );
+    return combineCodec(getFreezeAccountInstructionDataEncoder(), getFreezeAccountInstructionDataDecoder());
 }
 
 export type FreezeAccountInput<
-  TAccountAccount extends string = string,
-  TAccountMint extends string = string,
-  TAccountOwner extends string = string,
+    TAccountAccount extends string = string,
+    TAccountMint extends string = string,
+    TAccountOwner extends string = string,
 > = {
-  /** The account to freeze. */
-  account: Address<TAccountAccount>;
-  /** The token mint. */
-  mint: Address<TAccountMint>;
-  /** The mint freeze authority or its multisignature account. */
-  owner: Address<TAccountOwner> | TransactionSigner<TAccountOwner>;
-  multiSigners?: Array<TransactionSigner>;
+    /** The account to freeze. */
+    account: Address<TAccountAccount>;
+    /** The token mint. */
+    mint: Address<TAccountMint>;
+    /** The mint freeze authority or its multisignature account. */
+    owner: Address<TAccountOwner> | TransactionSigner<TAccountOwner>;
+    multiSigners?: Array<TransactionSigner>;
 };
 
 export function getFreezeAccountInstruction<
-  TAccountAccount extends string,
-  TAccountMint extends string,
-  TAccountOwner extends string,
-  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountAccount extends string,
+    TAccountMint extends string,
+    TAccountOwner extends string,
+    TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: FreezeAccountInput<TAccountAccount, TAccountMint, TAccountOwner>,
-  config?: { programAddress?: TProgramAddress }
+    input: FreezeAccountInput<TAccountAccount, TAccountMint, TAccountOwner>,
+    config?: { programAddress?: TProgramAddress }
 ): FreezeAccountInstruction<
-  TProgramAddress,
-  TAccountAccount,
-  TAccountMint,
-  (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
-    ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
-    : TAccountOwner
-> {
-  // Program address.
-  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
-
-  // Original accounts.
-  const originalAccounts = {
-    account: { value: input.account ?? null, isWritable: true },
-    mint: { value: input.mint ?? null, isWritable: false },
-    owner: { value: input.owner ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
-
-  // Original args.
-  const args = { ...input };
-
-  // Remaining accounts.
-  const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(
-    (signer) => ({
-      address: signer.address,
-      role: AccountRole.READONLY_SIGNER,
-      signer,
-    })
-  );
-
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.account),
-      getAccountMeta(accounts.mint),
-      getAccountMeta(accounts.owner),
-      ...remainingAccounts,
-    ],
-    data: getFreezeAccountInstructionDataEncoder().encode({}),
-    programAddress,
-  } as FreezeAccountInstruction<
     TProgramAddress,
     TAccountAccount,
     TAccountMint,
     (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
-      ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
-      : TAccountOwner
-  >);
+        ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
+        : TAccountOwner
+> {
+    // Program address.
+    const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
+
+    // Original accounts.
+    const originalAccounts = {
+        account: { value: input.account ?? null, isWritable: true },
+        mint: { value: input.mint ?? null, isWritable: false },
+        owner: { value: input.owner ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
+
+    // Original args.
+    const args = { ...input };
+
+    // Remaining accounts.
+    const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(signer => ({
+        address: signer.address,
+        role: AccountRole.READONLY_SIGNER,
+        signer,
+    }));
+
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [
+            getAccountMeta(accounts.account),
+            getAccountMeta(accounts.mint),
+            getAccountMeta(accounts.owner),
+            ...remainingAccounts,
+        ],
+        data: getFreezeAccountInstructionDataEncoder().encode({}),
+        programAddress,
+    } as FreezeAccountInstruction<
+        TProgramAddress,
+        TAccountAccount,
+        TAccountMint,
+        (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
+            ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
+            : TAccountOwner
+    >);
 }
 
 export type ParsedFreezeAccountInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    /** The account to freeze. */
-    account: TAccountMetas[0];
-    /** The token mint. */
-    mint: TAccountMetas[1];
-    /** The mint freeze authority or its multisignature account. */
-    owner: TAccountMetas[2];
-  };
-  data: FreezeAccountInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        /** The account to freeze. */
+        account: TAccountMetas[0];
+        /** The token mint. */
+        mint: TAccountMetas[1];
+        /** The mint freeze authority or its multisignature account. */
+        owner: TAccountMetas[2];
+    };
+    data: FreezeAccountInstructionData;
 };
 
-export function parseFreezeAccountInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
->(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+export function parseFreezeAccountInstruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedFreezeAccountInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 3) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: {
-      account: getNextAccount(),
-      mint: getNextAccount(),
-      owner: getNextAccount(),
-    },
-    data: getFreezeAccountInstructionDataDecoder().decode(instruction.data),
-  };
+    if (instruction.accounts.length < 3) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { account: getNextAccount(), mint: getNextAccount(), owner: getNextAccount() },
+        data: getFreezeAccountInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/token/src/generated/instructions/getAccountDataSize.ts
+++ b/test/e2e/token/src/generated/instructions/getAccountDataSize.ts
@@ -7,22 +7,22 @@
  */
 
 import {
-  combineCodec,
-  getStructDecoder,
-  getStructEncoder,
-  getU8Decoder,
-  getU8Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyAccount,
-  type ReadonlyUint8Array,
+    combineCodec,
+    getStructDecoder,
+    getStructEncoder,
+    getU8Decoder,
+    getU8Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyAccount,
+    type ReadonlyUint8Array,
 } from '@solana/kit';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -30,119 +30,101 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const GET_ACCOUNT_DATA_SIZE_DISCRIMINATOR = 21;
 
 export function getGetAccountDataSizeDiscriminatorBytes() {
-  return getU8Encoder().encode(GET_ACCOUNT_DATA_SIZE_DISCRIMINATOR);
+    return getU8Encoder().encode(GET_ACCOUNT_DATA_SIZE_DISCRIMINATOR);
 }
 
 export type GetAccountDataSizeInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMint extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMint extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountMint extends string
-        ? ReadonlyAccount<TAccountMint>
-        : TAccountMint,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [TAccountMint extends string ? ReadonlyAccount<TAccountMint> : TAccountMint, ...TRemainingAccounts]
+    >;
 
 export type GetAccountDataSizeInstructionData = { discriminator: number };
 
 export type GetAccountDataSizeInstructionDataArgs = {};
 
 export function getGetAccountDataSizeInstructionDataEncoder(): FixedSizeEncoder<GetAccountDataSizeInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([['discriminator', getU8Encoder()]]),
-    (value) => ({
-      ...value,
-      discriminator: GET_ACCOUNT_DATA_SIZE_DISCRIMINATOR,
-    })
-  );
+    return transformEncoder(getStructEncoder([['discriminator', getU8Encoder()]]), value => ({
+        ...value,
+        discriminator: GET_ACCOUNT_DATA_SIZE_DISCRIMINATOR,
+    }));
 }
 
 export function getGetAccountDataSizeInstructionDataDecoder(): FixedSizeDecoder<GetAccountDataSizeInstructionData> {
-  return getStructDecoder([['discriminator', getU8Decoder()]]);
+    return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getGetAccountDataSizeInstructionDataCodec(): FixedSizeCodec<
-  GetAccountDataSizeInstructionDataArgs,
-  GetAccountDataSizeInstructionData
+    GetAccountDataSizeInstructionDataArgs,
+    GetAccountDataSizeInstructionData
 > {
-  return combineCodec(
-    getGetAccountDataSizeInstructionDataEncoder(),
-    getGetAccountDataSizeInstructionDataDecoder()
-  );
+    return combineCodec(getGetAccountDataSizeInstructionDataEncoder(), getGetAccountDataSizeInstructionDataDecoder());
 }
 
 export type GetAccountDataSizeInput<TAccountMint extends string = string> = {
-  /** The mint to calculate for. */
-  mint: Address<TAccountMint>;
+    /** The mint to calculate for. */
+    mint: Address<TAccountMint>;
 };
 
 export function getGetAccountDataSizeInstruction<
-  TAccountMint extends string,
-  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMint extends string,
+    TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: GetAccountDataSizeInput<TAccountMint>,
-  config?: { programAddress?: TProgramAddress }
+    input: GetAccountDataSizeInput<TAccountMint>,
+    config?: { programAddress?: TProgramAddress }
 ): GetAccountDataSizeInstruction<TProgramAddress, TAccountMint> {
-  // Program address.
-  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
+    // Program address.
+    const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
-  // Original accounts.
-  const originalAccounts = {
-    mint: { value: input.mint ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
+    // Original accounts.
+    const originalAccounts = { mint: { value: input.mint ?? null, isWritable: false } };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [getAccountMeta(accounts.mint)],
-    data: getGetAccountDataSizeInstructionDataEncoder().encode({}),
-    programAddress,
-  } as GetAccountDataSizeInstruction<TProgramAddress, TAccountMint>);
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [getAccountMeta(accounts.mint)],
+        data: getGetAccountDataSizeInstructionDataEncoder().encode({}),
+        programAddress,
+    } as GetAccountDataSizeInstruction<TProgramAddress, TAccountMint>);
 }
 
 export type ParsedGetAccountDataSizeInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    /** The mint to calculate for. */
-    mint: TAccountMetas[0];
-  };
-  data: GetAccountDataSizeInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        /** The mint to calculate for. */
+        mint: TAccountMetas[0];
+    };
+    data: GetAccountDataSizeInstructionData;
 };
 
 export function parseGetAccountDataSizeInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
+    TProgram extends string,
+    TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedGetAccountDataSizeInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 1) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: { mint: getNextAccount() },
-    data: getGetAccountDataSizeInstructionDataDecoder().decode(
-      instruction.data
-    ),
-  };
+    if (instruction.accounts.length < 1) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { mint: getNextAccount() },
+        data: getGetAccountDataSizeInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/token/src/generated/instructions/initializeAccount.ts
+++ b/test/e2e/token/src/generated/instructions/initializeAccount.ts
@@ -7,23 +7,23 @@
  */
 
 import {
-  combineCodec,
-  getStructDecoder,
-  getStructEncoder,
-  getU8Decoder,
-  getU8Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyAccount,
-  type ReadonlyUint8Array,
-  type WritableAccount,
+    combineCodec,
+    getStructDecoder,
+    getStructEncoder,
+    getU8Decoder,
+    getU8Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyAccount,
+    type ReadonlyUint8Array,
+    type WritableAccount,
 } from '@solana/kit';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -31,183 +31,151 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const INITIALIZE_ACCOUNT_DISCRIMINATOR = 1;
 
 export function getInitializeAccountDiscriminatorBytes() {
-  return getU8Encoder().encode(INITIALIZE_ACCOUNT_DISCRIMINATOR);
+    return getU8Encoder().encode(INITIALIZE_ACCOUNT_DISCRIMINATOR);
 }
 
 export type InitializeAccountInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountAccount extends string | AccountMeta<string> = string,
-  TAccountMint extends string | AccountMeta<string> = string,
-  TAccountOwner extends string | AccountMeta<string> = string,
-  TAccountRent extends string | AccountMeta<string> =
-    'SysvarRent111111111111111111111111111111111',
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountAccount extends string | AccountMeta<string> = string,
+    TAccountMint extends string | AccountMeta<string> = string,
+    TAccountOwner extends string | AccountMeta<string> = string,
+    TAccountRent extends string | AccountMeta<string> = 'SysvarRent111111111111111111111111111111111',
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountAccount extends string
-        ? WritableAccount<TAccountAccount>
-        : TAccountAccount,
-      TAccountMint extends string
-        ? ReadonlyAccount<TAccountMint>
-        : TAccountMint,
-      TAccountOwner extends string
-        ? ReadonlyAccount<TAccountOwner>
-        : TAccountOwner,
-      TAccountRent extends string
-        ? ReadonlyAccount<TAccountRent>
-        : TAccountRent,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountAccount extends string ? WritableAccount<TAccountAccount> : TAccountAccount,
+            TAccountMint extends string ? ReadonlyAccount<TAccountMint> : TAccountMint,
+            TAccountOwner extends string ? ReadonlyAccount<TAccountOwner> : TAccountOwner,
+            TAccountRent extends string ? ReadonlyAccount<TAccountRent> : TAccountRent,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type InitializeAccountInstructionData = { discriminator: number };
 
 export type InitializeAccountInstructionDataArgs = {};
 
 export function getInitializeAccountInstructionDataEncoder(): FixedSizeEncoder<InitializeAccountInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([['discriminator', getU8Encoder()]]),
-    (value) => ({ ...value, discriminator: INITIALIZE_ACCOUNT_DISCRIMINATOR })
-  );
+    return transformEncoder(getStructEncoder([['discriminator', getU8Encoder()]]), value => ({
+        ...value,
+        discriminator: INITIALIZE_ACCOUNT_DISCRIMINATOR,
+    }));
 }
 
 export function getInitializeAccountInstructionDataDecoder(): FixedSizeDecoder<InitializeAccountInstructionData> {
-  return getStructDecoder([['discriminator', getU8Decoder()]]);
+    return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getInitializeAccountInstructionDataCodec(): FixedSizeCodec<
-  InitializeAccountInstructionDataArgs,
-  InitializeAccountInstructionData
+    InitializeAccountInstructionDataArgs,
+    InitializeAccountInstructionData
 > {
-  return combineCodec(
-    getInitializeAccountInstructionDataEncoder(),
-    getInitializeAccountInstructionDataDecoder()
-  );
+    return combineCodec(getInitializeAccountInstructionDataEncoder(), getInitializeAccountInstructionDataDecoder());
 }
 
 export type InitializeAccountInput<
-  TAccountAccount extends string = string,
-  TAccountMint extends string = string,
-  TAccountOwner extends string = string,
-  TAccountRent extends string = string,
+    TAccountAccount extends string = string,
+    TAccountMint extends string = string,
+    TAccountOwner extends string = string,
+    TAccountRent extends string = string,
 > = {
-  /** The account to initialize. */
-  account: Address<TAccountAccount>;
-  /** The mint this account will be associated with. */
-  mint: Address<TAccountMint>;
-  /** The new account's owner/multisignature. */
-  owner: Address<TAccountOwner>;
-  /** Rent sysvar. */
-  rent?: Address<TAccountRent>;
+    /** The account to initialize. */
+    account: Address<TAccountAccount>;
+    /** The mint this account will be associated with. */
+    mint: Address<TAccountMint>;
+    /** The new account's owner/multisignature. */
+    owner: Address<TAccountOwner>;
+    /** Rent sysvar. */
+    rent?: Address<TAccountRent>;
 };
 
 export function getInitializeAccountInstruction<
-  TAccountAccount extends string,
-  TAccountMint extends string,
-  TAccountOwner extends string,
-  TAccountRent extends string,
-  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountAccount extends string,
+    TAccountMint extends string,
+    TAccountOwner extends string,
+    TAccountRent extends string,
+    TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: InitializeAccountInput<
-    TAccountAccount,
-    TAccountMint,
-    TAccountOwner,
-    TAccountRent
-  >,
-  config?: { programAddress?: TProgramAddress }
-): InitializeAccountInstruction<
-  TProgramAddress,
-  TAccountAccount,
-  TAccountMint,
-  TAccountOwner,
-  TAccountRent
-> {
-  // Program address.
-  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
+    input: InitializeAccountInput<TAccountAccount, TAccountMint, TAccountOwner, TAccountRent>,
+    config?: { programAddress?: TProgramAddress }
+): InitializeAccountInstruction<TProgramAddress, TAccountAccount, TAccountMint, TAccountOwner, TAccountRent> {
+    // Program address.
+    const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
-  // Original accounts.
-  const originalAccounts = {
-    account: { value: input.account ?? null, isWritable: true },
-    mint: { value: input.mint ?? null, isWritable: false },
-    owner: { value: input.owner ?? null, isWritable: false },
-    rent: { value: input.rent ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
+    // Original accounts.
+    const originalAccounts = {
+        account: { value: input.account ?? null, isWritable: true },
+        mint: { value: input.mint ?? null, isWritable: false },
+        owner: { value: input.owner ?? null, isWritable: false },
+        rent: { value: input.rent ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
 
-  // Resolve default values.
-  if (!accounts.rent.value) {
-    accounts.rent.value =
-      'SysvarRent111111111111111111111111111111111' as Address<'SysvarRent111111111111111111111111111111111'>;
-  }
+    // Resolve default values.
+    if (!accounts.rent.value) {
+        accounts.rent.value =
+            'SysvarRent111111111111111111111111111111111' as Address<'SysvarRent111111111111111111111111111111111'>;
+    }
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.account),
-      getAccountMeta(accounts.mint),
-      getAccountMeta(accounts.owner),
-      getAccountMeta(accounts.rent),
-    ],
-    data: getInitializeAccountInstructionDataEncoder().encode({}),
-    programAddress,
-  } as InitializeAccountInstruction<
-    TProgramAddress,
-    TAccountAccount,
-    TAccountMint,
-    TAccountOwner,
-    TAccountRent
-  >);
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [
+            getAccountMeta(accounts.account),
+            getAccountMeta(accounts.mint),
+            getAccountMeta(accounts.owner),
+            getAccountMeta(accounts.rent),
+        ],
+        data: getInitializeAccountInstructionDataEncoder().encode({}),
+        programAddress,
+    } as InitializeAccountInstruction<TProgramAddress, TAccountAccount, TAccountMint, TAccountOwner, TAccountRent>);
 }
 
 export type ParsedInitializeAccountInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    /** The account to initialize. */
-    account: TAccountMetas[0];
-    /** The mint this account will be associated with. */
-    mint: TAccountMetas[1];
-    /** The new account's owner/multisignature. */
-    owner: TAccountMetas[2];
-    /** Rent sysvar. */
-    rent: TAccountMetas[3];
-  };
-  data: InitializeAccountInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        /** The account to initialize. */
+        account: TAccountMetas[0];
+        /** The mint this account will be associated with. */
+        mint: TAccountMetas[1];
+        /** The new account's owner/multisignature. */
+        owner: TAccountMetas[2];
+        /** Rent sysvar. */
+        rent: TAccountMetas[3];
+    };
+    data: InitializeAccountInstructionData;
 };
 
 export function parseInitializeAccountInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
+    TProgram extends string,
+    TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedInitializeAccountInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 4) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: {
-      account: getNextAccount(),
-      mint: getNextAccount(),
-      owner: getNextAccount(),
-      rent: getNextAccount(),
-    },
-    data: getInitializeAccountInstructionDataDecoder().decode(instruction.data),
-  };
+    if (instruction.accounts.length < 4) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: {
+            account: getNextAccount(),
+            mint: getNextAccount(),
+            owner: getNextAccount(),
+            rent: getNextAccount(),
+        },
+        data: getInitializeAccountInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/token/src/generated/instructions/initializeAccount2.ts
+++ b/test/e2e/token/src/generated/instructions/initializeAccount2.ts
@@ -7,25 +7,25 @@
  */
 
 import {
-  combineCodec,
-  getAddressDecoder,
-  getAddressEncoder,
-  getStructDecoder,
-  getStructEncoder,
-  getU8Decoder,
-  getU8Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyAccount,
-  type ReadonlyUint8Array,
-  type WritableAccount,
+    combineCodec,
+    getAddressDecoder,
+    getAddressEncoder,
+    getStructDecoder,
+    getStructEncoder,
+    getU8Decoder,
+    getU8Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyAccount,
+    type ReadonlyUint8Array,
+    type WritableAccount,
 } from '@solana/kit';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -33,184 +33,149 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const INITIALIZE_ACCOUNT2_DISCRIMINATOR = 16;
 
 export function getInitializeAccount2DiscriminatorBytes() {
-  return getU8Encoder().encode(INITIALIZE_ACCOUNT2_DISCRIMINATOR);
+    return getU8Encoder().encode(INITIALIZE_ACCOUNT2_DISCRIMINATOR);
 }
 
 export type InitializeAccount2Instruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountAccount extends string | AccountMeta<string> = string,
-  TAccountMint extends string | AccountMeta<string> = string,
-  TAccountRent extends string | AccountMeta<string> =
-    'SysvarRent111111111111111111111111111111111',
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountAccount extends string | AccountMeta<string> = string,
+    TAccountMint extends string | AccountMeta<string> = string,
+    TAccountRent extends string | AccountMeta<string> = 'SysvarRent111111111111111111111111111111111',
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountAccount extends string
-        ? WritableAccount<TAccountAccount>
-        : TAccountAccount,
-      TAccountMint extends string
-        ? ReadonlyAccount<TAccountMint>
-        : TAccountMint,
-      TAccountRent extends string
-        ? ReadonlyAccount<TAccountRent>
-        : TAccountRent,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountAccount extends string ? WritableAccount<TAccountAccount> : TAccountAccount,
+            TAccountMint extends string ? ReadonlyAccount<TAccountMint> : TAccountMint,
+            TAccountRent extends string ? ReadonlyAccount<TAccountRent> : TAccountRent,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type InitializeAccount2InstructionData = {
-  discriminator: number;
-  /** The new account's owner/multisignature. */
-  owner: Address;
+    discriminator: number;
+    /** The new account's owner/multisignature. */
+    owner: Address;
 };
 
 export type InitializeAccount2InstructionDataArgs = {
-  /** The new account's owner/multisignature. */
-  owner: Address;
+    /** The new account's owner/multisignature. */
+    owner: Address;
 };
 
 export function getInitializeAccount2InstructionDataEncoder(): FixedSizeEncoder<InitializeAccount2InstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', getU8Encoder()],
-      ['owner', getAddressEncoder()],
-    ]),
-    (value) => ({ ...value, discriminator: INITIALIZE_ACCOUNT2_DISCRIMINATOR })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', getU8Encoder()],
+            ['owner', getAddressEncoder()],
+        ]),
+        value => ({ ...value, discriminator: INITIALIZE_ACCOUNT2_DISCRIMINATOR })
+    );
 }
 
 export function getInitializeAccount2InstructionDataDecoder(): FixedSizeDecoder<InitializeAccount2InstructionData> {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-    ['owner', getAddressDecoder()],
-  ]);
+    return getStructDecoder([
+        ['discriminator', getU8Decoder()],
+        ['owner', getAddressDecoder()],
+    ]);
 }
 
 export function getInitializeAccount2InstructionDataCodec(): FixedSizeCodec<
-  InitializeAccount2InstructionDataArgs,
-  InitializeAccount2InstructionData
+    InitializeAccount2InstructionDataArgs,
+    InitializeAccount2InstructionData
 > {
-  return combineCodec(
-    getInitializeAccount2InstructionDataEncoder(),
-    getInitializeAccount2InstructionDataDecoder()
-  );
+    return combineCodec(getInitializeAccount2InstructionDataEncoder(), getInitializeAccount2InstructionDataDecoder());
 }
 
 export type InitializeAccount2Input<
-  TAccountAccount extends string = string,
-  TAccountMint extends string = string,
-  TAccountRent extends string = string,
+    TAccountAccount extends string = string,
+    TAccountMint extends string = string,
+    TAccountRent extends string = string,
 > = {
-  /** The account to initialize. */
-  account: Address<TAccountAccount>;
-  /** The mint this account will be associated with. */
-  mint: Address<TAccountMint>;
-  /** Rent sysvar. */
-  rent?: Address<TAccountRent>;
-  owner: InitializeAccount2InstructionDataArgs['owner'];
+    /** The account to initialize. */
+    account: Address<TAccountAccount>;
+    /** The mint this account will be associated with. */
+    mint: Address<TAccountMint>;
+    /** Rent sysvar. */
+    rent?: Address<TAccountRent>;
+    owner: InitializeAccount2InstructionDataArgs['owner'];
 };
 
 export function getInitializeAccount2Instruction<
-  TAccountAccount extends string,
-  TAccountMint extends string,
-  TAccountRent extends string,
-  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountAccount extends string,
+    TAccountMint extends string,
+    TAccountRent extends string,
+    TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: InitializeAccount2Input<TAccountAccount, TAccountMint, TAccountRent>,
-  config?: { programAddress?: TProgramAddress }
-): InitializeAccount2Instruction<
-  TProgramAddress,
-  TAccountAccount,
-  TAccountMint,
-  TAccountRent
-> {
-  // Program address.
-  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
+    input: InitializeAccount2Input<TAccountAccount, TAccountMint, TAccountRent>,
+    config?: { programAddress?: TProgramAddress }
+): InitializeAccount2Instruction<TProgramAddress, TAccountAccount, TAccountMint, TAccountRent> {
+    // Program address.
+    const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
-  // Original accounts.
-  const originalAccounts = {
-    account: { value: input.account ?? null, isWritable: true },
-    mint: { value: input.mint ?? null, isWritable: false },
-    rent: { value: input.rent ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
+    // Original accounts.
+    const originalAccounts = {
+        account: { value: input.account ?? null, isWritable: true },
+        mint: { value: input.mint ?? null, isWritable: false },
+        rent: { value: input.rent ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
 
-  // Original args.
-  const args = { ...input };
+    // Original args.
+    const args = { ...input };
 
-  // Resolve default values.
-  if (!accounts.rent.value) {
-    accounts.rent.value =
-      'SysvarRent111111111111111111111111111111111' as Address<'SysvarRent111111111111111111111111111111111'>;
-  }
+    // Resolve default values.
+    if (!accounts.rent.value) {
+        accounts.rent.value =
+            'SysvarRent111111111111111111111111111111111' as Address<'SysvarRent111111111111111111111111111111111'>;
+    }
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.account),
-      getAccountMeta(accounts.mint),
-      getAccountMeta(accounts.rent),
-    ],
-    data: getInitializeAccount2InstructionDataEncoder().encode(
-      args as InitializeAccount2InstructionDataArgs
-    ),
-    programAddress,
-  } as InitializeAccount2Instruction<
-    TProgramAddress,
-    TAccountAccount,
-    TAccountMint,
-    TAccountRent
-  >);
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [getAccountMeta(accounts.account), getAccountMeta(accounts.mint), getAccountMeta(accounts.rent)],
+        data: getInitializeAccount2InstructionDataEncoder().encode(args as InitializeAccount2InstructionDataArgs),
+        programAddress,
+    } as InitializeAccount2Instruction<TProgramAddress, TAccountAccount, TAccountMint, TAccountRent>);
 }
 
 export type ParsedInitializeAccount2Instruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    /** The account to initialize. */
-    account: TAccountMetas[0];
-    /** The mint this account will be associated with. */
-    mint: TAccountMetas[1];
-    /** Rent sysvar. */
-    rent: TAccountMetas[2];
-  };
-  data: InitializeAccount2InstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        /** The account to initialize. */
+        account: TAccountMetas[0];
+        /** The mint this account will be associated with. */
+        mint: TAccountMetas[1];
+        /** Rent sysvar. */
+        rent: TAccountMetas[2];
+    };
+    data: InitializeAccount2InstructionData;
 };
 
 export function parseInitializeAccount2Instruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
+    TProgram extends string,
+    TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedInitializeAccount2Instruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 3) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: {
-      account: getNextAccount(),
-      mint: getNextAccount(),
-      rent: getNextAccount(),
-    },
-    data: getInitializeAccount2InstructionDataDecoder().decode(
-      instruction.data
-    ),
-  };
+    if (instruction.accounts.length < 3) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { account: getNextAccount(), mint: getNextAccount(), rent: getNextAccount() },
+        data: getInitializeAccount2InstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/token/src/generated/instructions/initializeAccount3.ts
+++ b/test/e2e/token/src/generated/instructions/initializeAccount3.ts
@@ -7,25 +7,25 @@
  */
 
 import {
-  combineCodec,
-  getAddressDecoder,
-  getAddressEncoder,
-  getStructDecoder,
-  getStructEncoder,
-  getU8Decoder,
-  getU8Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyAccount,
-  type ReadonlyUint8Array,
-  type WritableAccount,
+    combineCodec,
+    getAddressDecoder,
+    getAddressEncoder,
+    getStructDecoder,
+    getStructEncoder,
+    getU8Decoder,
+    getU8Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyAccount,
+    type ReadonlyUint8Array,
+    type WritableAccount,
 } from '@solana/kit';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -33,156 +33,131 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const INITIALIZE_ACCOUNT3_DISCRIMINATOR = 18;
 
 export function getInitializeAccount3DiscriminatorBytes() {
-  return getU8Encoder().encode(INITIALIZE_ACCOUNT3_DISCRIMINATOR);
+    return getU8Encoder().encode(INITIALIZE_ACCOUNT3_DISCRIMINATOR);
 }
 
 export type InitializeAccount3Instruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountAccount extends string | AccountMeta<string> = string,
-  TAccountMint extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountAccount extends string | AccountMeta<string> = string,
+    TAccountMint extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountAccount extends string
-        ? WritableAccount<TAccountAccount>
-        : TAccountAccount,
-      TAccountMint extends string
-        ? ReadonlyAccount<TAccountMint>
-        : TAccountMint,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountAccount extends string ? WritableAccount<TAccountAccount> : TAccountAccount,
+            TAccountMint extends string ? ReadonlyAccount<TAccountMint> : TAccountMint,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type InitializeAccount3InstructionData = {
-  discriminator: number;
-  /** The new account's owner/multisignature. */
-  owner: Address;
+    discriminator: number;
+    /** The new account's owner/multisignature. */
+    owner: Address;
 };
 
 export type InitializeAccount3InstructionDataArgs = {
-  /** The new account's owner/multisignature. */
-  owner: Address;
+    /** The new account's owner/multisignature. */
+    owner: Address;
 };
 
 export function getInitializeAccount3InstructionDataEncoder(): FixedSizeEncoder<InitializeAccount3InstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', getU8Encoder()],
-      ['owner', getAddressEncoder()],
-    ]),
-    (value) => ({ ...value, discriminator: INITIALIZE_ACCOUNT3_DISCRIMINATOR })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', getU8Encoder()],
+            ['owner', getAddressEncoder()],
+        ]),
+        value => ({ ...value, discriminator: INITIALIZE_ACCOUNT3_DISCRIMINATOR })
+    );
 }
 
 export function getInitializeAccount3InstructionDataDecoder(): FixedSizeDecoder<InitializeAccount3InstructionData> {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-    ['owner', getAddressDecoder()],
-  ]);
+    return getStructDecoder([
+        ['discriminator', getU8Decoder()],
+        ['owner', getAddressDecoder()],
+    ]);
 }
 
 export function getInitializeAccount3InstructionDataCodec(): FixedSizeCodec<
-  InitializeAccount3InstructionDataArgs,
-  InitializeAccount3InstructionData
+    InitializeAccount3InstructionDataArgs,
+    InitializeAccount3InstructionData
 > {
-  return combineCodec(
-    getInitializeAccount3InstructionDataEncoder(),
-    getInitializeAccount3InstructionDataDecoder()
-  );
+    return combineCodec(getInitializeAccount3InstructionDataEncoder(), getInitializeAccount3InstructionDataDecoder());
 }
 
-export type InitializeAccount3Input<
-  TAccountAccount extends string = string,
-  TAccountMint extends string = string,
-> = {
-  /** The account to initialize. */
-  account: Address<TAccountAccount>;
-  /** The mint this account will be associated with. */
-  mint: Address<TAccountMint>;
-  owner: InitializeAccount3InstructionDataArgs['owner'];
+export type InitializeAccount3Input<TAccountAccount extends string = string, TAccountMint extends string = string> = {
+    /** The account to initialize. */
+    account: Address<TAccountAccount>;
+    /** The mint this account will be associated with. */
+    mint: Address<TAccountMint>;
+    owner: InitializeAccount3InstructionDataArgs['owner'];
 };
 
 export function getInitializeAccount3Instruction<
-  TAccountAccount extends string,
-  TAccountMint extends string,
-  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountAccount extends string,
+    TAccountMint extends string,
+    TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: InitializeAccount3Input<TAccountAccount, TAccountMint>,
-  config?: { programAddress?: TProgramAddress }
-): InitializeAccount3Instruction<
-  TProgramAddress,
-  TAccountAccount,
-  TAccountMint
-> {
-  // Program address.
-  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
+    input: InitializeAccount3Input<TAccountAccount, TAccountMint>,
+    config?: { programAddress?: TProgramAddress }
+): InitializeAccount3Instruction<TProgramAddress, TAccountAccount, TAccountMint> {
+    // Program address.
+    const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
-  // Original accounts.
-  const originalAccounts = {
-    account: { value: input.account ?? null, isWritable: true },
-    mint: { value: input.mint ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
+    // Original accounts.
+    const originalAccounts = {
+        account: { value: input.account ?? null, isWritable: true },
+        mint: { value: input.mint ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
 
-  // Original args.
-  const args = { ...input };
+    // Original args.
+    const args = { ...input };
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [getAccountMeta(accounts.account), getAccountMeta(accounts.mint)],
-    data: getInitializeAccount3InstructionDataEncoder().encode(
-      args as InitializeAccount3InstructionDataArgs
-    ),
-    programAddress,
-  } as InitializeAccount3Instruction<
-    TProgramAddress,
-    TAccountAccount,
-    TAccountMint
-  >);
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [getAccountMeta(accounts.account), getAccountMeta(accounts.mint)],
+        data: getInitializeAccount3InstructionDataEncoder().encode(args as InitializeAccount3InstructionDataArgs),
+        programAddress,
+    } as InitializeAccount3Instruction<TProgramAddress, TAccountAccount, TAccountMint>);
 }
 
 export type ParsedInitializeAccount3Instruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    /** The account to initialize. */
-    account: TAccountMetas[0];
-    /** The mint this account will be associated with. */
-    mint: TAccountMetas[1];
-  };
-  data: InitializeAccount3InstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        /** The account to initialize. */
+        account: TAccountMetas[0];
+        /** The mint this account will be associated with. */
+        mint: TAccountMetas[1];
+    };
+    data: InitializeAccount3InstructionData;
 };
 
 export function parseInitializeAccount3Instruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
+    TProgram extends string,
+    TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedInitializeAccount3Instruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 2) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: { account: getNextAccount(), mint: getNextAccount() },
-    data: getInitializeAccount3InstructionDataDecoder().decode(
-      instruction.data
-    ),
-  };
+    if (instruction.accounts.length < 2) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { account: getNextAccount(), mint: getNextAccount() },
+        data: getInitializeAccount3InstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/token/src/generated/instructions/initializeImmutableOwner.ts
+++ b/test/e2e/token/src/generated/instructions/initializeImmutableOwner.ts
@@ -7,22 +7,22 @@
  */
 
 import {
-  combineCodec,
-  getStructDecoder,
-  getStructEncoder,
-  getU8Decoder,
-  getU8Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyUint8Array,
-  type WritableAccount,
+    combineCodec,
+    getStructDecoder,
+    getStructEncoder,
+    getU8Decoder,
+    getU8Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyUint8Array,
+    type WritableAccount,
 } from '@solana/kit';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -30,121 +30,104 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const INITIALIZE_IMMUTABLE_OWNER_DISCRIMINATOR = 22;
 
 export function getInitializeImmutableOwnerDiscriminatorBytes() {
-  return getU8Encoder().encode(INITIALIZE_IMMUTABLE_OWNER_DISCRIMINATOR);
+    return getU8Encoder().encode(INITIALIZE_IMMUTABLE_OWNER_DISCRIMINATOR);
 }
 
 export type InitializeImmutableOwnerInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountAccount extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountAccount extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountAccount extends string
-        ? WritableAccount<TAccountAccount>
-        : TAccountAccount,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [TAccountAccount extends string ? WritableAccount<TAccountAccount> : TAccountAccount, ...TRemainingAccounts]
+    >;
 
 export type InitializeImmutableOwnerInstructionData = { discriminator: number };
 
 export type InitializeImmutableOwnerInstructionDataArgs = {};
 
 export function getInitializeImmutableOwnerInstructionDataEncoder(): FixedSizeEncoder<InitializeImmutableOwnerInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([['discriminator', getU8Encoder()]]),
-    (value) => ({
-      ...value,
-      discriminator: INITIALIZE_IMMUTABLE_OWNER_DISCRIMINATOR,
-    })
-  );
+    return transformEncoder(getStructEncoder([['discriminator', getU8Encoder()]]), value => ({
+        ...value,
+        discriminator: INITIALIZE_IMMUTABLE_OWNER_DISCRIMINATOR,
+    }));
 }
 
 export function getInitializeImmutableOwnerInstructionDataDecoder(): FixedSizeDecoder<InitializeImmutableOwnerInstructionData> {
-  return getStructDecoder([['discriminator', getU8Decoder()]]);
+    return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getInitializeImmutableOwnerInstructionDataCodec(): FixedSizeCodec<
-  InitializeImmutableOwnerInstructionDataArgs,
-  InitializeImmutableOwnerInstructionData
+    InitializeImmutableOwnerInstructionDataArgs,
+    InitializeImmutableOwnerInstructionData
 > {
-  return combineCodec(
-    getInitializeImmutableOwnerInstructionDataEncoder(),
-    getInitializeImmutableOwnerInstructionDataDecoder()
-  );
+    return combineCodec(
+        getInitializeImmutableOwnerInstructionDataEncoder(),
+        getInitializeImmutableOwnerInstructionDataDecoder()
+    );
 }
 
-export type InitializeImmutableOwnerInput<
-  TAccountAccount extends string = string,
-> = {
-  /** The account to initialize. */
-  account: Address<TAccountAccount>;
+export type InitializeImmutableOwnerInput<TAccountAccount extends string = string> = {
+    /** The account to initialize. */
+    account: Address<TAccountAccount>;
 };
 
 export function getInitializeImmutableOwnerInstruction<
-  TAccountAccount extends string,
-  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountAccount extends string,
+    TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: InitializeImmutableOwnerInput<TAccountAccount>,
-  config?: { programAddress?: TProgramAddress }
+    input: InitializeImmutableOwnerInput<TAccountAccount>,
+    config?: { programAddress?: TProgramAddress }
 ): InitializeImmutableOwnerInstruction<TProgramAddress, TAccountAccount> {
-  // Program address.
-  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
+    // Program address.
+    const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
-  // Original accounts.
-  const originalAccounts = {
-    account: { value: input.account ?? null, isWritable: true },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
+    // Original accounts.
+    const originalAccounts = { account: { value: input.account ?? null, isWritable: true } };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [getAccountMeta(accounts.account)],
-    data: getInitializeImmutableOwnerInstructionDataEncoder().encode({}),
-    programAddress,
-  } as InitializeImmutableOwnerInstruction<TProgramAddress, TAccountAccount>);
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [getAccountMeta(accounts.account)],
+        data: getInitializeImmutableOwnerInstructionDataEncoder().encode({}),
+        programAddress,
+    } as InitializeImmutableOwnerInstruction<TProgramAddress, TAccountAccount>);
 }
 
 export type ParsedInitializeImmutableOwnerInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    /** The account to initialize. */
-    account: TAccountMetas[0];
-  };
-  data: InitializeImmutableOwnerInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        /** The account to initialize. */
+        account: TAccountMetas[0];
+    };
+    data: InitializeImmutableOwnerInstructionData;
 };
 
 export function parseInitializeImmutableOwnerInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
+    TProgram extends string,
+    TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedInitializeImmutableOwnerInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 1) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: { account: getNextAccount() },
-    data: getInitializeImmutableOwnerInstructionDataDecoder().decode(
-      instruction.data
-    ),
-  };
+    if (instruction.accounts.length < 1) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { account: getNextAccount() },
+        data: getInitializeImmutableOwnerInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/token/src/generated/instructions/initializeMint.ts
+++ b/test/e2e/token/src/generated/instructions/initializeMint.ts
@@ -7,30 +7,30 @@
  */
 
 import {
-  combineCodec,
-  getAddressDecoder,
-  getAddressEncoder,
-  getOptionDecoder,
-  getOptionEncoder,
-  getStructDecoder,
-  getStructEncoder,
-  getU8Decoder,
-  getU8Encoder,
-  none,
-  transformEncoder,
-  type AccountMeta,
-  type Address,
-  type Codec,
-  type Decoder,
-  type Encoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type Option,
-  type OptionOrNullable,
-  type ReadonlyAccount,
-  type ReadonlyUint8Array,
-  type WritableAccount,
+    combineCodec,
+    getAddressDecoder,
+    getAddressEncoder,
+    getOptionDecoder,
+    getOptionEncoder,
+    getStructDecoder,
+    getStructEncoder,
+    getU8Decoder,
+    getU8Encoder,
+    none,
+    transformEncoder,
+    type AccountMeta,
+    type Address,
+    type Codec,
+    type Decoder,
+    type Encoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type Option,
+    type OptionOrNullable,
+    type ReadonlyAccount,
+    type ReadonlyUint8Array,
+    type WritableAccount,
 } from '@solana/kit';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -38,171 +38,152 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const INITIALIZE_MINT_DISCRIMINATOR = 0;
 
 export function getInitializeMintDiscriminatorBytes() {
-  return getU8Encoder().encode(INITIALIZE_MINT_DISCRIMINATOR);
+    return getU8Encoder().encode(INITIALIZE_MINT_DISCRIMINATOR);
 }
 
 export type InitializeMintInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMint extends string | AccountMeta<string> = string,
-  TAccountRent extends string | AccountMeta<string> =
-    'SysvarRent111111111111111111111111111111111',
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMint extends string | AccountMeta<string> = string,
+    TAccountRent extends string | AccountMeta<string> = 'SysvarRent111111111111111111111111111111111',
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountMint extends string
-        ? WritableAccount<TAccountMint>
-        : TAccountMint,
-      TAccountRent extends string
-        ? ReadonlyAccount<TAccountRent>
-        : TAccountRent,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountMint extends string ? WritableAccount<TAccountMint> : TAccountMint,
+            TAccountRent extends string ? ReadonlyAccount<TAccountRent> : TAccountRent,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type InitializeMintInstructionData = {
-  discriminator: number;
-  /** Number of decimals in token account amounts. */
-  decimals: number;
-  /** Minting authority. */
-  mintAuthority: Address;
-  /** Optional authority that can freeze token accounts. */
-  freezeAuthority: Option<Address>;
+    discriminator: number;
+    /** Number of decimals in token account amounts. */
+    decimals: number;
+    /** Minting authority. */
+    mintAuthority: Address;
+    /** Optional authority that can freeze token accounts. */
+    freezeAuthority: Option<Address>;
 };
 
 export type InitializeMintInstructionDataArgs = {
-  /** Number of decimals in token account amounts. */
-  decimals: number;
-  /** Minting authority. */
-  mintAuthority: Address;
-  /** Optional authority that can freeze token accounts. */
-  freezeAuthority?: OptionOrNullable<Address>;
+    /** Number of decimals in token account amounts. */
+    decimals: number;
+    /** Minting authority. */
+    mintAuthority: Address;
+    /** Optional authority that can freeze token accounts. */
+    freezeAuthority?: OptionOrNullable<Address>;
 };
 
 export function getInitializeMintInstructionDataEncoder(): Encoder<InitializeMintInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', getU8Encoder()],
-      ['decimals', getU8Encoder()],
-      ['mintAuthority', getAddressEncoder()],
-      ['freezeAuthority', getOptionEncoder(getAddressEncoder())],
-    ]),
-    (value) => ({
-      ...value,
-      discriminator: INITIALIZE_MINT_DISCRIMINATOR,
-      freezeAuthority: value.freezeAuthority ?? none(),
-    })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', getU8Encoder()],
+            ['decimals', getU8Encoder()],
+            ['mintAuthority', getAddressEncoder()],
+            ['freezeAuthority', getOptionEncoder(getAddressEncoder())],
+        ]),
+        value => ({
+            ...value,
+            discriminator: INITIALIZE_MINT_DISCRIMINATOR,
+            freezeAuthority: value.freezeAuthority ?? none(),
+        })
+    );
 }
 
 export function getInitializeMintInstructionDataDecoder(): Decoder<InitializeMintInstructionData> {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-    ['decimals', getU8Decoder()],
-    ['mintAuthority', getAddressDecoder()],
-    ['freezeAuthority', getOptionDecoder(getAddressDecoder())],
-  ]);
+    return getStructDecoder([
+        ['discriminator', getU8Decoder()],
+        ['decimals', getU8Decoder()],
+        ['mintAuthority', getAddressDecoder()],
+        ['freezeAuthority', getOptionDecoder(getAddressDecoder())],
+    ]);
 }
 
 export function getInitializeMintInstructionDataCodec(): Codec<
-  InitializeMintInstructionDataArgs,
-  InitializeMintInstructionData
+    InitializeMintInstructionDataArgs,
+    InitializeMintInstructionData
 > {
-  return combineCodec(
-    getInitializeMintInstructionDataEncoder(),
-    getInitializeMintInstructionDataDecoder()
-  );
+    return combineCodec(getInitializeMintInstructionDataEncoder(), getInitializeMintInstructionDataDecoder());
 }
 
-export type InitializeMintInput<
-  TAccountMint extends string = string,
-  TAccountRent extends string = string,
-> = {
-  /** Token mint account. */
-  mint: Address<TAccountMint>;
-  /** Rent sysvar. */
-  rent?: Address<TAccountRent>;
-  decimals: InitializeMintInstructionDataArgs['decimals'];
-  mintAuthority: InitializeMintInstructionDataArgs['mintAuthority'];
-  freezeAuthority?: InitializeMintInstructionDataArgs['freezeAuthority'];
+export type InitializeMintInput<TAccountMint extends string = string, TAccountRent extends string = string> = {
+    /** Token mint account. */
+    mint: Address<TAccountMint>;
+    /** Rent sysvar. */
+    rent?: Address<TAccountRent>;
+    decimals: InitializeMintInstructionDataArgs['decimals'];
+    mintAuthority: InitializeMintInstructionDataArgs['mintAuthority'];
+    freezeAuthority?: InitializeMintInstructionDataArgs['freezeAuthority'];
 };
 
 export function getInitializeMintInstruction<
-  TAccountMint extends string,
-  TAccountRent extends string,
-  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMint extends string,
+    TAccountRent extends string,
+    TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: InitializeMintInput<TAccountMint, TAccountRent>,
-  config?: { programAddress?: TProgramAddress }
+    input: InitializeMintInput<TAccountMint, TAccountRent>,
+    config?: { programAddress?: TProgramAddress }
 ): InitializeMintInstruction<TProgramAddress, TAccountMint, TAccountRent> {
-  // Program address.
-  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
+    // Program address.
+    const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
-  // Original accounts.
-  const originalAccounts = {
-    mint: { value: input.mint ?? null, isWritable: true },
-    rent: { value: input.rent ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
+    // Original accounts.
+    const originalAccounts = {
+        mint: { value: input.mint ?? null, isWritable: true },
+        rent: { value: input.rent ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
 
-  // Original args.
-  const args = { ...input };
+    // Original args.
+    const args = { ...input };
 
-  // Resolve default values.
-  if (!accounts.rent.value) {
-    accounts.rent.value =
-      'SysvarRent111111111111111111111111111111111' as Address<'SysvarRent111111111111111111111111111111111'>;
-  }
+    // Resolve default values.
+    if (!accounts.rent.value) {
+        accounts.rent.value =
+            'SysvarRent111111111111111111111111111111111' as Address<'SysvarRent111111111111111111111111111111111'>;
+    }
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [getAccountMeta(accounts.mint), getAccountMeta(accounts.rent)],
-    data: getInitializeMintInstructionDataEncoder().encode(
-      args as InitializeMintInstructionDataArgs
-    ),
-    programAddress,
-  } as InitializeMintInstruction<TProgramAddress, TAccountMint, TAccountRent>);
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [getAccountMeta(accounts.mint), getAccountMeta(accounts.rent)],
+        data: getInitializeMintInstructionDataEncoder().encode(args as InitializeMintInstructionDataArgs),
+        programAddress,
+    } as InitializeMintInstruction<TProgramAddress, TAccountMint, TAccountRent>);
 }
 
 export type ParsedInitializeMintInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    /** Token mint account. */
-    mint: TAccountMetas[0];
-    /** Rent sysvar. */
-    rent: TAccountMetas[1];
-  };
-  data: InitializeMintInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        /** Token mint account. */
+        mint: TAccountMetas[0];
+        /** Rent sysvar. */
+        rent: TAccountMetas[1];
+    };
+    data: InitializeMintInstructionData;
 };
 
-export function parseInitializeMintInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
->(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+export function parseInitializeMintInstruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedInitializeMintInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 2) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: { mint: getNextAccount(), rent: getNextAccount() },
-    data: getInitializeMintInstructionDataDecoder().decode(instruction.data),
-  };
+    if (instruction.accounts.length < 2) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { mint: getNextAccount(), rent: getNextAccount() },
+        data: getInitializeMintInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/token/src/generated/instructions/initializeMint2.ts
+++ b/test/e2e/token/src/generated/instructions/initializeMint2.ts
@@ -7,29 +7,29 @@
  */
 
 import {
-  combineCodec,
-  getAddressDecoder,
-  getAddressEncoder,
-  getOptionDecoder,
-  getOptionEncoder,
-  getStructDecoder,
-  getStructEncoder,
-  getU8Decoder,
-  getU8Encoder,
-  none,
-  transformEncoder,
-  type AccountMeta,
-  type Address,
-  type Codec,
-  type Decoder,
-  type Encoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type Option,
-  type OptionOrNullable,
-  type ReadonlyUint8Array,
-  type WritableAccount,
+    combineCodec,
+    getAddressDecoder,
+    getAddressEncoder,
+    getOptionDecoder,
+    getOptionEncoder,
+    getStructDecoder,
+    getStructEncoder,
+    getU8Decoder,
+    getU8Encoder,
+    none,
+    transformEncoder,
+    type AccountMeta,
+    type Address,
+    type Codec,
+    type Decoder,
+    type Encoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type Option,
+    type OptionOrNullable,
+    type ReadonlyUint8Array,
+    type WritableAccount,
 } from '@solana/kit';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -37,151 +37,133 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const INITIALIZE_MINT2_DISCRIMINATOR = 20;
 
 export function getInitializeMint2DiscriminatorBytes() {
-  return getU8Encoder().encode(INITIALIZE_MINT2_DISCRIMINATOR);
+    return getU8Encoder().encode(INITIALIZE_MINT2_DISCRIMINATOR);
 }
 
 export type InitializeMint2Instruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMint extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMint extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountMint extends string
-        ? WritableAccount<TAccountMint>
-        : TAccountMint,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [TAccountMint extends string ? WritableAccount<TAccountMint> : TAccountMint, ...TRemainingAccounts]
+    >;
 
 export type InitializeMint2InstructionData = {
-  discriminator: number;
-  /** Number of base 10 digits to the right of the decimal place. */
-  decimals: number;
-  /** The authority/multisignature to mint tokens. */
-  mintAuthority: Address;
-  /** The optional freeze authority/multisignature of the mint. */
-  freezeAuthority: Option<Address>;
+    discriminator: number;
+    /** Number of base 10 digits to the right of the decimal place. */
+    decimals: number;
+    /** The authority/multisignature to mint tokens. */
+    mintAuthority: Address;
+    /** The optional freeze authority/multisignature of the mint. */
+    freezeAuthority: Option<Address>;
 };
 
 export type InitializeMint2InstructionDataArgs = {
-  /** Number of base 10 digits to the right of the decimal place. */
-  decimals: number;
-  /** The authority/multisignature to mint tokens. */
-  mintAuthority: Address;
-  /** The optional freeze authority/multisignature of the mint. */
-  freezeAuthority?: OptionOrNullable<Address>;
+    /** Number of base 10 digits to the right of the decimal place. */
+    decimals: number;
+    /** The authority/multisignature to mint tokens. */
+    mintAuthority: Address;
+    /** The optional freeze authority/multisignature of the mint. */
+    freezeAuthority?: OptionOrNullable<Address>;
 };
 
 export function getInitializeMint2InstructionDataEncoder(): Encoder<InitializeMint2InstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', getU8Encoder()],
-      ['decimals', getU8Encoder()],
-      ['mintAuthority', getAddressEncoder()],
-      ['freezeAuthority', getOptionEncoder(getAddressEncoder())],
-    ]),
-    (value) => ({
-      ...value,
-      discriminator: INITIALIZE_MINT2_DISCRIMINATOR,
-      freezeAuthority: value.freezeAuthority ?? none(),
-    })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', getU8Encoder()],
+            ['decimals', getU8Encoder()],
+            ['mintAuthority', getAddressEncoder()],
+            ['freezeAuthority', getOptionEncoder(getAddressEncoder())],
+        ]),
+        value => ({
+            ...value,
+            discriminator: INITIALIZE_MINT2_DISCRIMINATOR,
+            freezeAuthority: value.freezeAuthority ?? none(),
+        })
+    );
 }
 
 export function getInitializeMint2InstructionDataDecoder(): Decoder<InitializeMint2InstructionData> {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-    ['decimals', getU8Decoder()],
-    ['mintAuthority', getAddressDecoder()],
-    ['freezeAuthority', getOptionDecoder(getAddressDecoder())],
-  ]);
+    return getStructDecoder([
+        ['discriminator', getU8Decoder()],
+        ['decimals', getU8Decoder()],
+        ['mintAuthority', getAddressDecoder()],
+        ['freezeAuthority', getOptionDecoder(getAddressDecoder())],
+    ]);
 }
 
 export function getInitializeMint2InstructionDataCodec(): Codec<
-  InitializeMint2InstructionDataArgs,
-  InitializeMint2InstructionData
+    InitializeMint2InstructionDataArgs,
+    InitializeMint2InstructionData
 > {
-  return combineCodec(
-    getInitializeMint2InstructionDataEncoder(),
-    getInitializeMint2InstructionDataDecoder()
-  );
+    return combineCodec(getInitializeMint2InstructionDataEncoder(), getInitializeMint2InstructionDataDecoder());
 }
 
 export type InitializeMint2Input<TAccountMint extends string = string> = {
-  /** The mint to initialize. */
-  mint: Address<TAccountMint>;
-  decimals: InitializeMint2InstructionDataArgs['decimals'];
-  mintAuthority: InitializeMint2InstructionDataArgs['mintAuthority'];
-  freezeAuthority?: InitializeMint2InstructionDataArgs['freezeAuthority'];
+    /** The mint to initialize. */
+    mint: Address<TAccountMint>;
+    decimals: InitializeMint2InstructionDataArgs['decimals'];
+    mintAuthority: InitializeMint2InstructionDataArgs['mintAuthority'];
+    freezeAuthority?: InitializeMint2InstructionDataArgs['freezeAuthority'];
 };
 
 export function getInitializeMint2Instruction<
-  TAccountMint extends string,
-  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMint extends string,
+    TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: InitializeMint2Input<TAccountMint>,
-  config?: { programAddress?: TProgramAddress }
+    input: InitializeMint2Input<TAccountMint>,
+    config?: { programAddress?: TProgramAddress }
 ): InitializeMint2Instruction<TProgramAddress, TAccountMint> {
-  // Program address.
-  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
+    // Program address.
+    const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
-  // Original accounts.
-  const originalAccounts = {
-    mint: { value: input.mint ?? null, isWritable: true },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
+    // Original accounts.
+    const originalAccounts = { mint: { value: input.mint ?? null, isWritable: true } };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
 
-  // Original args.
-  const args = { ...input };
+    // Original args.
+    const args = { ...input };
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [getAccountMeta(accounts.mint)],
-    data: getInitializeMint2InstructionDataEncoder().encode(
-      args as InitializeMint2InstructionDataArgs
-    ),
-    programAddress,
-  } as InitializeMint2Instruction<TProgramAddress, TAccountMint>);
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [getAccountMeta(accounts.mint)],
+        data: getInitializeMint2InstructionDataEncoder().encode(args as InitializeMint2InstructionDataArgs),
+        programAddress,
+    } as InitializeMint2Instruction<TProgramAddress, TAccountMint>);
 }
 
 export type ParsedInitializeMint2Instruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    /** The mint to initialize. */
-    mint: TAccountMetas[0];
-  };
-  data: InitializeMint2InstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        /** The mint to initialize. */
+        mint: TAccountMetas[0];
+    };
+    data: InitializeMint2InstructionData;
 };
 
-export function parseInitializeMint2Instruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
->(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+export function parseInitializeMint2Instruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedInitializeMint2Instruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 1) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: { mint: getNextAccount() },
-    data: getInitializeMint2InstructionDataDecoder().decode(instruction.data),
-  };
+    if (instruction.accounts.length < 1) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { mint: getNextAccount() },
+        data: getInitializeMint2InstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/token/src/generated/instructions/initializeMultisig.ts
+++ b/test/e2e/token/src/generated/instructions/initializeMultisig.ts
@@ -7,24 +7,24 @@
  */
 
 import {
-  AccountRole,
-  combineCodec,
-  getStructDecoder,
-  getStructEncoder,
-  getU8Decoder,
-  getU8Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyAccount,
-  type ReadonlyUint8Array,
-  type WritableAccount,
+    AccountRole,
+    combineCodec,
+    getStructDecoder,
+    getStructEncoder,
+    getU8Decoder,
+    getU8Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyAccount,
+    type ReadonlyUint8Array,
+    type WritableAccount,
 } from '@solana/kit';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -32,174 +32,141 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const INITIALIZE_MULTISIG_DISCRIMINATOR = 2;
 
 export function getInitializeMultisigDiscriminatorBytes() {
-  return getU8Encoder().encode(INITIALIZE_MULTISIG_DISCRIMINATOR);
+    return getU8Encoder().encode(INITIALIZE_MULTISIG_DISCRIMINATOR);
 }
 
 export type InitializeMultisigInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMultisig extends string | AccountMeta<string> = string,
-  TAccountRent extends string | AccountMeta<string> =
-    'SysvarRent111111111111111111111111111111111',
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMultisig extends string | AccountMeta<string> = string,
+    TAccountRent extends string | AccountMeta<string> = 'SysvarRent111111111111111111111111111111111',
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountMultisig extends string
-        ? WritableAccount<TAccountMultisig>
-        : TAccountMultisig,
-      TAccountRent extends string
-        ? ReadonlyAccount<TAccountRent>
-        : TAccountRent,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountMultisig extends string ? WritableAccount<TAccountMultisig> : TAccountMultisig,
+            TAccountRent extends string ? ReadonlyAccount<TAccountRent> : TAccountRent,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type InitializeMultisigInstructionData = {
-  discriminator: number;
-  /** The number of signers (M) required to validate this multisignature account. */
-  m: number;
+    discriminator: number;
+    /** The number of signers (M) required to validate this multisignature account. */
+    m: number;
 };
 
 export type InitializeMultisigInstructionDataArgs = {
-  /** The number of signers (M) required to validate this multisignature account. */
-  m: number;
+    /** The number of signers (M) required to validate this multisignature account. */
+    m: number;
 };
 
 export function getInitializeMultisigInstructionDataEncoder(): FixedSizeEncoder<InitializeMultisigInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', getU8Encoder()],
-      ['m', getU8Encoder()],
-    ]),
-    (value) => ({ ...value, discriminator: INITIALIZE_MULTISIG_DISCRIMINATOR })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', getU8Encoder()],
+            ['m', getU8Encoder()],
+        ]),
+        value => ({ ...value, discriminator: INITIALIZE_MULTISIG_DISCRIMINATOR })
+    );
 }
 
 export function getInitializeMultisigInstructionDataDecoder(): FixedSizeDecoder<InitializeMultisigInstructionData> {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-    ['m', getU8Decoder()],
-  ]);
+    return getStructDecoder([
+        ['discriminator', getU8Decoder()],
+        ['m', getU8Decoder()],
+    ]);
 }
 
 export function getInitializeMultisigInstructionDataCodec(): FixedSizeCodec<
-  InitializeMultisigInstructionDataArgs,
-  InitializeMultisigInstructionData
+    InitializeMultisigInstructionDataArgs,
+    InitializeMultisigInstructionData
 > {
-  return combineCodec(
-    getInitializeMultisigInstructionDataEncoder(),
-    getInitializeMultisigInstructionDataDecoder()
-  );
+    return combineCodec(getInitializeMultisigInstructionDataEncoder(), getInitializeMultisigInstructionDataDecoder());
 }
 
-export type InitializeMultisigInput<
-  TAccountMultisig extends string = string,
-  TAccountRent extends string = string,
-> = {
-  /** The multisignature account to initialize. */
-  multisig: Address<TAccountMultisig>;
-  /** Rent sysvar. */
-  rent?: Address<TAccountRent>;
-  m: InitializeMultisigInstructionDataArgs['m'];
-  signers: Array<Address>;
+export type InitializeMultisigInput<TAccountMultisig extends string = string, TAccountRent extends string = string> = {
+    /** The multisignature account to initialize. */
+    multisig: Address<TAccountMultisig>;
+    /** Rent sysvar. */
+    rent?: Address<TAccountRent>;
+    m: InitializeMultisigInstructionDataArgs['m'];
+    signers: Array<Address>;
 };
 
 export function getInitializeMultisigInstruction<
-  TAccountMultisig extends string,
-  TAccountRent extends string,
-  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMultisig extends string,
+    TAccountRent extends string,
+    TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: InitializeMultisigInput<TAccountMultisig, TAccountRent>,
-  config?: { programAddress?: TProgramAddress }
-): InitializeMultisigInstruction<
-  TProgramAddress,
-  TAccountMultisig,
-  TAccountRent
-> {
-  // Program address.
-  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
+    input: InitializeMultisigInput<TAccountMultisig, TAccountRent>,
+    config?: { programAddress?: TProgramAddress }
+): InitializeMultisigInstruction<TProgramAddress, TAccountMultisig, TAccountRent> {
+    // Program address.
+    const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
-  // Original accounts.
-  const originalAccounts = {
-    multisig: { value: input.multisig ?? null, isWritable: true },
-    rent: { value: input.rent ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
+    // Original accounts.
+    const originalAccounts = {
+        multisig: { value: input.multisig ?? null, isWritable: true },
+        rent: { value: input.rent ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
 
-  // Original args.
-  const args = { ...input };
+    // Original args.
+    const args = { ...input };
 
-  // Resolve default values.
-  if (!accounts.rent.value) {
-    accounts.rent.value =
-      'SysvarRent111111111111111111111111111111111' as Address<'SysvarRent111111111111111111111111111111111'>;
-  }
+    // Resolve default values.
+    if (!accounts.rent.value) {
+        accounts.rent.value =
+            'SysvarRent111111111111111111111111111111111' as Address<'SysvarRent111111111111111111111111111111111'>;
+    }
 
-  // Remaining accounts.
-  const remainingAccounts: AccountMeta[] = args.signers.map((address) => ({
-    address,
-    role: AccountRole.READONLY,
-  }));
+    // Remaining accounts.
+    const remainingAccounts: AccountMeta[] = args.signers.map(address => ({ address, role: AccountRole.READONLY }));
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.multisig),
-      getAccountMeta(accounts.rent),
-      ...remainingAccounts,
-    ],
-    data: getInitializeMultisigInstructionDataEncoder().encode(
-      args as InitializeMultisigInstructionDataArgs
-    ),
-    programAddress,
-  } as InitializeMultisigInstruction<
-    TProgramAddress,
-    TAccountMultisig,
-    TAccountRent
-  >);
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [getAccountMeta(accounts.multisig), getAccountMeta(accounts.rent), ...remainingAccounts],
+        data: getInitializeMultisigInstructionDataEncoder().encode(args as InitializeMultisigInstructionDataArgs),
+        programAddress,
+    } as InitializeMultisigInstruction<TProgramAddress, TAccountMultisig, TAccountRent>);
 }
 
 export type ParsedInitializeMultisigInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    /** The multisignature account to initialize. */
-    multisig: TAccountMetas[0];
-    /** Rent sysvar. */
-    rent: TAccountMetas[1];
-  };
-  data: InitializeMultisigInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        /** The multisignature account to initialize. */
+        multisig: TAccountMetas[0];
+        /** Rent sysvar. */
+        rent: TAccountMetas[1];
+    };
+    data: InitializeMultisigInstructionData;
 };
 
 export function parseInitializeMultisigInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
+    TProgram extends string,
+    TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedInitializeMultisigInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 2) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: { multisig: getNextAccount(), rent: getNextAccount() },
-    data: getInitializeMultisigInstructionDataDecoder().decode(
-      instruction.data
-    ),
-  };
+    if (instruction.accounts.length < 2) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { multisig: getNextAccount(), rent: getNextAccount() },
+        data: getInitializeMultisigInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/token/src/generated/instructions/initializeMultisig2.ts
+++ b/test/e2e/token/src/generated/instructions/initializeMultisig2.ts
@@ -7,23 +7,23 @@
  */
 
 import {
-  AccountRole,
-  combineCodec,
-  getStructDecoder,
-  getStructEncoder,
-  getU8Decoder,
-  getU8Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyUint8Array,
-  type WritableAccount,
+    AccountRole,
+    combineCodec,
+    getStructDecoder,
+    getStructEncoder,
+    getU8Decoder,
+    getU8Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyUint8Array,
+    type WritableAccount,
 } from '@solana/kit';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -31,143 +31,122 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const INITIALIZE_MULTISIG2_DISCRIMINATOR = 19;
 
 export function getInitializeMultisig2DiscriminatorBytes() {
-  return getU8Encoder().encode(INITIALIZE_MULTISIG2_DISCRIMINATOR);
+    return getU8Encoder().encode(INITIALIZE_MULTISIG2_DISCRIMINATOR);
 }
 
 export type InitializeMultisig2Instruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMultisig extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMultisig extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountMultisig extends string
-        ? WritableAccount<TAccountMultisig>
-        : TAccountMultisig,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [TAccountMultisig extends string ? WritableAccount<TAccountMultisig> : TAccountMultisig, ...TRemainingAccounts]
+    >;
 
 export type InitializeMultisig2InstructionData = {
-  discriminator: number;
-  /** The number of signers (M) required to validate this multisignature account. */
-  m: number;
+    discriminator: number;
+    /** The number of signers (M) required to validate this multisignature account. */
+    m: number;
 };
 
 export type InitializeMultisig2InstructionDataArgs = {
-  /** The number of signers (M) required to validate this multisignature account. */
-  m: number;
+    /** The number of signers (M) required to validate this multisignature account. */
+    m: number;
 };
 
 export function getInitializeMultisig2InstructionDataEncoder(): FixedSizeEncoder<InitializeMultisig2InstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', getU8Encoder()],
-      ['m', getU8Encoder()],
-    ]),
-    (value) => ({ ...value, discriminator: INITIALIZE_MULTISIG2_DISCRIMINATOR })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', getU8Encoder()],
+            ['m', getU8Encoder()],
+        ]),
+        value => ({ ...value, discriminator: INITIALIZE_MULTISIG2_DISCRIMINATOR })
+    );
 }
 
 export function getInitializeMultisig2InstructionDataDecoder(): FixedSizeDecoder<InitializeMultisig2InstructionData> {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-    ['m', getU8Decoder()],
-  ]);
+    return getStructDecoder([
+        ['discriminator', getU8Decoder()],
+        ['m', getU8Decoder()],
+    ]);
 }
 
 export function getInitializeMultisig2InstructionDataCodec(): FixedSizeCodec<
-  InitializeMultisig2InstructionDataArgs,
-  InitializeMultisig2InstructionData
+    InitializeMultisig2InstructionDataArgs,
+    InitializeMultisig2InstructionData
 > {
-  return combineCodec(
-    getInitializeMultisig2InstructionDataEncoder(),
-    getInitializeMultisig2InstructionDataDecoder()
-  );
+    return combineCodec(getInitializeMultisig2InstructionDataEncoder(), getInitializeMultisig2InstructionDataDecoder());
 }
 
-export type InitializeMultisig2Input<TAccountMultisig extends string = string> =
-  {
+export type InitializeMultisig2Input<TAccountMultisig extends string = string> = {
     /** The multisignature account to initialize. */
     multisig: Address<TAccountMultisig>;
     m: InitializeMultisig2InstructionDataArgs['m'];
     signers: Array<Address>;
-  };
+};
 
 export function getInitializeMultisig2Instruction<
-  TAccountMultisig extends string,
-  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMultisig extends string,
+    TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: InitializeMultisig2Input<TAccountMultisig>,
-  config?: { programAddress?: TProgramAddress }
+    input: InitializeMultisig2Input<TAccountMultisig>,
+    config?: { programAddress?: TProgramAddress }
 ): InitializeMultisig2Instruction<TProgramAddress, TAccountMultisig> {
-  // Program address.
-  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
+    // Program address.
+    const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
-  // Original accounts.
-  const originalAccounts = {
-    multisig: { value: input.multisig ?? null, isWritable: true },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
+    // Original accounts.
+    const originalAccounts = { multisig: { value: input.multisig ?? null, isWritable: true } };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
 
-  // Original args.
-  const args = { ...input };
+    // Original args.
+    const args = { ...input };
 
-  // Remaining accounts.
-  const remainingAccounts: AccountMeta[] = args.signers.map((address) => ({
-    address,
-    role: AccountRole.READONLY,
-  }));
+    // Remaining accounts.
+    const remainingAccounts: AccountMeta[] = args.signers.map(address => ({ address, role: AccountRole.READONLY }));
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [getAccountMeta(accounts.multisig), ...remainingAccounts],
-    data: getInitializeMultisig2InstructionDataEncoder().encode(
-      args as InitializeMultisig2InstructionDataArgs
-    ),
-    programAddress,
-  } as InitializeMultisig2Instruction<TProgramAddress, TAccountMultisig>);
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [getAccountMeta(accounts.multisig), ...remainingAccounts],
+        data: getInitializeMultisig2InstructionDataEncoder().encode(args as InitializeMultisig2InstructionDataArgs),
+        programAddress,
+    } as InitializeMultisig2Instruction<TProgramAddress, TAccountMultisig>);
 }
 
 export type ParsedInitializeMultisig2Instruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    /** The multisignature account to initialize. */
-    multisig: TAccountMetas[0];
-  };
-  data: InitializeMultisig2InstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        /** The multisignature account to initialize. */
+        multisig: TAccountMetas[0];
+    };
+    data: InitializeMultisig2InstructionData;
 };
 
 export function parseInitializeMultisig2Instruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
+    TProgram extends string,
+    TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedInitializeMultisig2Instruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 1) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: { multisig: getNextAccount() },
-    data: getInitializeMultisig2InstructionDataDecoder().decode(
-      instruction.data
-    ),
-  };
+    if (instruction.accounts.length < 1) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { multisig: getNextAccount() },
+        data: getInitializeMultisig2InstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/token/src/generated/instructions/mintTo.ts
+++ b/test/e2e/token/src/generated/instructions/mintTo.ts
@@ -7,29 +7,29 @@
  */
 
 import {
-  AccountRole,
-  combineCodec,
-  getStructDecoder,
-  getStructEncoder,
-  getU64Decoder,
-  getU64Encoder,
-  getU8Decoder,
-  getU8Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyAccount,
-  type ReadonlySignerAccount,
-  type ReadonlyUint8Array,
-  type TransactionSigner,
-  type WritableAccount,
+    AccountRole,
+    combineCodec,
+    getStructDecoder,
+    getStructEncoder,
+    getU64Decoder,
+    getU64Encoder,
+    getU8Decoder,
+    getU8Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyAccount,
+    type ReadonlySignerAccount,
+    type ReadonlyUint8Array,
+    type TransactionSigner,
+    type WritableAccount,
 } from '@solana/kit';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -37,194 +37,164 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const MINT_TO_DISCRIMINATOR = 7;
 
 export function getMintToDiscriminatorBytes() {
-  return getU8Encoder().encode(MINT_TO_DISCRIMINATOR);
+    return getU8Encoder().encode(MINT_TO_DISCRIMINATOR);
 }
 
 export type MintToInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMint extends string | AccountMeta<string> = string,
-  TAccountToken extends string | AccountMeta<string> = string,
-  TAccountMintAuthority extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMint extends string | AccountMeta<string> = string,
+    TAccountToken extends string | AccountMeta<string> = string,
+    TAccountMintAuthority extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountMint extends string
-        ? WritableAccount<TAccountMint>
-        : TAccountMint,
-      TAccountToken extends string
-        ? WritableAccount<TAccountToken>
-        : TAccountToken,
-      TAccountMintAuthority extends string
-        ? ReadonlyAccount<TAccountMintAuthority>
-        : TAccountMintAuthority,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountMint extends string ? WritableAccount<TAccountMint> : TAccountMint,
+            TAccountToken extends string ? WritableAccount<TAccountToken> : TAccountToken,
+            TAccountMintAuthority extends string ? ReadonlyAccount<TAccountMintAuthority> : TAccountMintAuthority,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type MintToInstructionData = {
-  discriminator: number;
-  /** The amount of new tokens to mint. */
-  amount: bigint;
+    discriminator: number;
+    /** The amount of new tokens to mint. */
+    amount: bigint;
 };
 
 export type MintToInstructionDataArgs = {
-  /** The amount of new tokens to mint. */
-  amount: number | bigint;
+    /** The amount of new tokens to mint. */
+    amount: number | bigint;
 };
 
 export function getMintToInstructionDataEncoder(): FixedSizeEncoder<MintToInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', getU8Encoder()],
-      ['amount', getU64Encoder()],
-    ]),
-    (value) => ({ ...value, discriminator: MINT_TO_DISCRIMINATOR })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', getU8Encoder()],
+            ['amount', getU64Encoder()],
+        ]),
+        value => ({ ...value, discriminator: MINT_TO_DISCRIMINATOR })
+    );
 }
 
 export function getMintToInstructionDataDecoder(): FixedSizeDecoder<MintToInstructionData> {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-    ['amount', getU64Decoder()],
-  ]);
+    return getStructDecoder([
+        ['discriminator', getU8Decoder()],
+        ['amount', getU64Decoder()],
+    ]);
 }
 
-export function getMintToInstructionDataCodec(): FixedSizeCodec<
-  MintToInstructionDataArgs,
-  MintToInstructionData
-> {
-  return combineCodec(
-    getMintToInstructionDataEncoder(),
-    getMintToInstructionDataDecoder()
-  );
+export function getMintToInstructionDataCodec(): FixedSizeCodec<MintToInstructionDataArgs, MintToInstructionData> {
+    return combineCodec(getMintToInstructionDataEncoder(), getMintToInstructionDataDecoder());
 }
 
 export type MintToInput<
-  TAccountMint extends string = string,
-  TAccountToken extends string = string,
-  TAccountMintAuthority extends string = string,
+    TAccountMint extends string = string,
+    TAccountToken extends string = string,
+    TAccountMintAuthority extends string = string,
 > = {
-  /** The mint account. */
-  mint: Address<TAccountMint>;
-  /** The account to mint tokens to. */
-  token: Address<TAccountToken>;
-  /** The mint's minting authority or its multisignature account. */
-  mintAuthority:
-    | Address<TAccountMintAuthority>
-    | TransactionSigner<TAccountMintAuthority>;
-  amount: MintToInstructionDataArgs['amount'];
-  multiSigners?: Array<TransactionSigner>;
+    /** The mint account. */
+    mint: Address<TAccountMint>;
+    /** The account to mint tokens to. */
+    token: Address<TAccountToken>;
+    /** The mint's minting authority or its multisignature account. */
+    mintAuthority: Address<TAccountMintAuthority> | TransactionSigner<TAccountMintAuthority>;
+    amount: MintToInstructionDataArgs['amount'];
+    multiSigners?: Array<TransactionSigner>;
 };
 
 export function getMintToInstruction<
-  TAccountMint extends string,
-  TAccountToken extends string,
-  TAccountMintAuthority extends string,
-  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMint extends string,
+    TAccountToken extends string,
+    TAccountMintAuthority extends string,
+    TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: MintToInput<TAccountMint, TAccountToken, TAccountMintAuthority>,
-  config?: { programAddress?: TProgramAddress }
+    input: MintToInput<TAccountMint, TAccountToken, TAccountMintAuthority>,
+    config?: { programAddress?: TProgramAddress }
 ): MintToInstruction<
-  TProgramAddress,
-  TAccountMint,
-  TAccountToken,
-  (typeof input)['mintAuthority'] extends TransactionSigner<TAccountMintAuthority>
-    ? ReadonlySignerAccount<TAccountMintAuthority> &
-        AccountSignerMeta<TAccountMintAuthority>
-    : TAccountMintAuthority
-> {
-  // Program address.
-  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
-
-  // Original accounts.
-  const originalAccounts = {
-    mint: { value: input.mint ?? null, isWritable: true },
-    token: { value: input.token ?? null, isWritable: true },
-    mintAuthority: { value: input.mintAuthority ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
-
-  // Original args.
-  const args = { ...input };
-
-  // Remaining accounts.
-  const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(
-    (signer) => ({
-      address: signer.address,
-      role: AccountRole.READONLY_SIGNER,
-      signer,
-    })
-  );
-
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.mint),
-      getAccountMeta(accounts.token),
-      getAccountMeta(accounts.mintAuthority),
-      ...remainingAccounts,
-    ],
-    data: getMintToInstructionDataEncoder().encode(
-      args as MintToInstructionDataArgs
-    ),
-    programAddress,
-  } as MintToInstruction<
     TProgramAddress,
     TAccountMint,
     TAccountToken,
     (typeof input)['mintAuthority'] extends TransactionSigner<TAccountMintAuthority>
-      ? ReadonlySignerAccount<TAccountMintAuthority> &
-          AccountSignerMeta<TAccountMintAuthority>
-      : TAccountMintAuthority
-  >);
+        ? ReadonlySignerAccount<TAccountMintAuthority> & AccountSignerMeta<TAccountMintAuthority>
+        : TAccountMintAuthority
+> {
+    // Program address.
+    const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
+
+    // Original accounts.
+    const originalAccounts = {
+        mint: { value: input.mint ?? null, isWritable: true },
+        token: { value: input.token ?? null, isWritable: true },
+        mintAuthority: { value: input.mintAuthority ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
+
+    // Original args.
+    const args = { ...input };
+
+    // Remaining accounts.
+    const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(signer => ({
+        address: signer.address,
+        role: AccountRole.READONLY_SIGNER,
+        signer,
+    }));
+
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [
+            getAccountMeta(accounts.mint),
+            getAccountMeta(accounts.token),
+            getAccountMeta(accounts.mintAuthority),
+            ...remainingAccounts,
+        ],
+        data: getMintToInstructionDataEncoder().encode(args as MintToInstructionDataArgs),
+        programAddress,
+    } as MintToInstruction<
+        TProgramAddress,
+        TAccountMint,
+        TAccountToken,
+        (typeof input)['mintAuthority'] extends TransactionSigner<TAccountMintAuthority>
+            ? ReadonlySignerAccount<TAccountMintAuthority> & AccountSignerMeta<TAccountMintAuthority>
+            : TAccountMintAuthority
+    >);
 }
 
 export type ParsedMintToInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    /** The mint account. */
-    mint: TAccountMetas[0];
-    /** The account to mint tokens to. */
-    token: TAccountMetas[1];
-    /** The mint's minting authority or its multisignature account. */
-    mintAuthority: TAccountMetas[2];
-  };
-  data: MintToInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        /** The mint account. */
+        mint: TAccountMetas[0];
+        /** The account to mint tokens to. */
+        token: TAccountMetas[1];
+        /** The mint's minting authority or its multisignature account. */
+        mintAuthority: TAccountMetas[2];
+    };
+    data: MintToInstructionData;
 };
 
-export function parseMintToInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
->(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+export function parseMintToInstruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedMintToInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 3) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: {
-      mint: getNextAccount(),
-      token: getNextAccount(),
-      mintAuthority: getNextAccount(),
-    },
-    data: getMintToInstructionDataDecoder().decode(instruction.data),
-  };
+    if (instruction.accounts.length < 3) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { mint: getNextAccount(), token: getNextAccount(), mintAuthority: getNextAccount() },
+        data: getMintToInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/token/src/generated/instructions/mintToChecked.ts
+++ b/test/e2e/token/src/generated/instructions/mintToChecked.ts
@@ -7,29 +7,29 @@
  */
 
 import {
-  AccountRole,
-  combineCodec,
-  getStructDecoder,
-  getStructEncoder,
-  getU64Decoder,
-  getU64Encoder,
-  getU8Decoder,
-  getU8Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyAccount,
-  type ReadonlySignerAccount,
-  type ReadonlyUint8Array,
-  type TransactionSigner,
-  type WritableAccount,
+    AccountRole,
+    combineCodec,
+    getStructDecoder,
+    getStructEncoder,
+    getU64Decoder,
+    getU64Encoder,
+    getU8Decoder,
+    getU8Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyAccount,
+    type ReadonlySignerAccount,
+    type ReadonlyUint8Array,
+    type TransactionSigner,
+    type WritableAccount,
 } from '@solana/kit';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -37,201 +37,174 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const MINT_TO_CHECKED_DISCRIMINATOR = 14;
 
 export function getMintToCheckedDiscriminatorBytes() {
-  return getU8Encoder().encode(MINT_TO_CHECKED_DISCRIMINATOR);
+    return getU8Encoder().encode(MINT_TO_CHECKED_DISCRIMINATOR);
 }
 
 export type MintToCheckedInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMint extends string | AccountMeta<string> = string,
-  TAccountToken extends string | AccountMeta<string> = string,
-  TAccountMintAuthority extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMint extends string | AccountMeta<string> = string,
+    TAccountToken extends string | AccountMeta<string> = string,
+    TAccountMintAuthority extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountMint extends string
-        ? WritableAccount<TAccountMint>
-        : TAccountMint,
-      TAccountToken extends string
-        ? WritableAccount<TAccountToken>
-        : TAccountToken,
-      TAccountMintAuthority extends string
-        ? ReadonlyAccount<TAccountMintAuthority>
-        : TAccountMintAuthority,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountMint extends string ? WritableAccount<TAccountMint> : TAccountMint,
+            TAccountToken extends string ? WritableAccount<TAccountToken> : TAccountToken,
+            TAccountMintAuthority extends string ? ReadonlyAccount<TAccountMintAuthority> : TAccountMintAuthority,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type MintToCheckedInstructionData = {
-  discriminator: number;
-  /** The amount of new tokens to mint. */
-  amount: bigint;
-  /** Expected number of base 10 digits to the right of the decimal place. */
-  decimals: number;
+    discriminator: number;
+    /** The amount of new tokens to mint. */
+    amount: bigint;
+    /** Expected number of base 10 digits to the right of the decimal place. */
+    decimals: number;
 };
 
 export type MintToCheckedInstructionDataArgs = {
-  /** The amount of new tokens to mint. */
-  amount: number | bigint;
-  /** Expected number of base 10 digits to the right of the decimal place. */
-  decimals: number;
+    /** The amount of new tokens to mint. */
+    amount: number | bigint;
+    /** Expected number of base 10 digits to the right of the decimal place. */
+    decimals: number;
 };
 
 export function getMintToCheckedInstructionDataEncoder(): FixedSizeEncoder<MintToCheckedInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', getU8Encoder()],
-      ['amount', getU64Encoder()],
-      ['decimals', getU8Encoder()],
-    ]),
-    (value) => ({ ...value, discriminator: MINT_TO_CHECKED_DISCRIMINATOR })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', getU8Encoder()],
+            ['amount', getU64Encoder()],
+            ['decimals', getU8Encoder()],
+        ]),
+        value => ({ ...value, discriminator: MINT_TO_CHECKED_DISCRIMINATOR })
+    );
 }
 
 export function getMintToCheckedInstructionDataDecoder(): FixedSizeDecoder<MintToCheckedInstructionData> {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-    ['amount', getU64Decoder()],
-    ['decimals', getU8Decoder()],
-  ]);
+    return getStructDecoder([
+        ['discriminator', getU8Decoder()],
+        ['amount', getU64Decoder()],
+        ['decimals', getU8Decoder()],
+    ]);
 }
 
 export function getMintToCheckedInstructionDataCodec(): FixedSizeCodec<
-  MintToCheckedInstructionDataArgs,
-  MintToCheckedInstructionData
+    MintToCheckedInstructionDataArgs,
+    MintToCheckedInstructionData
 > {
-  return combineCodec(
-    getMintToCheckedInstructionDataEncoder(),
-    getMintToCheckedInstructionDataDecoder()
-  );
+    return combineCodec(getMintToCheckedInstructionDataEncoder(), getMintToCheckedInstructionDataDecoder());
 }
 
 export type MintToCheckedInput<
-  TAccountMint extends string = string,
-  TAccountToken extends string = string,
-  TAccountMintAuthority extends string = string,
+    TAccountMint extends string = string,
+    TAccountToken extends string = string,
+    TAccountMintAuthority extends string = string,
 > = {
-  /** The mint. */
-  mint: Address<TAccountMint>;
-  /** The account to mint tokens to. */
-  token: Address<TAccountToken>;
-  /** The mint's minting authority or its multisignature account. */
-  mintAuthority:
-    | Address<TAccountMintAuthority>
-    | TransactionSigner<TAccountMintAuthority>;
-  amount: MintToCheckedInstructionDataArgs['amount'];
-  decimals: MintToCheckedInstructionDataArgs['decimals'];
-  multiSigners?: Array<TransactionSigner>;
+    /** The mint. */
+    mint: Address<TAccountMint>;
+    /** The account to mint tokens to. */
+    token: Address<TAccountToken>;
+    /** The mint's minting authority or its multisignature account. */
+    mintAuthority: Address<TAccountMintAuthority> | TransactionSigner<TAccountMintAuthority>;
+    amount: MintToCheckedInstructionDataArgs['amount'];
+    decimals: MintToCheckedInstructionDataArgs['decimals'];
+    multiSigners?: Array<TransactionSigner>;
 };
 
 export function getMintToCheckedInstruction<
-  TAccountMint extends string,
-  TAccountToken extends string,
-  TAccountMintAuthority extends string,
-  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMint extends string,
+    TAccountToken extends string,
+    TAccountMintAuthority extends string,
+    TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: MintToCheckedInput<TAccountMint, TAccountToken, TAccountMintAuthority>,
-  config?: { programAddress?: TProgramAddress }
+    input: MintToCheckedInput<TAccountMint, TAccountToken, TAccountMintAuthority>,
+    config?: { programAddress?: TProgramAddress }
 ): MintToCheckedInstruction<
-  TProgramAddress,
-  TAccountMint,
-  TAccountToken,
-  (typeof input)['mintAuthority'] extends TransactionSigner<TAccountMintAuthority>
-    ? ReadonlySignerAccount<TAccountMintAuthority> &
-        AccountSignerMeta<TAccountMintAuthority>
-    : TAccountMintAuthority
-> {
-  // Program address.
-  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
-
-  // Original accounts.
-  const originalAccounts = {
-    mint: { value: input.mint ?? null, isWritable: true },
-    token: { value: input.token ?? null, isWritable: true },
-    mintAuthority: { value: input.mintAuthority ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
-
-  // Original args.
-  const args = { ...input };
-
-  // Remaining accounts.
-  const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(
-    (signer) => ({
-      address: signer.address,
-      role: AccountRole.READONLY_SIGNER,
-      signer,
-    })
-  );
-
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.mint),
-      getAccountMeta(accounts.token),
-      getAccountMeta(accounts.mintAuthority),
-      ...remainingAccounts,
-    ],
-    data: getMintToCheckedInstructionDataEncoder().encode(
-      args as MintToCheckedInstructionDataArgs
-    ),
-    programAddress,
-  } as MintToCheckedInstruction<
     TProgramAddress,
     TAccountMint,
     TAccountToken,
     (typeof input)['mintAuthority'] extends TransactionSigner<TAccountMintAuthority>
-      ? ReadonlySignerAccount<TAccountMintAuthority> &
-          AccountSignerMeta<TAccountMintAuthority>
-      : TAccountMintAuthority
-  >);
+        ? ReadonlySignerAccount<TAccountMintAuthority> & AccountSignerMeta<TAccountMintAuthority>
+        : TAccountMintAuthority
+> {
+    // Program address.
+    const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
+
+    // Original accounts.
+    const originalAccounts = {
+        mint: { value: input.mint ?? null, isWritable: true },
+        token: { value: input.token ?? null, isWritable: true },
+        mintAuthority: { value: input.mintAuthority ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
+
+    // Original args.
+    const args = { ...input };
+
+    // Remaining accounts.
+    const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(signer => ({
+        address: signer.address,
+        role: AccountRole.READONLY_SIGNER,
+        signer,
+    }));
+
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [
+            getAccountMeta(accounts.mint),
+            getAccountMeta(accounts.token),
+            getAccountMeta(accounts.mintAuthority),
+            ...remainingAccounts,
+        ],
+        data: getMintToCheckedInstructionDataEncoder().encode(args as MintToCheckedInstructionDataArgs),
+        programAddress,
+    } as MintToCheckedInstruction<
+        TProgramAddress,
+        TAccountMint,
+        TAccountToken,
+        (typeof input)['mintAuthority'] extends TransactionSigner<TAccountMintAuthority>
+            ? ReadonlySignerAccount<TAccountMintAuthority> & AccountSignerMeta<TAccountMintAuthority>
+            : TAccountMintAuthority
+    >);
 }
 
 export type ParsedMintToCheckedInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    /** The mint. */
-    mint: TAccountMetas[0];
-    /** The account to mint tokens to. */
-    token: TAccountMetas[1];
-    /** The mint's minting authority or its multisignature account. */
-    mintAuthority: TAccountMetas[2];
-  };
-  data: MintToCheckedInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        /** The mint. */
+        mint: TAccountMetas[0];
+        /** The account to mint tokens to. */
+        token: TAccountMetas[1];
+        /** The mint's minting authority or its multisignature account. */
+        mintAuthority: TAccountMetas[2];
+    };
+    data: MintToCheckedInstructionData;
 };
 
-export function parseMintToCheckedInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
->(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+export function parseMintToCheckedInstruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedMintToCheckedInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 3) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: {
-      mint: getNextAccount(),
-      token: getNextAccount(),
-      mintAuthority: getNextAccount(),
-    },
-    data: getMintToCheckedInstructionDataDecoder().decode(instruction.data),
-  };
+    if (instruction.accounts.length < 3) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { mint: getNextAccount(), token: getNextAccount(), mintAuthority: getNextAccount() },
+        data: getMintToCheckedInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/token/src/generated/instructions/recoverNestedAssociatedToken.ts
+++ b/test/e2e/token/src/generated/instructions/recoverNestedAssociatedToken.ts
@@ -7,372 +7,272 @@
  */
 
 import {
-  combineCodec,
-  getStructDecoder,
-  getStructEncoder,
-  getU8Decoder,
-  getU8Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyAccount,
-  type ReadonlyUint8Array,
-  type TransactionSigner,
-  type WritableAccount,
-  type WritableSignerAccount,
+    combineCodec,
+    getStructDecoder,
+    getStructEncoder,
+    getU8Decoder,
+    getU8Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyAccount,
+    type ReadonlyUint8Array,
+    type TransactionSigner,
+    type WritableAccount,
+    type WritableSignerAccount,
 } from '@solana/kit';
 import { findAssociatedTokenPda } from '../pdas';
 import { ASSOCIATED_TOKEN_PROGRAM_ADDRESS } from '../programs';
-import {
-  expectAddress,
-  getAccountMetaFactory,
-  type ResolvedAccount,
-} from '../shared';
+import { expectAddress, getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
 export const RECOVER_NESTED_ASSOCIATED_TOKEN_DISCRIMINATOR = 2;
 
 export function getRecoverNestedAssociatedTokenDiscriminatorBytes() {
-  return getU8Encoder().encode(RECOVER_NESTED_ASSOCIATED_TOKEN_DISCRIMINATOR);
+    return getU8Encoder().encode(RECOVER_NESTED_ASSOCIATED_TOKEN_DISCRIMINATOR);
 }
 
 export type RecoverNestedAssociatedTokenInstruction<
-  TProgram extends string = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
-  TAccountNestedAssociatedAccountAddress extends string | AccountMeta<string> =
-    string,
-  TAccountNestedTokenMintAddress extends string | AccountMeta<string> = string,
-  TAccountDestinationAssociatedAccountAddress extends
-    | string
-    | AccountMeta<string> = string,
-  TAccountOwnerAssociatedAccountAddress extends string | AccountMeta<string> =
-    string,
-  TAccountOwnerTokenMintAddress extends string | AccountMeta<string> = string,
-  TAccountWalletAddress extends string | AccountMeta<string> = string,
-  TAccountTokenProgram extends string | AccountMeta<string> =
-    'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    TAccountNestedAssociatedAccountAddress extends string | AccountMeta<string> = string,
+    TAccountNestedTokenMintAddress extends string | AccountMeta<string> = string,
+    TAccountDestinationAssociatedAccountAddress extends string | AccountMeta<string> = string,
+    TAccountOwnerAssociatedAccountAddress extends string | AccountMeta<string> = string,
+    TAccountOwnerTokenMintAddress extends string | AccountMeta<string> = string,
+    TAccountWalletAddress extends string | AccountMeta<string> = string,
+    TAccountTokenProgram extends string | AccountMeta<string> = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountNestedAssociatedAccountAddress extends string
-        ? WritableAccount<TAccountNestedAssociatedAccountAddress>
-        : TAccountNestedAssociatedAccountAddress,
-      TAccountNestedTokenMintAddress extends string
-        ? ReadonlyAccount<TAccountNestedTokenMintAddress>
-        : TAccountNestedTokenMintAddress,
-      TAccountDestinationAssociatedAccountAddress extends string
-        ? WritableAccount<TAccountDestinationAssociatedAccountAddress>
-        : TAccountDestinationAssociatedAccountAddress,
-      TAccountOwnerAssociatedAccountAddress extends string
-        ? ReadonlyAccount<TAccountOwnerAssociatedAccountAddress>
-        : TAccountOwnerAssociatedAccountAddress,
-      TAccountOwnerTokenMintAddress extends string
-        ? ReadonlyAccount<TAccountOwnerTokenMintAddress>
-        : TAccountOwnerTokenMintAddress,
-      TAccountWalletAddress extends string
-        ? WritableSignerAccount<TAccountWalletAddress> &
-            AccountSignerMeta<TAccountWalletAddress>
-        : TAccountWalletAddress,
-      TAccountTokenProgram extends string
-        ? ReadonlyAccount<TAccountTokenProgram>
-        : TAccountTokenProgram,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountNestedAssociatedAccountAddress extends string
+                ? WritableAccount<TAccountNestedAssociatedAccountAddress>
+                : TAccountNestedAssociatedAccountAddress,
+            TAccountNestedTokenMintAddress extends string
+                ? ReadonlyAccount<TAccountNestedTokenMintAddress>
+                : TAccountNestedTokenMintAddress,
+            TAccountDestinationAssociatedAccountAddress extends string
+                ? WritableAccount<TAccountDestinationAssociatedAccountAddress>
+                : TAccountDestinationAssociatedAccountAddress,
+            TAccountOwnerAssociatedAccountAddress extends string
+                ? ReadonlyAccount<TAccountOwnerAssociatedAccountAddress>
+                : TAccountOwnerAssociatedAccountAddress,
+            TAccountOwnerTokenMintAddress extends string
+                ? ReadonlyAccount<TAccountOwnerTokenMintAddress>
+                : TAccountOwnerTokenMintAddress,
+            TAccountWalletAddress extends string
+                ? WritableSignerAccount<TAccountWalletAddress> & AccountSignerMeta<TAccountWalletAddress>
+                : TAccountWalletAddress,
+            TAccountTokenProgram extends string ? ReadonlyAccount<TAccountTokenProgram> : TAccountTokenProgram,
+            ...TRemainingAccounts,
+        ]
+    >;
 
-export type RecoverNestedAssociatedTokenInstructionData = {
-  discriminator: number;
-};
+export type RecoverNestedAssociatedTokenInstructionData = { discriminator: number };
 
 export type RecoverNestedAssociatedTokenInstructionDataArgs = {};
 
 export function getRecoverNestedAssociatedTokenInstructionDataEncoder(): FixedSizeEncoder<RecoverNestedAssociatedTokenInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([['discriminator', getU8Encoder()]]),
-    (value) => ({
-      ...value,
-      discriminator: RECOVER_NESTED_ASSOCIATED_TOKEN_DISCRIMINATOR,
-    })
-  );
+    return transformEncoder(getStructEncoder([['discriminator', getU8Encoder()]]), value => ({
+        ...value,
+        discriminator: RECOVER_NESTED_ASSOCIATED_TOKEN_DISCRIMINATOR,
+    }));
 }
 
 export function getRecoverNestedAssociatedTokenInstructionDataDecoder(): FixedSizeDecoder<RecoverNestedAssociatedTokenInstructionData> {
-  return getStructDecoder([['discriminator', getU8Decoder()]]);
+    return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getRecoverNestedAssociatedTokenInstructionDataCodec(): FixedSizeCodec<
-  RecoverNestedAssociatedTokenInstructionDataArgs,
-  RecoverNestedAssociatedTokenInstructionData
+    RecoverNestedAssociatedTokenInstructionDataArgs,
+    RecoverNestedAssociatedTokenInstructionData
 > {
-  return combineCodec(
-    getRecoverNestedAssociatedTokenInstructionDataEncoder(),
-    getRecoverNestedAssociatedTokenInstructionDataDecoder()
-  );
+    return combineCodec(
+        getRecoverNestedAssociatedTokenInstructionDataEncoder(),
+        getRecoverNestedAssociatedTokenInstructionDataDecoder()
+    );
 }
 
 export type RecoverNestedAssociatedTokenAsyncInput<
-  TAccountNestedAssociatedAccountAddress extends string = string,
-  TAccountNestedTokenMintAddress extends string = string,
-  TAccountDestinationAssociatedAccountAddress extends string = string,
-  TAccountOwnerAssociatedAccountAddress extends string = string,
-  TAccountOwnerTokenMintAddress extends string = string,
-  TAccountWalletAddress extends string = string,
-  TAccountTokenProgram extends string = string,
+    TAccountNestedAssociatedAccountAddress extends string = string,
+    TAccountNestedTokenMintAddress extends string = string,
+    TAccountDestinationAssociatedAccountAddress extends string = string,
+    TAccountOwnerAssociatedAccountAddress extends string = string,
+    TAccountOwnerTokenMintAddress extends string = string,
+    TAccountWalletAddress extends string = string,
+    TAccountTokenProgram extends string = string,
 > = {
-  /** Nested associated token account, must be owned by `ownerAssociatedAccountAddress`. */
-  nestedAssociatedAccountAddress?: Address<TAccountNestedAssociatedAccountAddress>;
-  /** Token mint for the nested associated token account. */
-  nestedTokenMintAddress: Address<TAccountNestedTokenMintAddress>;
-  /** Wallet's associated token account. */
-  destinationAssociatedAccountAddress?: Address<TAccountDestinationAssociatedAccountAddress>;
-  /** Owner associated token account address, must be owned by `walletAddress`. */
-  ownerAssociatedAccountAddress?: Address<TAccountOwnerAssociatedAccountAddress>;
-  /** Token mint for the owner associated token account. */
-  ownerTokenMintAddress: Address<TAccountOwnerTokenMintAddress>;
-  /** Wallet address for the owner associated token account. */
-  walletAddress: TransactionSigner<TAccountWalletAddress>;
-  /** SPL Token program. */
-  tokenProgram?: Address<TAccountTokenProgram>;
+    /** Nested associated token account, must be owned by `ownerAssociatedAccountAddress`. */
+    nestedAssociatedAccountAddress?: Address<TAccountNestedAssociatedAccountAddress>;
+    /** Token mint for the nested associated token account. */
+    nestedTokenMintAddress: Address<TAccountNestedTokenMintAddress>;
+    /** Wallet's associated token account. */
+    destinationAssociatedAccountAddress?: Address<TAccountDestinationAssociatedAccountAddress>;
+    /** Owner associated token account address, must be owned by `walletAddress`. */
+    ownerAssociatedAccountAddress?: Address<TAccountOwnerAssociatedAccountAddress>;
+    /** Token mint for the owner associated token account. */
+    ownerTokenMintAddress: Address<TAccountOwnerTokenMintAddress>;
+    /** Wallet address for the owner associated token account. */
+    walletAddress: TransactionSigner<TAccountWalletAddress>;
+    /** SPL Token program. */
+    tokenProgram?: Address<TAccountTokenProgram>;
 };
 
 export async function getRecoverNestedAssociatedTokenInstructionAsync<
-  TAccountNestedAssociatedAccountAddress extends string,
-  TAccountNestedTokenMintAddress extends string,
-  TAccountDestinationAssociatedAccountAddress extends string,
-  TAccountOwnerAssociatedAccountAddress extends string,
-  TAccountOwnerTokenMintAddress extends string,
-  TAccountWalletAddress extends string,
-  TAccountTokenProgram extends string,
-  TProgramAddress extends Address = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    TAccountNestedAssociatedAccountAddress extends string,
+    TAccountNestedTokenMintAddress extends string,
+    TAccountDestinationAssociatedAccountAddress extends string,
+    TAccountOwnerAssociatedAccountAddress extends string,
+    TAccountOwnerTokenMintAddress extends string,
+    TAccountWalletAddress extends string,
+    TAccountTokenProgram extends string,
+    TProgramAddress extends Address = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
 >(
-  input: RecoverNestedAssociatedTokenAsyncInput<
-    TAccountNestedAssociatedAccountAddress,
-    TAccountNestedTokenMintAddress,
-    TAccountDestinationAssociatedAccountAddress,
-    TAccountOwnerAssociatedAccountAddress,
-    TAccountOwnerTokenMintAddress,
-    TAccountWalletAddress,
-    TAccountTokenProgram
-  >,
-  config?: { programAddress?: TProgramAddress }
+    input: RecoverNestedAssociatedTokenAsyncInput<
+        TAccountNestedAssociatedAccountAddress,
+        TAccountNestedTokenMintAddress,
+        TAccountDestinationAssociatedAccountAddress,
+        TAccountOwnerAssociatedAccountAddress,
+        TAccountOwnerTokenMintAddress,
+        TAccountWalletAddress,
+        TAccountTokenProgram
+    >,
+    config?: { programAddress?: TProgramAddress }
 ): Promise<
-  RecoverNestedAssociatedTokenInstruction<
-    TProgramAddress,
-    TAccountNestedAssociatedAccountAddress,
-    TAccountNestedTokenMintAddress,
-    TAccountDestinationAssociatedAccountAddress,
-    TAccountOwnerAssociatedAccountAddress,
-    TAccountOwnerTokenMintAddress,
-    TAccountWalletAddress,
-    TAccountTokenProgram
-  >
+    RecoverNestedAssociatedTokenInstruction<
+        TProgramAddress,
+        TAccountNestedAssociatedAccountAddress,
+        TAccountNestedTokenMintAddress,
+        TAccountDestinationAssociatedAccountAddress,
+        TAccountOwnerAssociatedAccountAddress,
+        TAccountOwnerTokenMintAddress,
+        TAccountWalletAddress,
+        TAccountTokenProgram
+    >
 > {
-  // Program address.
-  const programAddress =
-    config?.programAddress ?? ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
+    // Program address.
+    const programAddress = config?.programAddress ?? ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
 
-  // Original accounts.
-  const originalAccounts = {
-    nestedAssociatedAccountAddress: {
-      value: input.nestedAssociatedAccountAddress ?? null,
-      isWritable: true,
-    },
-    nestedTokenMintAddress: {
-      value: input.nestedTokenMintAddress ?? null,
-      isWritable: false,
-    },
-    destinationAssociatedAccountAddress: {
-      value: input.destinationAssociatedAccountAddress ?? null,
-      isWritable: true,
-    },
-    ownerAssociatedAccountAddress: {
-      value: input.ownerAssociatedAccountAddress ?? null,
-      isWritable: false,
-    },
-    ownerTokenMintAddress: {
-      value: input.ownerTokenMintAddress ?? null,
-      isWritable: false,
-    },
-    walletAddress: { value: input.walletAddress ?? null, isWritable: true },
-    tokenProgram: { value: input.tokenProgram ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
+    // Original accounts.
+    const originalAccounts = {
+        nestedAssociatedAccountAddress: { value: input.nestedAssociatedAccountAddress ?? null, isWritable: true },
+        nestedTokenMintAddress: { value: input.nestedTokenMintAddress ?? null, isWritable: false },
+        destinationAssociatedAccountAddress: {
+            value: input.destinationAssociatedAccountAddress ?? null,
+            isWritable: true,
+        },
+        ownerAssociatedAccountAddress: { value: input.ownerAssociatedAccountAddress ?? null, isWritable: false },
+        ownerTokenMintAddress: { value: input.ownerTokenMintAddress ?? null, isWritable: false },
+        walletAddress: { value: input.walletAddress ?? null, isWritable: true },
+        tokenProgram: { value: input.tokenProgram ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
 
-  // Resolve default values.
-  if (!accounts.tokenProgram.value) {
-    accounts.tokenProgram.value =
-      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' as Address<'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'>;
-  }
-  if (!accounts.ownerAssociatedAccountAddress.value) {
-    accounts.ownerAssociatedAccountAddress.value = await findAssociatedTokenPda(
-      {
-        owner: expectAddress(accounts.walletAddress.value),
-        tokenProgram: expectAddress(accounts.tokenProgram.value),
-        mint: expectAddress(accounts.ownerTokenMintAddress.value),
-      }
-    );
-  }
-  if (!accounts.nestedAssociatedAccountAddress.value) {
-    accounts.nestedAssociatedAccountAddress.value =
-      await findAssociatedTokenPda({
-        owner: expectAddress(accounts.ownerAssociatedAccountAddress.value),
-        tokenProgram: expectAddress(accounts.tokenProgram.value),
-        mint: expectAddress(accounts.nestedTokenMintAddress.value),
-      });
-  }
-  if (!accounts.destinationAssociatedAccountAddress.value) {
-    accounts.destinationAssociatedAccountAddress.value =
-      await findAssociatedTokenPda({
-        owner: expectAddress(accounts.walletAddress.value),
-        tokenProgram: expectAddress(accounts.tokenProgram.value),
-        mint: expectAddress(accounts.nestedTokenMintAddress.value),
-      });
-  }
+    // Resolve default values.
+    if (!accounts.tokenProgram.value) {
+        accounts.tokenProgram.value =
+            'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' as Address<'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'>;
+    }
+    if (!accounts.ownerAssociatedAccountAddress.value) {
+        accounts.ownerAssociatedAccountAddress.value = await findAssociatedTokenPda({
+            owner: expectAddress(accounts.walletAddress.value),
+            tokenProgram: expectAddress(accounts.tokenProgram.value),
+            mint: expectAddress(accounts.ownerTokenMintAddress.value),
+        });
+    }
+    if (!accounts.nestedAssociatedAccountAddress.value) {
+        accounts.nestedAssociatedAccountAddress.value = await findAssociatedTokenPda({
+            owner: expectAddress(accounts.ownerAssociatedAccountAddress.value),
+            tokenProgram: expectAddress(accounts.tokenProgram.value),
+            mint: expectAddress(accounts.nestedTokenMintAddress.value),
+        });
+    }
+    if (!accounts.destinationAssociatedAccountAddress.value) {
+        accounts.destinationAssociatedAccountAddress.value = await findAssociatedTokenPda({
+            owner: expectAddress(accounts.walletAddress.value),
+            tokenProgram: expectAddress(accounts.tokenProgram.value),
+            mint: expectAddress(accounts.nestedTokenMintAddress.value),
+        });
+    }
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.nestedAssociatedAccountAddress),
-      getAccountMeta(accounts.nestedTokenMintAddress),
-      getAccountMeta(accounts.destinationAssociatedAccountAddress),
-      getAccountMeta(accounts.ownerAssociatedAccountAddress),
-      getAccountMeta(accounts.ownerTokenMintAddress),
-      getAccountMeta(accounts.walletAddress),
-      getAccountMeta(accounts.tokenProgram),
-    ],
-    data: getRecoverNestedAssociatedTokenInstructionDataEncoder().encode({}),
-    programAddress,
-  } as RecoverNestedAssociatedTokenInstruction<
-    TProgramAddress,
-    TAccountNestedAssociatedAccountAddress,
-    TAccountNestedTokenMintAddress,
-    TAccountDestinationAssociatedAccountAddress,
-    TAccountOwnerAssociatedAccountAddress,
-    TAccountOwnerTokenMintAddress,
-    TAccountWalletAddress,
-    TAccountTokenProgram
-  >);
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [
+            getAccountMeta(accounts.nestedAssociatedAccountAddress),
+            getAccountMeta(accounts.nestedTokenMintAddress),
+            getAccountMeta(accounts.destinationAssociatedAccountAddress),
+            getAccountMeta(accounts.ownerAssociatedAccountAddress),
+            getAccountMeta(accounts.ownerTokenMintAddress),
+            getAccountMeta(accounts.walletAddress),
+            getAccountMeta(accounts.tokenProgram),
+        ],
+        data: getRecoverNestedAssociatedTokenInstructionDataEncoder().encode({}),
+        programAddress,
+    } as RecoverNestedAssociatedTokenInstruction<
+        TProgramAddress,
+        TAccountNestedAssociatedAccountAddress,
+        TAccountNestedTokenMintAddress,
+        TAccountDestinationAssociatedAccountAddress,
+        TAccountOwnerAssociatedAccountAddress,
+        TAccountOwnerTokenMintAddress,
+        TAccountWalletAddress,
+        TAccountTokenProgram
+    >);
 }
 
 export type RecoverNestedAssociatedTokenInput<
-  TAccountNestedAssociatedAccountAddress extends string = string,
-  TAccountNestedTokenMintAddress extends string = string,
-  TAccountDestinationAssociatedAccountAddress extends string = string,
-  TAccountOwnerAssociatedAccountAddress extends string = string,
-  TAccountOwnerTokenMintAddress extends string = string,
-  TAccountWalletAddress extends string = string,
-  TAccountTokenProgram extends string = string,
+    TAccountNestedAssociatedAccountAddress extends string = string,
+    TAccountNestedTokenMintAddress extends string = string,
+    TAccountDestinationAssociatedAccountAddress extends string = string,
+    TAccountOwnerAssociatedAccountAddress extends string = string,
+    TAccountOwnerTokenMintAddress extends string = string,
+    TAccountWalletAddress extends string = string,
+    TAccountTokenProgram extends string = string,
 > = {
-  /** Nested associated token account, must be owned by `ownerAssociatedAccountAddress`. */
-  nestedAssociatedAccountAddress: Address<TAccountNestedAssociatedAccountAddress>;
-  /** Token mint for the nested associated token account. */
-  nestedTokenMintAddress: Address<TAccountNestedTokenMintAddress>;
-  /** Wallet's associated token account. */
-  destinationAssociatedAccountAddress: Address<TAccountDestinationAssociatedAccountAddress>;
-  /** Owner associated token account address, must be owned by `walletAddress`. */
-  ownerAssociatedAccountAddress: Address<TAccountOwnerAssociatedAccountAddress>;
-  /** Token mint for the owner associated token account. */
-  ownerTokenMintAddress: Address<TAccountOwnerTokenMintAddress>;
-  /** Wallet address for the owner associated token account. */
-  walletAddress: TransactionSigner<TAccountWalletAddress>;
-  /** SPL Token program. */
-  tokenProgram?: Address<TAccountTokenProgram>;
+    /** Nested associated token account, must be owned by `ownerAssociatedAccountAddress`. */
+    nestedAssociatedAccountAddress: Address<TAccountNestedAssociatedAccountAddress>;
+    /** Token mint for the nested associated token account. */
+    nestedTokenMintAddress: Address<TAccountNestedTokenMintAddress>;
+    /** Wallet's associated token account. */
+    destinationAssociatedAccountAddress: Address<TAccountDestinationAssociatedAccountAddress>;
+    /** Owner associated token account address, must be owned by `walletAddress`. */
+    ownerAssociatedAccountAddress: Address<TAccountOwnerAssociatedAccountAddress>;
+    /** Token mint for the owner associated token account. */
+    ownerTokenMintAddress: Address<TAccountOwnerTokenMintAddress>;
+    /** Wallet address for the owner associated token account. */
+    walletAddress: TransactionSigner<TAccountWalletAddress>;
+    /** SPL Token program. */
+    tokenProgram?: Address<TAccountTokenProgram>;
 };
 
 export function getRecoverNestedAssociatedTokenInstruction<
-  TAccountNestedAssociatedAccountAddress extends string,
-  TAccountNestedTokenMintAddress extends string,
-  TAccountDestinationAssociatedAccountAddress extends string,
-  TAccountOwnerAssociatedAccountAddress extends string,
-  TAccountOwnerTokenMintAddress extends string,
-  TAccountWalletAddress extends string,
-  TAccountTokenProgram extends string,
-  TProgramAddress extends Address = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    TAccountNestedAssociatedAccountAddress extends string,
+    TAccountNestedTokenMintAddress extends string,
+    TAccountDestinationAssociatedAccountAddress extends string,
+    TAccountOwnerAssociatedAccountAddress extends string,
+    TAccountOwnerTokenMintAddress extends string,
+    TAccountWalletAddress extends string,
+    TAccountTokenProgram extends string,
+    TProgramAddress extends Address = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
 >(
-  input: RecoverNestedAssociatedTokenInput<
-    TAccountNestedAssociatedAccountAddress,
-    TAccountNestedTokenMintAddress,
-    TAccountDestinationAssociatedAccountAddress,
-    TAccountOwnerAssociatedAccountAddress,
-    TAccountOwnerTokenMintAddress,
-    TAccountWalletAddress,
-    TAccountTokenProgram
-  >,
-  config?: { programAddress?: TProgramAddress }
+    input: RecoverNestedAssociatedTokenInput<
+        TAccountNestedAssociatedAccountAddress,
+        TAccountNestedTokenMintAddress,
+        TAccountDestinationAssociatedAccountAddress,
+        TAccountOwnerAssociatedAccountAddress,
+        TAccountOwnerTokenMintAddress,
+        TAccountWalletAddress,
+        TAccountTokenProgram
+    >,
+    config?: { programAddress?: TProgramAddress }
 ): RecoverNestedAssociatedTokenInstruction<
-  TProgramAddress,
-  TAccountNestedAssociatedAccountAddress,
-  TAccountNestedTokenMintAddress,
-  TAccountDestinationAssociatedAccountAddress,
-  TAccountOwnerAssociatedAccountAddress,
-  TAccountOwnerTokenMintAddress,
-  TAccountWalletAddress,
-  TAccountTokenProgram
-> {
-  // Program address.
-  const programAddress =
-    config?.programAddress ?? ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
-
-  // Original accounts.
-  const originalAccounts = {
-    nestedAssociatedAccountAddress: {
-      value: input.nestedAssociatedAccountAddress ?? null,
-      isWritable: true,
-    },
-    nestedTokenMintAddress: {
-      value: input.nestedTokenMintAddress ?? null,
-      isWritable: false,
-    },
-    destinationAssociatedAccountAddress: {
-      value: input.destinationAssociatedAccountAddress ?? null,
-      isWritable: true,
-    },
-    ownerAssociatedAccountAddress: {
-      value: input.ownerAssociatedAccountAddress ?? null,
-      isWritable: false,
-    },
-    ownerTokenMintAddress: {
-      value: input.ownerTokenMintAddress ?? null,
-      isWritable: false,
-    },
-    walletAddress: { value: input.walletAddress ?? null, isWritable: true },
-    tokenProgram: { value: input.tokenProgram ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
-
-  // Resolve default values.
-  if (!accounts.tokenProgram.value) {
-    accounts.tokenProgram.value =
-      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' as Address<'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'>;
-  }
-
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.nestedAssociatedAccountAddress),
-      getAccountMeta(accounts.nestedTokenMintAddress),
-      getAccountMeta(accounts.destinationAssociatedAccountAddress),
-      getAccountMeta(accounts.ownerAssociatedAccountAddress),
-      getAccountMeta(accounts.ownerTokenMintAddress),
-      getAccountMeta(accounts.walletAddress),
-      getAccountMeta(accounts.tokenProgram),
-    ],
-    data: getRecoverNestedAssociatedTokenInstructionDataEncoder().encode({}),
-    programAddress,
-  } as RecoverNestedAssociatedTokenInstruction<
     TProgramAddress,
     TAccountNestedAssociatedAccountAddress,
     TAccountNestedTokenMintAddress,
@@ -381,64 +281,109 @@ export function getRecoverNestedAssociatedTokenInstruction<
     TAccountOwnerTokenMintAddress,
     TAccountWalletAddress,
     TAccountTokenProgram
-  >);
+> {
+    // Program address.
+    const programAddress = config?.programAddress ?? ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
+
+    // Original accounts.
+    const originalAccounts = {
+        nestedAssociatedAccountAddress: { value: input.nestedAssociatedAccountAddress ?? null, isWritable: true },
+        nestedTokenMintAddress: { value: input.nestedTokenMintAddress ?? null, isWritable: false },
+        destinationAssociatedAccountAddress: {
+            value: input.destinationAssociatedAccountAddress ?? null,
+            isWritable: true,
+        },
+        ownerAssociatedAccountAddress: { value: input.ownerAssociatedAccountAddress ?? null, isWritable: false },
+        ownerTokenMintAddress: { value: input.ownerTokenMintAddress ?? null, isWritable: false },
+        walletAddress: { value: input.walletAddress ?? null, isWritable: true },
+        tokenProgram: { value: input.tokenProgram ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
+
+    // Resolve default values.
+    if (!accounts.tokenProgram.value) {
+        accounts.tokenProgram.value =
+            'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' as Address<'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'>;
+    }
+
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [
+            getAccountMeta(accounts.nestedAssociatedAccountAddress),
+            getAccountMeta(accounts.nestedTokenMintAddress),
+            getAccountMeta(accounts.destinationAssociatedAccountAddress),
+            getAccountMeta(accounts.ownerAssociatedAccountAddress),
+            getAccountMeta(accounts.ownerTokenMintAddress),
+            getAccountMeta(accounts.walletAddress),
+            getAccountMeta(accounts.tokenProgram),
+        ],
+        data: getRecoverNestedAssociatedTokenInstructionDataEncoder().encode({}),
+        programAddress,
+    } as RecoverNestedAssociatedTokenInstruction<
+        TProgramAddress,
+        TAccountNestedAssociatedAccountAddress,
+        TAccountNestedTokenMintAddress,
+        TAccountDestinationAssociatedAccountAddress,
+        TAccountOwnerAssociatedAccountAddress,
+        TAccountOwnerTokenMintAddress,
+        TAccountWalletAddress,
+        TAccountTokenProgram
+    >);
 }
 
 export type ParsedRecoverNestedAssociatedTokenInstruction<
-  TProgram extends string = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    /** Nested associated token account, must be owned by `ownerAssociatedAccountAddress`. */
-    nestedAssociatedAccountAddress: TAccountMetas[0];
-    /** Token mint for the nested associated token account. */
-    nestedTokenMintAddress: TAccountMetas[1];
-    /** Wallet's associated token account. */
-    destinationAssociatedAccountAddress: TAccountMetas[2];
-    /** Owner associated token account address, must be owned by `walletAddress`. */
-    ownerAssociatedAccountAddress: TAccountMetas[3];
-    /** Token mint for the owner associated token account. */
-    ownerTokenMintAddress: TAccountMetas[4];
-    /** Wallet address for the owner associated token account. */
-    walletAddress: TAccountMetas[5];
-    /** SPL Token program. */
-    tokenProgram: TAccountMetas[6];
-  };
-  data: RecoverNestedAssociatedTokenInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        /** Nested associated token account, must be owned by `ownerAssociatedAccountAddress`. */
+        nestedAssociatedAccountAddress: TAccountMetas[0];
+        /** Token mint for the nested associated token account. */
+        nestedTokenMintAddress: TAccountMetas[1];
+        /** Wallet's associated token account. */
+        destinationAssociatedAccountAddress: TAccountMetas[2];
+        /** Owner associated token account address, must be owned by `walletAddress`. */
+        ownerAssociatedAccountAddress: TAccountMetas[3];
+        /** Token mint for the owner associated token account. */
+        ownerTokenMintAddress: TAccountMetas[4];
+        /** Wallet address for the owner associated token account. */
+        walletAddress: TAccountMetas[5];
+        /** SPL Token program. */
+        tokenProgram: TAccountMetas[6];
+    };
+    data: RecoverNestedAssociatedTokenInstructionData;
 };
 
 export function parseRecoverNestedAssociatedTokenInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
+    TProgram extends string,
+    TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedRecoverNestedAssociatedTokenInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 7) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: {
-      nestedAssociatedAccountAddress: getNextAccount(),
-      nestedTokenMintAddress: getNextAccount(),
-      destinationAssociatedAccountAddress: getNextAccount(),
-      ownerAssociatedAccountAddress: getNextAccount(),
-      ownerTokenMintAddress: getNextAccount(),
-      walletAddress: getNextAccount(),
-      tokenProgram: getNextAccount(),
-    },
-    data: getRecoverNestedAssociatedTokenInstructionDataDecoder().decode(
-      instruction.data
-    ),
-  };
+    if (instruction.accounts.length < 7) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: {
+            nestedAssociatedAccountAddress: getNextAccount(),
+            nestedTokenMintAddress: getNextAccount(),
+            destinationAssociatedAccountAddress: getNextAccount(),
+            ownerAssociatedAccountAddress: getNextAccount(),
+            ownerTokenMintAddress: getNextAccount(),
+            walletAddress: getNextAccount(),
+            tokenProgram: getNextAccount(),
+        },
+        data: getRecoverNestedAssociatedTokenInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/token/src/generated/instructions/revoke.ts
+++ b/test/e2e/token/src/generated/instructions/revoke.ts
@@ -7,27 +7,27 @@
  */
 
 import {
-  AccountRole,
-  combineCodec,
-  getStructDecoder,
-  getStructEncoder,
-  getU8Decoder,
-  getU8Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyAccount,
-  type ReadonlySignerAccount,
-  type ReadonlyUint8Array,
-  type TransactionSigner,
-  type WritableAccount,
+    AccountRole,
+    combineCodec,
+    getStructDecoder,
+    getStructEncoder,
+    getU8Decoder,
+    getU8Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyAccount,
+    type ReadonlySignerAccount,
+    type ReadonlyUint8Array,
+    type TransactionSigner,
+    type WritableAccount,
 } from '@solana/kit';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -35,156 +35,131 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const REVOKE_DISCRIMINATOR = 5;
 
 export function getRevokeDiscriminatorBytes() {
-  return getU8Encoder().encode(REVOKE_DISCRIMINATOR);
+    return getU8Encoder().encode(REVOKE_DISCRIMINATOR);
 }
 
 export type RevokeInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountSource extends string | AccountMeta<string> = string,
-  TAccountOwner extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountSource extends string | AccountMeta<string> = string,
+    TAccountOwner extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountSource extends string
-        ? WritableAccount<TAccountSource>
-        : TAccountSource,
-      TAccountOwner extends string
-        ? ReadonlyAccount<TAccountOwner>
-        : TAccountOwner,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountSource extends string ? WritableAccount<TAccountSource> : TAccountSource,
+            TAccountOwner extends string ? ReadonlyAccount<TAccountOwner> : TAccountOwner,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type RevokeInstructionData = { discriminator: number };
 
 export type RevokeInstructionDataArgs = {};
 
 export function getRevokeInstructionDataEncoder(): FixedSizeEncoder<RevokeInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([['discriminator', getU8Encoder()]]),
-    (value) => ({ ...value, discriminator: REVOKE_DISCRIMINATOR })
-  );
+    return transformEncoder(getStructEncoder([['discriminator', getU8Encoder()]]), value => ({
+        ...value,
+        discriminator: REVOKE_DISCRIMINATOR,
+    }));
 }
 
 export function getRevokeInstructionDataDecoder(): FixedSizeDecoder<RevokeInstructionData> {
-  return getStructDecoder([['discriminator', getU8Decoder()]]);
+    return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
-export function getRevokeInstructionDataCodec(): FixedSizeCodec<
-  RevokeInstructionDataArgs,
-  RevokeInstructionData
-> {
-  return combineCodec(
-    getRevokeInstructionDataEncoder(),
-    getRevokeInstructionDataDecoder()
-  );
+export function getRevokeInstructionDataCodec(): FixedSizeCodec<RevokeInstructionDataArgs, RevokeInstructionData> {
+    return combineCodec(getRevokeInstructionDataEncoder(), getRevokeInstructionDataDecoder());
 }
 
-export type RevokeInput<
-  TAccountSource extends string = string,
-  TAccountOwner extends string = string,
-> = {
-  /** The source account. */
-  source: Address<TAccountSource>;
-  /** The source account owner or its multisignature. */
-  owner: Address<TAccountOwner> | TransactionSigner<TAccountOwner>;
-  multiSigners?: Array<TransactionSigner>;
+export type RevokeInput<TAccountSource extends string = string, TAccountOwner extends string = string> = {
+    /** The source account. */
+    source: Address<TAccountSource>;
+    /** The source account owner or its multisignature. */
+    owner: Address<TAccountOwner> | TransactionSigner<TAccountOwner>;
+    multiSigners?: Array<TransactionSigner>;
 };
 
 export function getRevokeInstruction<
-  TAccountSource extends string,
-  TAccountOwner extends string,
-  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountSource extends string,
+    TAccountOwner extends string,
+    TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: RevokeInput<TAccountSource, TAccountOwner>,
-  config?: { programAddress?: TProgramAddress }
+    input: RevokeInput<TAccountSource, TAccountOwner>,
+    config?: { programAddress?: TProgramAddress }
 ): RevokeInstruction<
-  TProgramAddress,
-  TAccountSource,
-  (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
-    ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
-    : TAccountOwner
-> {
-  // Program address.
-  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
-
-  // Original accounts.
-  const originalAccounts = {
-    source: { value: input.source ?? null, isWritable: true },
-    owner: { value: input.owner ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
-
-  // Original args.
-  const args = { ...input };
-
-  // Remaining accounts.
-  const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(
-    (signer) => ({
-      address: signer.address,
-      role: AccountRole.READONLY_SIGNER,
-      signer,
-    })
-  );
-
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.source),
-      getAccountMeta(accounts.owner),
-      ...remainingAccounts,
-    ],
-    data: getRevokeInstructionDataEncoder().encode({}),
-    programAddress,
-  } as RevokeInstruction<
     TProgramAddress,
     TAccountSource,
     (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
-      ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
-      : TAccountOwner
-  >);
+        ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
+        : TAccountOwner
+> {
+    // Program address.
+    const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
+
+    // Original accounts.
+    const originalAccounts = {
+        source: { value: input.source ?? null, isWritable: true },
+        owner: { value: input.owner ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
+
+    // Original args.
+    const args = { ...input };
+
+    // Remaining accounts.
+    const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(signer => ({
+        address: signer.address,
+        role: AccountRole.READONLY_SIGNER,
+        signer,
+    }));
+
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [getAccountMeta(accounts.source), getAccountMeta(accounts.owner), ...remainingAccounts],
+        data: getRevokeInstructionDataEncoder().encode({}),
+        programAddress,
+    } as RevokeInstruction<
+        TProgramAddress,
+        TAccountSource,
+        (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
+            ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
+            : TAccountOwner
+    >);
 }
 
 export type ParsedRevokeInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    /** The source account. */
-    source: TAccountMetas[0];
-    /** The source account owner or its multisignature. */
-    owner: TAccountMetas[1];
-  };
-  data: RevokeInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        /** The source account. */
+        source: TAccountMetas[0];
+        /** The source account owner or its multisignature. */
+        owner: TAccountMetas[1];
+    };
+    data: RevokeInstructionData;
 };
 
-export function parseRevokeInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
->(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+export function parseRevokeInstruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedRevokeInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 2) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: { source: getNextAccount(), owner: getNextAccount() },
-    data: getRevokeInstructionDataDecoder().decode(instruction.data),
-  };
+    if (instruction.accounts.length < 2) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { source: getNextAccount(), owner: getNextAccount() },
+        data: getRevokeInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/token/src/generated/instructions/setAuthority.ts
+++ b/test/e2e/token/src/generated/instructions/setAuthority.ts
@@ -7,219 +7,190 @@
  */
 
 import {
-  AccountRole,
-  combineCodec,
-  getAddressDecoder,
-  getAddressEncoder,
-  getOptionDecoder,
-  getOptionEncoder,
-  getStructDecoder,
-  getStructEncoder,
-  getU8Decoder,
-  getU8Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type Codec,
-  type Decoder,
-  type Encoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type Option,
-  type OptionOrNullable,
-  type ReadonlyAccount,
-  type ReadonlySignerAccount,
-  type ReadonlyUint8Array,
-  type TransactionSigner,
-  type WritableAccount,
+    AccountRole,
+    combineCodec,
+    getAddressDecoder,
+    getAddressEncoder,
+    getOptionDecoder,
+    getOptionEncoder,
+    getStructDecoder,
+    getStructEncoder,
+    getU8Decoder,
+    getU8Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type Codec,
+    type Decoder,
+    type Encoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type Option,
+    type OptionOrNullable,
+    type ReadonlyAccount,
+    type ReadonlySignerAccount,
+    type ReadonlyUint8Array,
+    type TransactionSigner,
+    type WritableAccount,
 } from '@solana/kit';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
-import {
-  getAuthorityTypeDecoder,
-  getAuthorityTypeEncoder,
-  type AuthorityType,
-  type AuthorityTypeArgs,
-} from '../types';
+import { getAuthorityTypeDecoder, getAuthorityTypeEncoder, type AuthorityType, type AuthorityTypeArgs } from '../types';
 
 export const SET_AUTHORITY_DISCRIMINATOR = 6;
 
 export function getSetAuthorityDiscriminatorBytes() {
-  return getU8Encoder().encode(SET_AUTHORITY_DISCRIMINATOR);
+    return getU8Encoder().encode(SET_AUTHORITY_DISCRIMINATOR);
 }
 
 export type SetAuthorityInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountOwned extends string | AccountMeta<string> = string,
-  TAccountOwner extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountOwned extends string | AccountMeta<string> = string,
+    TAccountOwner extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountOwned extends string
-        ? WritableAccount<TAccountOwned>
-        : TAccountOwned,
-      TAccountOwner extends string
-        ? ReadonlyAccount<TAccountOwner>
-        : TAccountOwner,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountOwned extends string ? WritableAccount<TAccountOwned> : TAccountOwned,
+            TAccountOwner extends string ? ReadonlyAccount<TAccountOwner> : TAccountOwner,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type SetAuthorityInstructionData = {
-  discriminator: number;
-  /** The type of authority to update. */
-  authorityType: AuthorityType;
-  /** The new authority */
-  newAuthority: Option<Address>;
+    discriminator: number;
+    /** The type of authority to update. */
+    authorityType: AuthorityType;
+    /** The new authority */
+    newAuthority: Option<Address>;
 };
 
 export type SetAuthorityInstructionDataArgs = {
-  /** The type of authority to update. */
-  authorityType: AuthorityTypeArgs;
-  /** The new authority */
-  newAuthority: OptionOrNullable<Address>;
+    /** The type of authority to update. */
+    authorityType: AuthorityTypeArgs;
+    /** The new authority */
+    newAuthority: OptionOrNullable<Address>;
 };
 
 export function getSetAuthorityInstructionDataEncoder(): Encoder<SetAuthorityInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', getU8Encoder()],
-      ['authorityType', getAuthorityTypeEncoder()],
-      ['newAuthority', getOptionEncoder(getAddressEncoder())],
-    ]),
-    (value) => ({ ...value, discriminator: SET_AUTHORITY_DISCRIMINATOR })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', getU8Encoder()],
+            ['authorityType', getAuthorityTypeEncoder()],
+            ['newAuthority', getOptionEncoder(getAddressEncoder())],
+        ]),
+        value => ({ ...value, discriminator: SET_AUTHORITY_DISCRIMINATOR })
+    );
 }
 
 export function getSetAuthorityInstructionDataDecoder(): Decoder<SetAuthorityInstructionData> {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-    ['authorityType', getAuthorityTypeDecoder()],
-    ['newAuthority', getOptionDecoder(getAddressDecoder())],
-  ]);
+    return getStructDecoder([
+        ['discriminator', getU8Decoder()],
+        ['authorityType', getAuthorityTypeDecoder()],
+        ['newAuthority', getOptionDecoder(getAddressDecoder())],
+    ]);
 }
 
 export function getSetAuthorityInstructionDataCodec(): Codec<
-  SetAuthorityInstructionDataArgs,
-  SetAuthorityInstructionData
+    SetAuthorityInstructionDataArgs,
+    SetAuthorityInstructionData
 > {
-  return combineCodec(
-    getSetAuthorityInstructionDataEncoder(),
-    getSetAuthorityInstructionDataDecoder()
-  );
+    return combineCodec(getSetAuthorityInstructionDataEncoder(), getSetAuthorityInstructionDataDecoder());
 }
 
-export type SetAuthorityInput<
-  TAccountOwned extends string = string,
-  TAccountOwner extends string = string,
-> = {
-  /** The mint or account to change the authority of. */
-  owned: Address<TAccountOwned>;
-  /** The current authority or the multisignature account of the mint or account to update. */
-  owner: Address<TAccountOwner> | TransactionSigner<TAccountOwner>;
-  authorityType: SetAuthorityInstructionDataArgs['authorityType'];
-  newAuthority: SetAuthorityInstructionDataArgs['newAuthority'];
-  multiSigners?: Array<TransactionSigner>;
+export type SetAuthorityInput<TAccountOwned extends string = string, TAccountOwner extends string = string> = {
+    /** The mint or account to change the authority of. */
+    owned: Address<TAccountOwned>;
+    /** The current authority or the multisignature account of the mint or account to update. */
+    owner: Address<TAccountOwner> | TransactionSigner<TAccountOwner>;
+    authorityType: SetAuthorityInstructionDataArgs['authorityType'];
+    newAuthority: SetAuthorityInstructionDataArgs['newAuthority'];
+    multiSigners?: Array<TransactionSigner>;
 };
 
 export function getSetAuthorityInstruction<
-  TAccountOwned extends string,
-  TAccountOwner extends string,
-  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountOwned extends string,
+    TAccountOwner extends string,
+    TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: SetAuthorityInput<TAccountOwned, TAccountOwner>,
-  config?: { programAddress?: TProgramAddress }
+    input: SetAuthorityInput<TAccountOwned, TAccountOwner>,
+    config?: { programAddress?: TProgramAddress }
 ): SetAuthorityInstruction<
-  TProgramAddress,
-  TAccountOwned,
-  (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
-    ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
-    : TAccountOwner
-> {
-  // Program address.
-  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
-
-  // Original accounts.
-  const originalAccounts = {
-    owned: { value: input.owned ?? null, isWritable: true },
-    owner: { value: input.owner ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
-
-  // Original args.
-  const args = { ...input };
-
-  // Remaining accounts.
-  const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(
-    (signer) => ({
-      address: signer.address,
-      role: AccountRole.READONLY_SIGNER,
-      signer,
-    })
-  );
-
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.owned),
-      getAccountMeta(accounts.owner),
-      ...remainingAccounts,
-    ],
-    data: getSetAuthorityInstructionDataEncoder().encode(
-      args as SetAuthorityInstructionDataArgs
-    ),
-    programAddress,
-  } as SetAuthorityInstruction<
     TProgramAddress,
     TAccountOwned,
     (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
-      ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
-      : TAccountOwner
-  >);
+        ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
+        : TAccountOwner
+> {
+    // Program address.
+    const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
+
+    // Original accounts.
+    const originalAccounts = {
+        owned: { value: input.owned ?? null, isWritable: true },
+        owner: { value: input.owner ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
+
+    // Original args.
+    const args = { ...input };
+
+    // Remaining accounts.
+    const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(signer => ({
+        address: signer.address,
+        role: AccountRole.READONLY_SIGNER,
+        signer,
+    }));
+
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [getAccountMeta(accounts.owned), getAccountMeta(accounts.owner), ...remainingAccounts],
+        data: getSetAuthorityInstructionDataEncoder().encode(args as SetAuthorityInstructionDataArgs),
+        programAddress,
+    } as SetAuthorityInstruction<
+        TProgramAddress,
+        TAccountOwned,
+        (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
+            ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
+            : TAccountOwner
+    >);
 }
 
 export type ParsedSetAuthorityInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    /** The mint or account to change the authority of. */
-    owned: TAccountMetas[0];
-    /** The current authority or the multisignature account of the mint or account to update. */
-    owner: TAccountMetas[1];
-  };
-  data: SetAuthorityInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        /** The mint or account to change the authority of. */
+        owned: TAccountMetas[0];
+        /** The current authority or the multisignature account of the mint or account to update. */
+        owner: TAccountMetas[1];
+    };
+    data: SetAuthorityInstructionData;
 };
 
-export function parseSetAuthorityInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
->(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+export function parseSetAuthorityInstruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedSetAuthorityInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 2) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: { owned: getNextAccount(), owner: getNextAccount() },
-    data: getSetAuthorityInstructionDataDecoder().decode(instruction.data),
-  };
+    if (instruction.accounts.length < 2) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { owned: getNextAccount(), owner: getNextAccount() },
+        data: getSetAuthorityInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/token/src/generated/instructions/syncNative.ts
+++ b/test/e2e/token/src/generated/instructions/syncNative.ts
@@ -7,22 +7,22 @@
  */
 
 import {
-  combineCodec,
-  getStructDecoder,
-  getStructEncoder,
-  getU8Decoder,
-  getU8Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyUint8Array,
-  type WritableAccount,
+    combineCodec,
+    getStructDecoder,
+    getStructEncoder,
+    getU8Decoder,
+    getU8Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyUint8Array,
+    type WritableAccount,
 } from '@solana/kit';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -30,114 +30,98 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const SYNC_NATIVE_DISCRIMINATOR = 17;
 
 export function getSyncNativeDiscriminatorBytes() {
-  return getU8Encoder().encode(SYNC_NATIVE_DISCRIMINATOR);
+    return getU8Encoder().encode(SYNC_NATIVE_DISCRIMINATOR);
 }
 
 export type SyncNativeInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountAccount extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountAccount extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountAccount extends string
-        ? WritableAccount<TAccountAccount>
-        : TAccountAccount,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [TAccountAccount extends string ? WritableAccount<TAccountAccount> : TAccountAccount, ...TRemainingAccounts]
+    >;
 
 export type SyncNativeInstructionData = { discriminator: number };
 
 export type SyncNativeInstructionDataArgs = {};
 
 export function getSyncNativeInstructionDataEncoder(): FixedSizeEncoder<SyncNativeInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([['discriminator', getU8Encoder()]]),
-    (value) => ({ ...value, discriminator: SYNC_NATIVE_DISCRIMINATOR })
-  );
+    return transformEncoder(getStructEncoder([['discriminator', getU8Encoder()]]), value => ({
+        ...value,
+        discriminator: SYNC_NATIVE_DISCRIMINATOR,
+    }));
 }
 
 export function getSyncNativeInstructionDataDecoder(): FixedSizeDecoder<SyncNativeInstructionData> {
-  return getStructDecoder([['discriminator', getU8Decoder()]]);
+    return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getSyncNativeInstructionDataCodec(): FixedSizeCodec<
-  SyncNativeInstructionDataArgs,
-  SyncNativeInstructionData
+    SyncNativeInstructionDataArgs,
+    SyncNativeInstructionData
 > {
-  return combineCodec(
-    getSyncNativeInstructionDataEncoder(),
-    getSyncNativeInstructionDataDecoder()
-  );
+    return combineCodec(getSyncNativeInstructionDataEncoder(), getSyncNativeInstructionDataDecoder());
 }
 
 export type SyncNativeInput<TAccountAccount extends string = string> = {
-  /** The native token account to sync with its underlying lamports. */
-  account: Address<TAccountAccount>;
+    /** The native token account to sync with its underlying lamports. */
+    account: Address<TAccountAccount>;
 };
 
 export function getSyncNativeInstruction<
-  TAccountAccount extends string,
-  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountAccount extends string,
+    TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: SyncNativeInput<TAccountAccount>,
-  config?: { programAddress?: TProgramAddress }
+    input: SyncNativeInput<TAccountAccount>,
+    config?: { programAddress?: TProgramAddress }
 ): SyncNativeInstruction<TProgramAddress, TAccountAccount> {
-  // Program address.
-  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
+    // Program address.
+    const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
-  // Original accounts.
-  const originalAccounts = {
-    account: { value: input.account ?? null, isWritable: true },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
+    // Original accounts.
+    const originalAccounts = { account: { value: input.account ?? null, isWritable: true } };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [getAccountMeta(accounts.account)],
-    data: getSyncNativeInstructionDataEncoder().encode({}),
-    programAddress,
-  } as SyncNativeInstruction<TProgramAddress, TAccountAccount>);
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [getAccountMeta(accounts.account)],
+        data: getSyncNativeInstructionDataEncoder().encode({}),
+        programAddress,
+    } as SyncNativeInstruction<TProgramAddress, TAccountAccount>);
 }
 
 export type ParsedSyncNativeInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    /** The native token account to sync with its underlying lamports. */
-    account: TAccountMetas[0];
-  };
-  data: SyncNativeInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        /** The native token account to sync with its underlying lamports. */
+        account: TAccountMetas[0];
+    };
+    data: SyncNativeInstructionData;
 };
 
-export function parseSyncNativeInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
->(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+export function parseSyncNativeInstruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedSyncNativeInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 1) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: { account: getNextAccount() },
-    data: getSyncNativeInstructionDataDecoder().decode(instruction.data),
-  };
+    if (instruction.accounts.length < 1) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { account: getNextAccount() },
+        data: getSyncNativeInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/token/src/generated/instructions/thawAccount.ts
+++ b/test/e2e/token/src/generated/instructions/thawAccount.ts
@@ -7,27 +7,27 @@
  */
 
 import {
-  AccountRole,
-  combineCodec,
-  getStructDecoder,
-  getStructEncoder,
-  getU8Decoder,
-  getU8Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyAccount,
-  type ReadonlySignerAccount,
-  type ReadonlyUint8Array,
-  type TransactionSigner,
-  type WritableAccount,
+    AccountRole,
+    combineCodec,
+    getStructDecoder,
+    getStructEncoder,
+    getU8Decoder,
+    getU8Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyAccount,
+    type ReadonlySignerAccount,
+    type ReadonlyUint8Array,
+    type TransactionSigner,
+    type WritableAccount,
 } from '@solana/kit';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -35,174 +35,153 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const THAW_ACCOUNT_DISCRIMINATOR = 11;
 
 export function getThawAccountDiscriminatorBytes() {
-  return getU8Encoder().encode(THAW_ACCOUNT_DISCRIMINATOR);
+    return getU8Encoder().encode(THAW_ACCOUNT_DISCRIMINATOR);
 }
 
 export type ThawAccountInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountAccount extends string | AccountMeta<string> = string,
-  TAccountMint extends string | AccountMeta<string> = string,
-  TAccountOwner extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountAccount extends string | AccountMeta<string> = string,
+    TAccountMint extends string | AccountMeta<string> = string,
+    TAccountOwner extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountAccount extends string
-        ? WritableAccount<TAccountAccount>
-        : TAccountAccount,
-      TAccountMint extends string
-        ? ReadonlyAccount<TAccountMint>
-        : TAccountMint,
-      TAccountOwner extends string
-        ? ReadonlyAccount<TAccountOwner>
-        : TAccountOwner,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountAccount extends string ? WritableAccount<TAccountAccount> : TAccountAccount,
+            TAccountMint extends string ? ReadonlyAccount<TAccountMint> : TAccountMint,
+            TAccountOwner extends string ? ReadonlyAccount<TAccountOwner> : TAccountOwner,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type ThawAccountInstructionData = { discriminator: number };
 
 export type ThawAccountInstructionDataArgs = {};
 
 export function getThawAccountInstructionDataEncoder(): FixedSizeEncoder<ThawAccountInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([['discriminator', getU8Encoder()]]),
-    (value) => ({ ...value, discriminator: THAW_ACCOUNT_DISCRIMINATOR })
-  );
+    return transformEncoder(getStructEncoder([['discriminator', getU8Encoder()]]), value => ({
+        ...value,
+        discriminator: THAW_ACCOUNT_DISCRIMINATOR,
+    }));
 }
 
 export function getThawAccountInstructionDataDecoder(): FixedSizeDecoder<ThawAccountInstructionData> {
-  return getStructDecoder([['discriminator', getU8Decoder()]]);
+    return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getThawAccountInstructionDataCodec(): FixedSizeCodec<
-  ThawAccountInstructionDataArgs,
-  ThawAccountInstructionData
+    ThawAccountInstructionDataArgs,
+    ThawAccountInstructionData
 > {
-  return combineCodec(
-    getThawAccountInstructionDataEncoder(),
-    getThawAccountInstructionDataDecoder()
-  );
+    return combineCodec(getThawAccountInstructionDataEncoder(), getThawAccountInstructionDataDecoder());
 }
 
 export type ThawAccountInput<
-  TAccountAccount extends string = string,
-  TAccountMint extends string = string,
-  TAccountOwner extends string = string,
+    TAccountAccount extends string = string,
+    TAccountMint extends string = string,
+    TAccountOwner extends string = string,
 > = {
-  /** The account to thaw. */
-  account: Address<TAccountAccount>;
-  /** The token mint. */
-  mint: Address<TAccountMint>;
-  /** The mint freeze authority or its multisignature account. */
-  owner: Address<TAccountOwner> | TransactionSigner<TAccountOwner>;
-  multiSigners?: Array<TransactionSigner>;
+    /** The account to thaw. */
+    account: Address<TAccountAccount>;
+    /** The token mint. */
+    mint: Address<TAccountMint>;
+    /** The mint freeze authority or its multisignature account. */
+    owner: Address<TAccountOwner> | TransactionSigner<TAccountOwner>;
+    multiSigners?: Array<TransactionSigner>;
 };
 
 export function getThawAccountInstruction<
-  TAccountAccount extends string,
-  TAccountMint extends string,
-  TAccountOwner extends string,
-  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountAccount extends string,
+    TAccountMint extends string,
+    TAccountOwner extends string,
+    TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: ThawAccountInput<TAccountAccount, TAccountMint, TAccountOwner>,
-  config?: { programAddress?: TProgramAddress }
+    input: ThawAccountInput<TAccountAccount, TAccountMint, TAccountOwner>,
+    config?: { programAddress?: TProgramAddress }
 ): ThawAccountInstruction<
-  TProgramAddress,
-  TAccountAccount,
-  TAccountMint,
-  (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
-    ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
-    : TAccountOwner
-> {
-  // Program address.
-  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
-
-  // Original accounts.
-  const originalAccounts = {
-    account: { value: input.account ?? null, isWritable: true },
-    mint: { value: input.mint ?? null, isWritable: false },
-    owner: { value: input.owner ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
-
-  // Original args.
-  const args = { ...input };
-
-  // Remaining accounts.
-  const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(
-    (signer) => ({
-      address: signer.address,
-      role: AccountRole.READONLY_SIGNER,
-      signer,
-    })
-  );
-
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.account),
-      getAccountMeta(accounts.mint),
-      getAccountMeta(accounts.owner),
-      ...remainingAccounts,
-    ],
-    data: getThawAccountInstructionDataEncoder().encode({}),
-    programAddress,
-  } as ThawAccountInstruction<
     TProgramAddress,
     TAccountAccount,
     TAccountMint,
     (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
-      ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
-      : TAccountOwner
-  >);
+        ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
+        : TAccountOwner
+> {
+    // Program address.
+    const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
+
+    // Original accounts.
+    const originalAccounts = {
+        account: { value: input.account ?? null, isWritable: true },
+        mint: { value: input.mint ?? null, isWritable: false },
+        owner: { value: input.owner ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
+
+    // Original args.
+    const args = { ...input };
+
+    // Remaining accounts.
+    const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(signer => ({
+        address: signer.address,
+        role: AccountRole.READONLY_SIGNER,
+        signer,
+    }));
+
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [
+            getAccountMeta(accounts.account),
+            getAccountMeta(accounts.mint),
+            getAccountMeta(accounts.owner),
+            ...remainingAccounts,
+        ],
+        data: getThawAccountInstructionDataEncoder().encode({}),
+        programAddress,
+    } as ThawAccountInstruction<
+        TProgramAddress,
+        TAccountAccount,
+        TAccountMint,
+        (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
+            ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
+            : TAccountOwner
+    >);
 }
 
 export type ParsedThawAccountInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    /** The account to thaw. */
-    account: TAccountMetas[0];
-    /** The token mint. */
-    mint: TAccountMetas[1];
-    /** The mint freeze authority or its multisignature account. */
-    owner: TAccountMetas[2];
-  };
-  data: ThawAccountInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        /** The account to thaw. */
+        account: TAccountMetas[0];
+        /** The token mint. */
+        mint: TAccountMetas[1];
+        /** The mint freeze authority or its multisignature account. */
+        owner: TAccountMetas[2];
+    };
+    data: ThawAccountInstructionData;
 };
 
-export function parseThawAccountInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
->(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+export function parseThawAccountInstruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedThawAccountInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 3) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: {
-      account: getNextAccount(),
-      mint: getNextAccount(),
-      owner: getNextAccount(),
-    },
-    data: getThawAccountInstructionDataDecoder().decode(instruction.data),
-  };
+    if (instruction.accounts.length < 3) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { account: getNextAccount(), mint: getNextAccount(), owner: getNextAccount() },
+        data: getThawAccountInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/token/src/generated/instructions/transfer.ts
+++ b/test/e2e/token/src/generated/instructions/transfer.ts
@@ -7,29 +7,29 @@
  */
 
 import {
-  AccountRole,
-  combineCodec,
-  getStructDecoder,
-  getStructEncoder,
-  getU64Decoder,
-  getU64Encoder,
-  getU8Decoder,
-  getU8Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyAccount,
-  type ReadonlySignerAccount,
-  type ReadonlyUint8Array,
-  type TransactionSigner,
-  type WritableAccount,
+    AccountRole,
+    combineCodec,
+    getStructDecoder,
+    getStructEncoder,
+    getU64Decoder,
+    getU64Encoder,
+    getU8Decoder,
+    getU8Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyAccount,
+    type ReadonlySignerAccount,
+    type ReadonlyUint8Array,
+    type TransactionSigner,
+    type WritableAccount,
 } from '@solana/kit';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -37,192 +37,167 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const TRANSFER_DISCRIMINATOR = 3;
 
 export function getTransferDiscriminatorBytes() {
-  return getU8Encoder().encode(TRANSFER_DISCRIMINATOR);
+    return getU8Encoder().encode(TRANSFER_DISCRIMINATOR);
 }
 
 export type TransferInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountSource extends string | AccountMeta<string> = string,
-  TAccountDestination extends string | AccountMeta<string> = string,
-  TAccountAuthority extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountSource extends string | AccountMeta<string> = string,
+    TAccountDestination extends string | AccountMeta<string> = string,
+    TAccountAuthority extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountSource extends string
-        ? WritableAccount<TAccountSource>
-        : TAccountSource,
-      TAccountDestination extends string
-        ? WritableAccount<TAccountDestination>
-        : TAccountDestination,
-      TAccountAuthority extends string
-        ? ReadonlyAccount<TAccountAuthority>
-        : TAccountAuthority,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountSource extends string ? WritableAccount<TAccountSource> : TAccountSource,
+            TAccountDestination extends string ? WritableAccount<TAccountDestination> : TAccountDestination,
+            TAccountAuthority extends string ? ReadonlyAccount<TAccountAuthority> : TAccountAuthority,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type TransferInstructionData = {
-  discriminator: number;
-  /** The amount of tokens to transfer. */
-  amount: bigint;
+    discriminator: number;
+    /** The amount of tokens to transfer. */
+    amount: bigint;
 };
 
 export type TransferInstructionDataArgs = {
-  /** The amount of tokens to transfer. */
-  amount: number | bigint;
+    /** The amount of tokens to transfer. */
+    amount: number | bigint;
 };
 
 export function getTransferInstructionDataEncoder(): FixedSizeEncoder<TransferInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', getU8Encoder()],
-      ['amount', getU64Encoder()],
-    ]),
-    (value) => ({ ...value, discriminator: TRANSFER_DISCRIMINATOR })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', getU8Encoder()],
+            ['amount', getU64Encoder()],
+        ]),
+        value => ({ ...value, discriminator: TRANSFER_DISCRIMINATOR })
+    );
 }
 
 export function getTransferInstructionDataDecoder(): FixedSizeDecoder<TransferInstructionData> {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-    ['amount', getU64Decoder()],
-  ]);
+    return getStructDecoder([
+        ['discriminator', getU8Decoder()],
+        ['amount', getU64Decoder()],
+    ]);
 }
 
 export function getTransferInstructionDataCodec(): FixedSizeCodec<
-  TransferInstructionDataArgs,
-  TransferInstructionData
+    TransferInstructionDataArgs,
+    TransferInstructionData
 > {
-  return combineCodec(
-    getTransferInstructionDataEncoder(),
-    getTransferInstructionDataDecoder()
-  );
+    return combineCodec(getTransferInstructionDataEncoder(), getTransferInstructionDataDecoder());
 }
 
 export type TransferInput<
-  TAccountSource extends string = string,
-  TAccountDestination extends string = string,
-  TAccountAuthority extends string = string,
+    TAccountSource extends string = string,
+    TAccountDestination extends string = string,
+    TAccountAuthority extends string = string,
 > = {
-  /** The source account. */
-  source: Address<TAccountSource>;
-  /** The destination account. */
-  destination: Address<TAccountDestination>;
-  /** The source account's owner/delegate or its multisignature account. */
-  authority: Address<TAccountAuthority> | TransactionSigner<TAccountAuthority>;
-  amount: TransferInstructionDataArgs['amount'];
-  multiSigners?: Array<TransactionSigner>;
+    /** The source account. */
+    source: Address<TAccountSource>;
+    /** The destination account. */
+    destination: Address<TAccountDestination>;
+    /** The source account's owner/delegate or its multisignature account. */
+    authority: Address<TAccountAuthority> | TransactionSigner<TAccountAuthority>;
+    amount: TransferInstructionDataArgs['amount'];
+    multiSigners?: Array<TransactionSigner>;
 };
 
 export function getTransferInstruction<
-  TAccountSource extends string,
-  TAccountDestination extends string,
-  TAccountAuthority extends string,
-  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountSource extends string,
+    TAccountDestination extends string,
+    TAccountAuthority extends string,
+    TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: TransferInput<TAccountSource, TAccountDestination, TAccountAuthority>,
-  config?: { programAddress?: TProgramAddress }
+    input: TransferInput<TAccountSource, TAccountDestination, TAccountAuthority>,
+    config?: { programAddress?: TProgramAddress }
 ): TransferInstruction<
-  TProgramAddress,
-  TAccountSource,
-  TAccountDestination,
-  (typeof input)['authority'] extends TransactionSigner<TAccountAuthority>
-    ? ReadonlySignerAccount<TAccountAuthority> &
-        AccountSignerMeta<TAccountAuthority>
-    : TAccountAuthority
-> {
-  // Program address.
-  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
-
-  // Original accounts.
-  const originalAccounts = {
-    source: { value: input.source ?? null, isWritable: true },
-    destination: { value: input.destination ?? null, isWritable: true },
-    authority: { value: input.authority ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
-
-  // Original args.
-  const args = { ...input };
-
-  // Remaining accounts.
-  const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(
-    (signer) => ({
-      address: signer.address,
-      role: AccountRole.READONLY_SIGNER,
-      signer,
-    })
-  );
-
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.source),
-      getAccountMeta(accounts.destination),
-      getAccountMeta(accounts.authority),
-      ...remainingAccounts,
-    ],
-    data: getTransferInstructionDataEncoder().encode(
-      args as TransferInstructionDataArgs
-    ),
-    programAddress,
-  } as TransferInstruction<
     TProgramAddress,
     TAccountSource,
     TAccountDestination,
     (typeof input)['authority'] extends TransactionSigner<TAccountAuthority>
-      ? ReadonlySignerAccount<TAccountAuthority> &
-          AccountSignerMeta<TAccountAuthority>
-      : TAccountAuthority
-  >);
+        ? ReadonlySignerAccount<TAccountAuthority> & AccountSignerMeta<TAccountAuthority>
+        : TAccountAuthority
+> {
+    // Program address.
+    const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
+
+    // Original accounts.
+    const originalAccounts = {
+        source: { value: input.source ?? null, isWritable: true },
+        destination: { value: input.destination ?? null, isWritable: true },
+        authority: { value: input.authority ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
+
+    // Original args.
+    const args = { ...input };
+
+    // Remaining accounts.
+    const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(signer => ({
+        address: signer.address,
+        role: AccountRole.READONLY_SIGNER,
+        signer,
+    }));
+
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [
+            getAccountMeta(accounts.source),
+            getAccountMeta(accounts.destination),
+            getAccountMeta(accounts.authority),
+            ...remainingAccounts,
+        ],
+        data: getTransferInstructionDataEncoder().encode(args as TransferInstructionDataArgs),
+        programAddress,
+    } as TransferInstruction<
+        TProgramAddress,
+        TAccountSource,
+        TAccountDestination,
+        (typeof input)['authority'] extends TransactionSigner<TAccountAuthority>
+            ? ReadonlySignerAccount<TAccountAuthority> & AccountSignerMeta<TAccountAuthority>
+            : TAccountAuthority
+    >);
 }
 
 export type ParsedTransferInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    /** The source account. */
-    source: TAccountMetas[0];
-    /** The destination account. */
-    destination: TAccountMetas[1];
-    /** The source account's owner/delegate or its multisignature account. */
-    authority: TAccountMetas[2];
-  };
-  data: TransferInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        /** The source account. */
+        source: TAccountMetas[0];
+        /** The destination account. */
+        destination: TAccountMetas[1];
+        /** The source account's owner/delegate or its multisignature account. */
+        authority: TAccountMetas[2];
+    };
+    data: TransferInstructionData;
 };
 
-export function parseTransferInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
->(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+export function parseTransferInstruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedTransferInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 3) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: {
-      source: getNextAccount(),
-      destination: getNextAccount(),
-      authority: getNextAccount(),
-    },
-    data: getTransferInstructionDataDecoder().decode(instruction.data),
-  };
+    if (instruction.accounts.length < 3) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { source: getNextAccount(), destination: getNextAccount(), authority: getNextAccount() },
+        data: getTransferInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/token/src/generated/instructions/transferChecked.ts
+++ b/test/e2e/token/src/generated/instructions/transferChecked.ts
@@ -7,29 +7,29 @@
  */
 
 import {
-  AccountRole,
-  combineCodec,
-  getStructDecoder,
-  getStructEncoder,
-  getU64Decoder,
-  getU64Encoder,
-  getU8Decoder,
-  getU8Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyAccount,
-  type ReadonlySignerAccount,
-  type ReadonlyUint8Array,
-  type TransactionSigner,
-  type WritableAccount,
+    AccountRole,
+    combineCodec,
+    getStructDecoder,
+    getStructEncoder,
+    getU64Decoder,
+    getU64Encoder,
+    getU8Decoder,
+    getU8Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyAccount,
+    type ReadonlySignerAccount,
+    type ReadonlyUint8Array,
+    type TransactionSigner,
+    type WritableAccount,
 } from '@solana/kit';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -37,219 +37,191 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const TRANSFER_CHECKED_DISCRIMINATOR = 12;
 
 export function getTransferCheckedDiscriminatorBytes() {
-  return getU8Encoder().encode(TRANSFER_CHECKED_DISCRIMINATOR);
+    return getU8Encoder().encode(TRANSFER_CHECKED_DISCRIMINATOR);
 }
 
 export type TransferCheckedInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountSource extends string | AccountMeta<string> = string,
-  TAccountMint extends string | AccountMeta<string> = string,
-  TAccountDestination extends string | AccountMeta<string> = string,
-  TAccountAuthority extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountSource extends string | AccountMeta<string> = string,
+    TAccountMint extends string | AccountMeta<string> = string,
+    TAccountDestination extends string | AccountMeta<string> = string,
+    TAccountAuthority extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountSource extends string
-        ? WritableAccount<TAccountSource>
-        : TAccountSource,
-      TAccountMint extends string
-        ? ReadonlyAccount<TAccountMint>
-        : TAccountMint,
-      TAccountDestination extends string
-        ? WritableAccount<TAccountDestination>
-        : TAccountDestination,
-      TAccountAuthority extends string
-        ? ReadonlyAccount<TAccountAuthority>
-        : TAccountAuthority,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [
+            TAccountSource extends string ? WritableAccount<TAccountSource> : TAccountSource,
+            TAccountMint extends string ? ReadonlyAccount<TAccountMint> : TAccountMint,
+            TAccountDestination extends string ? WritableAccount<TAccountDestination> : TAccountDestination,
+            TAccountAuthority extends string ? ReadonlyAccount<TAccountAuthority> : TAccountAuthority,
+            ...TRemainingAccounts,
+        ]
+    >;
 
 export type TransferCheckedInstructionData = {
-  discriminator: number;
-  /** The amount of tokens to transfer. */
-  amount: bigint;
-  /** Expected number of base 10 digits to the right of the decimal place. */
-  decimals: number;
+    discriminator: number;
+    /** The amount of tokens to transfer. */
+    amount: bigint;
+    /** Expected number of base 10 digits to the right of the decimal place. */
+    decimals: number;
 };
 
 export type TransferCheckedInstructionDataArgs = {
-  /** The amount of tokens to transfer. */
-  amount: number | bigint;
-  /** Expected number of base 10 digits to the right of the decimal place. */
-  decimals: number;
+    /** The amount of tokens to transfer. */
+    amount: number | bigint;
+    /** Expected number of base 10 digits to the right of the decimal place. */
+    decimals: number;
 };
 
 export function getTransferCheckedInstructionDataEncoder(): FixedSizeEncoder<TransferCheckedInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', getU8Encoder()],
-      ['amount', getU64Encoder()],
-      ['decimals', getU8Encoder()],
-    ]),
-    (value) => ({ ...value, discriminator: TRANSFER_CHECKED_DISCRIMINATOR })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', getU8Encoder()],
+            ['amount', getU64Encoder()],
+            ['decimals', getU8Encoder()],
+        ]),
+        value => ({ ...value, discriminator: TRANSFER_CHECKED_DISCRIMINATOR })
+    );
 }
 
 export function getTransferCheckedInstructionDataDecoder(): FixedSizeDecoder<TransferCheckedInstructionData> {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-    ['amount', getU64Decoder()],
-    ['decimals', getU8Decoder()],
-  ]);
+    return getStructDecoder([
+        ['discriminator', getU8Decoder()],
+        ['amount', getU64Decoder()],
+        ['decimals', getU8Decoder()],
+    ]);
 }
 
 export function getTransferCheckedInstructionDataCodec(): FixedSizeCodec<
-  TransferCheckedInstructionDataArgs,
-  TransferCheckedInstructionData
+    TransferCheckedInstructionDataArgs,
+    TransferCheckedInstructionData
 > {
-  return combineCodec(
-    getTransferCheckedInstructionDataEncoder(),
-    getTransferCheckedInstructionDataDecoder()
-  );
+    return combineCodec(getTransferCheckedInstructionDataEncoder(), getTransferCheckedInstructionDataDecoder());
 }
 
 export type TransferCheckedInput<
-  TAccountSource extends string = string,
-  TAccountMint extends string = string,
-  TAccountDestination extends string = string,
-  TAccountAuthority extends string = string,
+    TAccountSource extends string = string,
+    TAccountMint extends string = string,
+    TAccountDestination extends string = string,
+    TAccountAuthority extends string = string,
 > = {
-  /** The source account. */
-  source: Address<TAccountSource>;
-  /** The token mint. */
-  mint: Address<TAccountMint>;
-  /** The destination account. */
-  destination: Address<TAccountDestination>;
-  /** The source account's owner/delegate or its multisignature account. */
-  authority: Address<TAccountAuthority> | TransactionSigner<TAccountAuthority>;
-  amount: TransferCheckedInstructionDataArgs['amount'];
-  decimals: TransferCheckedInstructionDataArgs['decimals'];
-  multiSigners?: Array<TransactionSigner>;
+    /** The source account. */
+    source: Address<TAccountSource>;
+    /** The token mint. */
+    mint: Address<TAccountMint>;
+    /** The destination account. */
+    destination: Address<TAccountDestination>;
+    /** The source account's owner/delegate or its multisignature account. */
+    authority: Address<TAccountAuthority> | TransactionSigner<TAccountAuthority>;
+    amount: TransferCheckedInstructionDataArgs['amount'];
+    decimals: TransferCheckedInstructionDataArgs['decimals'];
+    multiSigners?: Array<TransactionSigner>;
 };
 
 export function getTransferCheckedInstruction<
-  TAccountSource extends string,
-  TAccountMint extends string,
-  TAccountDestination extends string,
-  TAccountAuthority extends string,
-  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountSource extends string,
+    TAccountMint extends string,
+    TAccountDestination extends string,
+    TAccountAuthority extends string,
+    TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: TransferCheckedInput<
-    TAccountSource,
-    TAccountMint,
-    TAccountDestination,
-    TAccountAuthority
-  >,
-  config?: { programAddress?: TProgramAddress }
+    input: TransferCheckedInput<TAccountSource, TAccountMint, TAccountDestination, TAccountAuthority>,
+    config?: { programAddress?: TProgramAddress }
 ): TransferCheckedInstruction<
-  TProgramAddress,
-  TAccountSource,
-  TAccountMint,
-  TAccountDestination,
-  (typeof input)['authority'] extends TransactionSigner<TAccountAuthority>
-    ? ReadonlySignerAccount<TAccountAuthority> &
-        AccountSignerMeta<TAccountAuthority>
-    : TAccountAuthority
-> {
-  // Program address.
-  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
-
-  // Original accounts.
-  const originalAccounts = {
-    source: { value: input.source ?? null, isWritable: true },
-    mint: { value: input.mint ?? null, isWritable: false },
-    destination: { value: input.destination ?? null, isWritable: true },
-    authority: { value: input.authority ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
-
-  // Original args.
-  const args = { ...input };
-
-  // Remaining accounts.
-  const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(
-    (signer) => ({
-      address: signer.address,
-      role: AccountRole.READONLY_SIGNER,
-      signer,
-    })
-  );
-
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [
-      getAccountMeta(accounts.source),
-      getAccountMeta(accounts.mint),
-      getAccountMeta(accounts.destination),
-      getAccountMeta(accounts.authority),
-      ...remainingAccounts,
-    ],
-    data: getTransferCheckedInstructionDataEncoder().encode(
-      args as TransferCheckedInstructionDataArgs
-    ),
-    programAddress,
-  } as TransferCheckedInstruction<
     TProgramAddress,
     TAccountSource,
     TAccountMint,
     TAccountDestination,
     (typeof input)['authority'] extends TransactionSigner<TAccountAuthority>
-      ? ReadonlySignerAccount<TAccountAuthority> &
-          AccountSignerMeta<TAccountAuthority>
-      : TAccountAuthority
-  >);
+        ? ReadonlySignerAccount<TAccountAuthority> & AccountSignerMeta<TAccountAuthority>
+        : TAccountAuthority
+> {
+    // Program address.
+    const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
+
+    // Original accounts.
+    const originalAccounts = {
+        source: { value: input.source ?? null, isWritable: true },
+        mint: { value: input.mint ?? null, isWritable: false },
+        destination: { value: input.destination ?? null, isWritable: true },
+        authority: { value: input.authority ?? null, isWritable: false },
+    };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
+
+    // Original args.
+    const args = { ...input };
+
+    // Remaining accounts.
+    const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(signer => ({
+        address: signer.address,
+        role: AccountRole.READONLY_SIGNER,
+        signer,
+    }));
+
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [
+            getAccountMeta(accounts.source),
+            getAccountMeta(accounts.mint),
+            getAccountMeta(accounts.destination),
+            getAccountMeta(accounts.authority),
+            ...remainingAccounts,
+        ],
+        data: getTransferCheckedInstructionDataEncoder().encode(args as TransferCheckedInstructionDataArgs),
+        programAddress,
+    } as TransferCheckedInstruction<
+        TProgramAddress,
+        TAccountSource,
+        TAccountMint,
+        TAccountDestination,
+        (typeof input)['authority'] extends TransactionSigner<TAccountAuthority>
+            ? ReadonlySignerAccount<TAccountAuthority> & AccountSignerMeta<TAccountAuthority>
+            : TAccountAuthority
+    >);
 }
 
 export type ParsedTransferCheckedInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    /** The source account. */
-    source: TAccountMetas[0];
-    /** The token mint. */
-    mint: TAccountMetas[1];
-    /** The destination account. */
-    destination: TAccountMetas[2];
-    /** The source account's owner/delegate or its multisignature account. */
-    authority: TAccountMetas[3];
-  };
-  data: TransferCheckedInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        /** The source account. */
+        source: TAccountMetas[0];
+        /** The token mint. */
+        mint: TAccountMetas[1];
+        /** The destination account. */
+        destination: TAccountMetas[2];
+        /** The source account's owner/delegate or its multisignature account. */
+        authority: TAccountMetas[3];
+    };
+    data: TransferCheckedInstructionData;
 };
 
-export function parseTransferCheckedInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
->(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+export function parseTransferCheckedInstruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedTransferCheckedInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 4) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: {
-      source: getNextAccount(),
-      mint: getNextAccount(),
-      destination: getNextAccount(),
-      authority: getNextAccount(),
-    },
-    data: getTransferCheckedInstructionDataDecoder().decode(instruction.data),
-  };
+    if (instruction.accounts.length < 4) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: {
+            source: getNextAccount(),
+            mint: getNextAccount(),
+            destination: getNextAccount(),
+            authority: getNextAccount(),
+        },
+        data: getTransferCheckedInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/token/src/generated/instructions/uiAmountToAmount.ts
+++ b/test/e2e/token/src/generated/instructions/uiAmountToAmount.ts
@@ -7,24 +7,24 @@
  */
 
 import {
-  combineCodec,
-  getStructDecoder,
-  getStructEncoder,
-  getU8Decoder,
-  getU8Encoder,
-  getUtf8Decoder,
-  getUtf8Encoder,
-  transformEncoder,
-  type AccountMeta,
-  type Address,
-  type Codec,
-  type Decoder,
-  type Encoder,
-  type Instruction,
-  type InstructionWithAccounts,
-  type InstructionWithData,
-  type ReadonlyAccount,
-  type ReadonlyUint8Array,
+    combineCodec,
+    getStructDecoder,
+    getStructEncoder,
+    getU8Decoder,
+    getU8Encoder,
+    getUtf8Decoder,
+    getUtf8Encoder,
+    transformEncoder,
+    type AccountMeta,
+    type Address,
+    type Codec,
+    type Decoder,
+    type Encoder,
+    type Instruction,
+    type InstructionWithAccounts,
+    type InstructionWithData,
+    type ReadonlyAccount,
+    type ReadonlyUint8Array,
 } from '@solana/kit';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -32,133 +32,115 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const UI_AMOUNT_TO_AMOUNT_DISCRIMINATOR = 24;
 
 export function getUiAmountToAmountDiscriminatorBytes() {
-  return getU8Encoder().encode(UI_AMOUNT_TO_AMOUNT_DISCRIMINATOR);
+    return getU8Encoder().encode(UI_AMOUNT_TO_AMOUNT_DISCRIMINATOR);
 }
 
 export type UiAmountToAmountInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMint extends string | AccountMeta<string> = string,
-  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMint extends string | AccountMeta<string> = string,
+    TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
-  InstructionWithData<ReadonlyUint8Array> &
-  InstructionWithAccounts<
-    [
-      TAccountMint extends string
-        ? ReadonlyAccount<TAccountMint>
-        : TAccountMint,
-      ...TRemainingAccounts,
-    ]
-  >;
+    InstructionWithData<ReadonlyUint8Array> &
+    InstructionWithAccounts<
+        [TAccountMint extends string ? ReadonlyAccount<TAccountMint> : TAccountMint, ...TRemainingAccounts]
+    >;
 
 export type UiAmountToAmountInstructionData = {
-  discriminator: number;
-  /** The ui_amount of tokens to reformat. */
-  uiAmount: string;
+    discriminator: number;
+    /** The ui_amount of tokens to reformat. */
+    uiAmount: string;
 };
 
 export type UiAmountToAmountInstructionDataArgs = {
-  /** The ui_amount of tokens to reformat. */
-  uiAmount: string;
+    /** The ui_amount of tokens to reformat. */
+    uiAmount: string;
 };
 
 export function getUiAmountToAmountInstructionDataEncoder(): Encoder<UiAmountToAmountInstructionDataArgs> {
-  return transformEncoder(
-    getStructEncoder([
-      ['discriminator', getU8Encoder()],
-      ['uiAmount', getUtf8Encoder()],
-    ]),
-    (value) => ({ ...value, discriminator: UI_AMOUNT_TO_AMOUNT_DISCRIMINATOR })
-  );
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', getU8Encoder()],
+            ['uiAmount', getUtf8Encoder()],
+        ]),
+        value => ({ ...value, discriminator: UI_AMOUNT_TO_AMOUNT_DISCRIMINATOR })
+    );
 }
 
 export function getUiAmountToAmountInstructionDataDecoder(): Decoder<UiAmountToAmountInstructionData> {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-    ['uiAmount', getUtf8Decoder()],
-  ]);
+    return getStructDecoder([
+        ['discriminator', getU8Decoder()],
+        ['uiAmount', getUtf8Decoder()],
+    ]);
 }
 
 export function getUiAmountToAmountInstructionDataCodec(): Codec<
-  UiAmountToAmountInstructionDataArgs,
-  UiAmountToAmountInstructionData
+    UiAmountToAmountInstructionDataArgs,
+    UiAmountToAmountInstructionData
 > {
-  return combineCodec(
-    getUiAmountToAmountInstructionDataEncoder(),
-    getUiAmountToAmountInstructionDataDecoder()
-  );
+    return combineCodec(getUiAmountToAmountInstructionDataEncoder(), getUiAmountToAmountInstructionDataDecoder());
 }
 
 export type UiAmountToAmountInput<TAccountMint extends string = string> = {
-  /** The mint to calculate for. */
-  mint: Address<TAccountMint>;
-  uiAmount: UiAmountToAmountInstructionDataArgs['uiAmount'];
+    /** The mint to calculate for. */
+    mint: Address<TAccountMint>;
+    uiAmount: UiAmountToAmountInstructionDataArgs['uiAmount'];
 };
 
 export function getUiAmountToAmountInstruction<
-  TAccountMint extends string,
-  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMint extends string,
+    TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: UiAmountToAmountInput<TAccountMint>,
-  config?: { programAddress?: TProgramAddress }
+    input: UiAmountToAmountInput<TAccountMint>,
+    config?: { programAddress?: TProgramAddress }
 ): UiAmountToAmountInstruction<TProgramAddress, TAccountMint> {
-  // Program address.
-  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
+    // Program address.
+    const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
-  // Original accounts.
-  const originalAccounts = {
-    mint: { value: input.mint ?? null, isWritable: false },
-  };
-  const accounts = originalAccounts as Record<
-    keyof typeof originalAccounts,
-    ResolvedAccount
-  >;
+    // Original accounts.
+    const originalAccounts = { mint: { value: input.mint ?? null, isWritable: false } };
+    const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedAccount>;
 
-  // Original args.
-  const args = { ...input };
+    // Original args.
+    const args = { ...input };
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-  return Object.freeze({
-    accounts: [getAccountMeta(accounts.mint)],
-    data: getUiAmountToAmountInstructionDataEncoder().encode(
-      args as UiAmountToAmountInstructionDataArgs
-    ),
-    programAddress,
-  } as UiAmountToAmountInstruction<TProgramAddress, TAccountMint>);
+    const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+    return Object.freeze({
+        accounts: [getAccountMeta(accounts.mint)],
+        data: getUiAmountToAmountInstructionDataEncoder().encode(args as UiAmountToAmountInstructionDataArgs),
+        programAddress,
+    } as UiAmountToAmountInstruction<TProgramAddress, TAccountMint>);
 }
 
 export type ParsedUiAmountToAmountInstruction<
-  TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+    TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
-  programAddress: Address<TProgram>;
-  accounts: {
-    /** The mint to calculate for. */
-    mint: TAccountMetas[0];
-  };
-  data: UiAmountToAmountInstructionData;
+    programAddress: Address<TProgram>;
+    accounts: {
+        /** The mint to calculate for. */
+        mint: TAccountMetas[0];
+    };
+    data: UiAmountToAmountInstructionData;
 };
 
-export function parseUiAmountToAmountInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly AccountMeta[],
->(
-  instruction: Instruction<TProgram> &
-    InstructionWithAccounts<TAccountMetas> &
-    InstructionWithData<ReadonlyUint8Array>
+export function parseUiAmountToAmountInstruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(
+    instruction: Instruction<TProgram> &
+        InstructionWithAccounts<TAccountMetas> &
+        InstructionWithData<ReadonlyUint8Array>
 ): ParsedUiAmountToAmountInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 1) {
-    // TODO: Coded error.
-    throw new Error('Not enough accounts');
-  }
-  let accountIndex = 0;
-  const getNextAccount = () => {
-    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-    accountIndex += 1;
-    return accountMeta;
-  };
-  return {
-    programAddress: instruction.programAddress,
-    accounts: { mint: getNextAccount() },
-    data: getUiAmountToAmountInstructionDataDecoder().decode(instruction.data),
-  };
+    if (instruction.accounts.length < 1) {
+        // TODO: Coded error.
+        throw new Error('Not enough accounts');
+    }
+    let accountIndex = 0;
+    const getNextAccount = () => {
+        const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+        accountIndex += 1;
+        return accountMeta;
+    };
+    return {
+        programAddress: instruction.programAddress,
+        accounts: { mint: getNextAccount() },
+        data: getUiAmountToAmountInstructionDataDecoder().decode(instruction.data),
+    };
 }

--- a/test/e2e/token/src/generated/pdas/associatedToken.ts
+++ b/test/e2e/token/src/generated/pdas/associatedToken.ts
@@ -6,36 +6,31 @@
  * @see https://github.com/codama-idl/codama
  */
 
-import {
-  getAddressEncoder,
-  getProgramDerivedAddress,
-  type Address,
-  type ProgramDerivedAddress,
-} from '@solana/kit';
+import { getAddressEncoder, getProgramDerivedAddress, type Address, type ProgramDerivedAddress } from '@solana/kit';
 
 export type AssociatedTokenSeeds = {
-  /** The wallet address of the associated token account. */
-  owner: Address;
-  /** The address of the token program to use. */
-  tokenProgram: Address;
-  /** The mint address of the associated token account. */
-  mint: Address;
+    /** The wallet address of the associated token account. */
+    owner: Address;
+    /** The address of the token program to use. */
+    tokenProgram: Address;
+    /** The mint address of the associated token account. */
+    mint: Address;
 };
 
 /** The address of the associated token account. */
 export async function findAssociatedTokenPda(
-  seeds: AssociatedTokenSeeds,
-  config: { programAddress?: Address | undefined } = {}
+    seeds: AssociatedTokenSeeds,
+    config: { programAddress?: Address | undefined } = {}
 ): Promise<ProgramDerivedAddress> {
-  const {
-    programAddress = 'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL' as Address<'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL'>,
-  } = config;
-  return await getProgramDerivedAddress({
-    programAddress,
-    seeds: [
-      getAddressEncoder().encode(seeds.owner),
-      getAddressEncoder().encode(seeds.tokenProgram),
-      getAddressEncoder().encode(seeds.mint),
-    ],
-  });
+    const {
+        programAddress = 'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL' as Address<'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL'>,
+    } = config;
+    return await getProgramDerivedAddress({
+        programAddress,
+        seeds: [
+            getAddressEncoder().encode(seeds.owner),
+            getAddressEncoder().encode(seeds.tokenProgram),
+            getAddressEncoder().encode(seeds.mint),
+        ],
+    });
 }

--- a/test/e2e/token/src/generated/programs/associatedToken.ts
+++ b/test/e2e/token/src/generated/programs/associatedToken.ts
@@ -6,54 +6,45 @@
  * @see https://github.com/codama-idl/codama
  */
 
+import { containsBytes, getU8Encoder, type Address, type ReadonlyUint8Array } from '@solana/kit';
 import {
-  containsBytes,
-  getU8Encoder,
-  type Address,
-  type ReadonlyUint8Array,
-} from '@solana/kit';
-import {
-  type ParsedCreateAssociatedTokenIdempotentInstruction,
-  type ParsedCreateAssociatedTokenInstruction,
-  type ParsedRecoverNestedAssociatedTokenInstruction,
+    type ParsedCreateAssociatedTokenIdempotentInstruction,
+    type ParsedCreateAssociatedTokenInstruction,
+    type ParsedRecoverNestedAssociatedTokenInstruction,
 } from '../instructions';
 
 export const ASSOCIATED_TOKEN_PROGRAM_ADDRESS =
-  'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL' as Address<'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL'>;
+    'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL' as Address<'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL'>;
 
 export enum AssociatedTokenInstruction {
-  CreateAssociatedToken,
-  CreateAssociatedTokenIdempotent,
-  RecoverNestedAssociatedToken,
+    CreateAssociatedToken,
+    CreateAssociatedTokenIdempotent,
+    RecoverNestedAssociatedToken,
 }
 
 export function identifyAssociatedTokenInstruction(
-  instruction: { data: ReadonlyUint8Array } | ReadonlyUint8Array
+    instruction: { data: ReadonlyUint8Array } | ReadonlyUint8Array
 ): AssociatedTokenInstruction {
-  const data = 'data' in instruction ? instruction.data : instruction;
-  if (containsBytes(data, getU8Encoder().encode(0), 0)) {
-    return AssociatedTokenInstruction.CreateAssociatedToken;
-  }
-  if (containsBytes(data, getU8Encoder().encode(1), 0)) {
-    return AssociatedTokenInstruction.CreateAssociatedTokenIdempotent;
-  }
-  if (containsBytes(data, getU8Encoder().encode(2), 0)) {
-    return AssociatedTokenInstruction.RecoverNestedAssociatedToken;
-  }
-  throw new Error(
-    'The provided instruction could not be identified as a associatedToken instruction.'
-  );
+    const data = 'data' in instruction ? instruction.data : instruction;
+    if (containsBytes(data, getU8Encoder().encode(0), 0)) {
+        return AssociatedTokenInstruction.CreateAssociatedToken;
+    }
+    if (containsBytes(data, getU8Encoder().encode(1), 0)) {
+        return AssociatedTokenInstruction.CreateAssociatedTokenIdempotent;
+    }
+    if (containsBytes(data, getU8Encoder().encode(2), 0)) {
+        return AssociatedTokenInstruction.RecoverNestedAssociatedToken;
+    }
+    throw new Error('The provided instruction could not be identified as a associatedToken instruction.');
 }
 
-export type ParsedAssociatedTokenInstruction<
-  TProgram extends string = 'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL',
-> =
-  | ({
-      instructionType: AssociatedTokenInstruction.CreateAssociatedToken;
-    } & ParsedCreateAssociatedTokenInstruction<TProgram>)
-  | ({
-      instructionType: AssociatedTokenInstruction.CreateAssociatedTokenIdempotent;
-    } & ParsedCreateAssociatedTokenIdempotentInstruction<TProgram>)
-  | ({
-      instructionType: AssociatedTokenInstruction.RecoverNestedAssociatedToken;
-    } & ParsedRecoverNestedAssociatedTokenInstruction<TProgram>);
+export type ParsedAssociatedTokenInstruction<TProgram extends string = 'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL'> =
+    | ({
+          instructionType: AssociatedTokenInstruction.CreateAssociatedToken;
+      } & ParsedCreateAssociatedTokenInstruction<TProgram>)
+    | ({
+          instructionType: AssociatedTokenInstruction.CreateAssociatedTokenIdempotent;
+      } & ParsedCreateAssociatedTokenIdempotentInstruction<TProgram>)
+    | ({
+          instructionType: AssociatedTokenInstruction.RecoverNestedAssociatedToken;
+      } & ParsedRecoverNestedAssociatedTokenInstruction<TProgram>);

--- a/test/e2e/token/src/generated/programs/system.ts
+++ b/test/e2e/token/src/generated/programs/system.ts
@@ -6,35 +6,25 @@
  * @see https://github.com/codama-idl/codama
  */
 
-import {
-  containsBytes,
-  getU32Encoder,
-  type Address,
-  type ReadonlyUint8Array,
-} from '@solana/kit';
+import { containsBytes, getU32Encoder, type Address, type ReadonlyUint8Array } from '@solana/kit';
 import { type ParsedCreateAccountInstruction } from '../instructions';
 
-export const SYSTEM_PROGRAM_ADDRESS =
-  '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
+export const SYSTEM_PROGRAM_ADDRESS = '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
 
 export enum SystemInstruction {
-  CreateAccount,
+    CreateAccount,
 }
 
 export function identifySystemInstruction(
-  instruction: { data: ReadonlyUint8Array } | ReadonlyUint8Array
+    instruction: { data: ReadonlyUint8Array } | ReadonlyUint8Array
 ): SystemInstruction {
-  const data = 'data' in instruction ? instruction.data : instruction;
-  if (containsBytes(data, getU32Encoder().encode(0), 0)) {
-    return SystemInstruction.CreateAccount;
-  }
-  throw new Error(
-    'The provided instruction could not be identified as a system instruction.'
-  );
+    const data = 'data' in instruction ? instruction.data : instruction;
+    if (containsBytes(data, getU32Encoder().encode(0), 0)) {
+        return SystemInstruction.CreateAccount;
+    }
+    throw new Error('The provided instruction could not be identified as a system instruction.');
 }
 
-export type ParsedSystemInstruction<
-  TProgram extends string = '11111111111111111111111111111111',
-> = {
-  instructionType: SystemInstruction.CreateAccount;
+export type ParsedSystemInstruction<TProgram extends string = '11111111111111111111111111111111'> = {
+    instructionType: SystemInstruction.CreateAccount;
 } & ParsedCreateAccountInstruction<TProgram>;

--- a/test/e2e/token/src/generated/programs/token.ts
+++ b/test/e2e/token/src/generated/programs/token.ts
@@ -6,254 +6,193 @@
  * @see https://github.com/codama-idl/codama
  */
 
+import { containsBytes, getU8Encoder, type Address, type ReadonlyUint8Array } from '@solana/kit';
 import {
-  containsBytes,
-  getU8Encoder,
-  type Address,
-  type ReadonlyUint8Array,
-} from '@solana/kit';
-import {
-  type ParsedAmountToUiAmountInstruction,
-  type ParsedApproveCheckedInstruction,
-  type ParsedApproveInstruction,
-  type ParsedBurnCheckedInstruction,
-  type ParsedBurnInstruction,
-  type ParsedCloseAccountInstruction,
-  type ParsedFreezeAccountInstruction,
-  type ParsedGetAccountDataSizeInstruction,
-  type ParsedInitializeAccount2Instruction,
-  type ParsedInitializeAccount3Instruction,
-  type ParsedInitializeAccountInstruction,
-  type ParsedInitializeImmutableOwnerInstruction,
-  type ParsedInitializeMint2Instruction,
-  type ParsedInitializeMintInstruction,
-  type ParsedInitializeMultisig2Instruction,
-  type ParsedInitializeMultisigInstruction,
-  type ParsedMintToCheckedInstruction,
-  type ParsedMintToInstruction,
-  type ParsedRevokeInstruction,
-  type ParsedSetAuthorityInstruction,
-  type ParsedSyncNativeInstruction,
-  type ParsedThawAccountInstruction,
-  type ParsedTransferCheckedInstruction,
-  type ParsedTransferInstruction,
-  type ParsedUiAmountToAmountInstruction,
+    type ParsedAmountToUiAmountInstruction,
+    type ParsedApproveCheckedInstruction,
+    type ParsedApproveInstruction,
+    type ParsedBurnCheckedInstruction,
+    type ParsedBurnInstruction,
+    type ParsedCloseAccountInstruction,
+    type ParsedFreezeAccountInstruction,
+    type ParsedGetAccountDataSizeInstruction,
+    type ParsedInitializeAccount2Instruction,
+    type ParsedInitializeAccount3Instruction,
+    type ParsedInitializeAccountInstruction,
+    type ParsedInitializeImmutableOwnerInstruction,
+    type ParsedInitializeMint2Instruction,
+    type ParsedInitializeMintInstruction,
+    type ParsedInitializeMultisig2Instruction,
+    type ParsedInitializeMultisigInstruction,
+    type ParsedMintToCheckedInstruction,
+    type ParsedMintToInstruction,
+    type ParsedRevokeInstruction,
+    type ParsedSetAuthorityInstruction,
+    type ParsedSyncNativeInstruction,
+    type ParsedThawAccountInstruction,
+    type ParsedTransferCheckedInstruction,
+    type ParsedTransferInstruction,
+    type ParsedUiAmountToAmountInstruction,
 } from '../instructions';
 
 export const TOKEN_PROGRAM_ADDRESS =
-  'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' as Address<'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'>;
+    'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' as Address<'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'>;
 
 export enum TokenAccount {
-  Mint,
-  Token,
-  Multisig,
+    Mint,
+    Token,
+    Multisig,
 }
 
-export function identifyTokenAccount(
-  account: { data: ReadonlyUint8Array } | ReadonlyUint8Array
-): TokenAccount {
-  const data = 'data' in account ? account.data : account;
-  if (data.length === 82) {
-    return TokenAccount.Mint;
-  }
-  if (data.length === 165) {
-    return TokenAccount.Token;
-  }
-  if (data.length === 355) {
-    return TokenAccount.Multisig;
-  }
-  throw new Error(
-    'The provided account could not be identified as a token account.'
-  );
+export function identifyTokenAccount(account: { data: ReadonlyUint8Array } | ReadonlyUint8Array): TokenAccount {
+    const data = 'data' in account ? account.data : account;
+    if (data.length === 82) {
+        return TokenAccount.Mint;
+    }
+    if (data.length === 165) {
+        return TokenAccount.Token;
+    }
+    if (data.length === 355) {
+        return TokenAccount.Multisig;
+    }
+    throw new Error('The provided account could not be identified as a token account.');
 }
 
 export enum TokenInstruction {
-  InitializeMint,
-  InitializeAccount,
-  InitializeMultisig,
-  Transfer,
-  Approve,
-  Revoke,
-  SetAuthority,
-  MintTo,
-  Burn,
-  CloseAccount,
-  FreezeAccount,
-  ThawAccount,
-  TransferChecked,
-  ApproveChecked,
-  MintToChecked,
-  BurnChecked,
-  InitializeAccount2,
-  SyncNative,
-  InitializeAccount3,
-  InitializeMultisig2,
-  InitializeMint2,
-  GetAccountDataSize,
-  InitializeImmutableOwner,
-  AmountToUiAmount,
-  UiAmountToAmount,
+    InitializeMint,
+    InitializeAccount,
+    InitializeMultisig,
+    Transfer,
+    Approve,
+    Revoke,
+    SetAuthority,
+    MintTo,
+    Burn,
+    CloseAccount,
+    FreezeAccount,
+    ThawAccount,
+    TransferChecked,
+    ApproveChecked,
+    MintToChecked,
+    BurnChecked,
+    InitializeAccount2,
+    SyncNative,
+    InitializeAccount3,
+    InitializeMultisig2,
+    InitializeMint2,
+    GetAccountDataSize,
+    InitializeImmutableOwner,
+    AmountToUiAmount,
+    UiAmountToAmount,
 }
 
 export function identifyTokenInstruction(
-  instruction: { data: ReadonlyUint8Array } | ReadonlyUint8Array
+    instruction: { data: ReadonlyUint8Array } | ReadonlyUint8Array
 ): TokenInstruction {
-  const data = 'data' in instruction ? instruction.data : instruction;
-  if (containsBytes(data, getU8Encoder().encode(0), 0)) {
-    return TokenInstruction.InitializeMint;
-  }
-  if (containsBytes(data, getU8Encoder().encode(1), 0)) {
-    return TokenInstruction.InitializeAccount;
-  }
-  if (containsBytes(data, getU8Encoder().encode(2), 0)) {
-    return TokenInstruction.InitializeMultisig;
-  }
-  if (containsBytes(data, getU8Encoder().encode(3), 0)) {
-    return TokenInstruction.Transfer;
-  }
-  if (containsBytes(data, getU8Encoder().encode(4), 0)) {
-    return TokenInstruction.Approve;
-  }
-  if (containsBytes(data, getU8Encoder().encode(5), 0)) {
-    return TokenInstruction.Revoke;
-  }
-  if (containsBytes(data, getU8Encoder().encode(6), 0)) {
-    return TokenInstruction.SetAuthority;
-  }
-  if (containsBytes(data, getU8Encoder().encode(7), 0)) {
-    return TokenInstruction.MintTo;
-  }
-  if (containsBytes(data, getU8Encoder().encode(8), 0)) {
-    return TokenInstruction.Burn;
-  }
-  if (containsBytes(data, getU8Encoder().encode(9), 0)) {
-    return TokenInstruction.CloseAccount;
-  }
-  if (containsBytes(data, getU8Encoder().encode(10), 0)) {
-    return TokenInstruction.FreezeAccount;
-  }
-  if (containsBytes(data, getU8Encoder().encode(11), 0)) {
-    return TokenInstruction.ThawAccount;
-  }
-  if (containsBytes(data, getU8Encoder().encode(12), 0)) {
-    return TokenInstruction.TransferChecked;
-  }
-  if (containsBytes(data, getU8Encoder().encode(13), 0)) {
-    return TokenInstruction.ApproveChecked;
-  }
-  if (containsBytes(data, getU8Encoder().encode(14), 0)) {
-    return TokenInstruction.MintToChecked;
-  }
-  if (containsBytes(data, getU8Encoder().encode(15), 0)) {
-    return TokenInstruction.BurnChecked;
-  }
-  if (containsBytes(data, getU8Encoder().encode(16), 0)) {
-    return TokenInstruction.InitializeAccount2;
-  }
-  if (containsBytes(data, getU8Encoder().encode(17), 0)) {
-    return TokenInstruction.SyncNative;
-  }
-  if (containsBytes(data, getU8Encoder().encode(18), 0)) {
-    return TokenInstruction.InitializeAccount3;
-  }
-  if (containsBytes(data, getU8Encoder().encode(19), 0)) {
-    return TokenInstruction.InitializeMultisig2;
-  }
-  if (containsBytes(data, getU8Encoder().encode(20), 0)) {
-    return TokenInstruction.InitializeMint2;
-  }
-  if (containsBytes(data, getU8Encoder().encode(21), 0)) {
-    return TokenInstruction.GetAccountDataSize;
-  }
-  if (containsBytes(data, getU8Encoder().encode(22), 0)) {
-    return TokenInstruction.InitializeImmutableOwner;
-  }
-  if (containsBytes(data, getU8Encoder().encode(23), 0)) {
-    return TokenInstruction.AmountToUiAmount;
-  }
-  if (containsBytes(data, getU8Encoder().encode(24), 0)) {
-    return TokenInstruction.UiAmountToAmount;
-  }
-  throw new Error(
-    'The provided instruction could not be identified as a token instruction.'
-  );
+    const data = 'data' in instruction ? instruction.data : instruction;
+    if (containsBytes(data, getU8Encoder().encode(0), 0)) {
+        return TokenInstruction.InitializeMint;
+    }
+    if (containsBytes(data, getU8Encoder().encode(1), 0)) {
+        return TokenInstruction.InitializeAccount;
+    }
+    if (containsBytes(data, getU8Encoder().encode(2), 0)) {
+        return TokenInstruction.InitializeMultisig;
+    }
+    if (containsBytes(data, getU8Encoder().encode(3), 0)) {
+        return TokenInstruction.Transfer;
+    }
+    if (containsBytes(data, getU8Encoder().encode(4), 0)) {
+        return TokenInstruction.Approve;
+    }
+    if (containsBytes(data, getU8Encoder().encode(5), 0)) {
+        return TokenInstruction.Revoke;
+    }
+    if (containsBytes(data, getU8Encoder().encode(6), 0)) {
+        return TokenInstruction.SetAuthority;
+    }
+    if (containsBytes(data, getU8Encoder().encode(7), 0)) {
+        return TokenInstruction.MintTo;
+    }
+    if (containsBytes(data, getU8Encoder().encode(8), 0)) {
+        return TokenInstruction.Burn;
+    }
+    if (containsBytes(data, getU8Encoder().encode(9), 0)) {
+        return TokenInstruction.CloseAccount;
+    }
+    if (containsBytes(data, getU8Encoder().encode(10), 0)) {
+        return TokenInstruction.FreezeAccount;
+    }
+    if (containsBytes(data, getU8Encoder().encode(11), 0)) {
+        return TokenInstruction.ThawAccount;
+    }
+    if (containsBytes(data, getU8Encoder().encode(12), 0)) {
+        return TokenInstruction.TransferChecked;
+    }
+    if (containsBytes(data, getU8Encoder().encode(13), 0)) {
+        return TokenInstruction.ApproveChecked;
+    }
+    if (containsBytes(data, getU8Encoder().encode(14), 0)) {
+        return TokenInstruction.MintToChecked;
+    }
+    if (containsBytes(data, getU8Encoder().encode(15), 0)) {
+        return TokenInstruction.BurnChecked;
+    }
+    if (containsBytes(data, getU8Encoder().encode(16), 0)) {
+        return TokenInstruction.InitializeAccount2;
+    }
+    if (containsBytes(data, getU8Encoder().encode(17), 0)) {
+        return TokenInstruction.SyncNative;
+    }
+    if (containsBytes(data, getU8Encoder().encode(18), 0)) {
+        return TokenInstruction.InitializeAccount3;
+    }
+    if (containsBytes(data, getU8Encoder().encode(19), 0)) {
+        return TokenInstruction.InitializeMultisig2;
+    }
+    if (containsBytes(data, getU8Encoder().encode(20), 0)) {
+        return TokenInstruction.InitializeMint2;
+    }
+    if (containsBytes(data, getU8Encoder().encode(21), 0)) {
+        return TokenInstruction.GetAccountDataSize;
+    }
+    if (containsBytes(data, getU8Encoder().encode(22), 0)) {
+        return TokenInstruction.InitializeImmutableOwner;
+    }
+    if (containsBytes(data, getU8Encoder().encode(23), 0)) {
+        return TokenInstruction.AmountToUiAmount;
+    }
+    if (containsBytes(data, getU8Encoder().encode(24), 0)) {
+        return TokenInstruction.UiAmountToAmount;
+    }
+    throw new Error('The provided instruction could not be identified as a token instruction.');
 }
 
-export type ParsedTokenInstruction<
-  TProgram extends string = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
-> =
-  | ({
-      instructionType: TokenInstruction.InitializeMint;
-    } & ParsedInitializeMintInstruction<TProgram>)
-  | ({
-      instructionType: TokenInstruction.InitializeAccount;
-    } & ParsedInitializeAccountInstruction<TProgram>)
-  | ({
-      instructionType: TokenInstruction.InitializeMultisig;
-    } & ParsedInitializeMultisigInstruction<TProgram>)
-  | ({
-      instructionType: TokenInstruction.Transfer;
-    } & ParsedTransferInstruction<TProgram>)
-  | ({
-      instructionType: TokenInstruction.Approve;
-    } & ParsedApproveInstruction<TProgram>)
-  | ({
-      instructionType: TokenInstruction.Revoke;
-    } & ParsedRevokeInstruction<TProgram>)
-  | ({
-      instructionType: TokenInstruction.SetAuthority;
-    } & ParsedSetAuthorityInstruction<TProgram>)
-  | ({
-      instructionType: TokenInstruction.MintTo;
-    } & ParsedMintToInstruction<TProgram>)
-  | ({
-      instructionType: TokenInstruction.Burn;
-    } & ParsedBurnInstruction<TProgram>)
-  | ({
-      instructionType: TokenInstruction.CloseAccount;
-    } & ParsedCloseAccountInstruction<TProgram>)
-  | ({
-      instructionType: TokenInstruction.FreezeAccount;
-    } & ParsedFreezeAccountInstruction<TProgram>)
-  | ({
-      instructionType: TokenInstruction.ThawAccount;
-    } & ParsedThawAccountInstruction<TProgram>)
-  | ({
-      instructionType: TokenInstruction.TransferChecked;
-    } & ParsedTransferCheckedInstruction<TProgram>)
-  | ({
-      instructionType: TokenInstruction.ApproveChecked;
-    } & ParsedApproveCheckedInstruction<TProgram>)
-  | ({
-      instructionType: TokenInstruction.MintToChecked;
-    } & ParsedMintToCheckedInstruction<TProgram>)
-  | ({
-      instructionType: TokenInstruction.BurnChecked;
-    } & ParsedBurnCheckedInstruction<TProgram>)
-  | ({
-      instructionType: TokenInstruction.InitializeAccount2;
-    } & ParsedInitializeAccount2Instruction<TProgram>)
-  | ({
-      instructionType: TokenInstruction.SyncNative;
-    } & ParsedSyncNativeInstruction<TProgram>)
-  | ({
-      instructionType: TokenInstruction.InitializeAccount3;
-    } & ParsedInitializeAccount3Instruction<TProgram>)
-  | ({
-      instructionType: TokenInstruction.InitializeMultisig2;
-    } & ParsedInitializeMultisig2Instruction<TProgram>)
-  | ({
-      instructionType: TokenInstruction.InitializeMint2;
-    } & ParsedInitializeMint2Instruction<TProgram>)
-  | ({
-      instructionType: TokenInstruction.GetAccountDataSize;
-    } & ParsedGetAccountDataSizeInstruction<TProgram>)
-  | ({
-      instructionType: TokenInstruction.InitializeImmutableOwner;
-    } & ParsedInitializeImmutableOwnerInstruction<TProgram>)
-  | ({
-      instructionType: TokenInstruction.AmountToUiAmount;
-    } & ParsedAmountToUiAmountInstruction<TProgram>)
-  | ({
-      instructionType: TokenInstruction.UiAmountToAmount;
-    } & ParsedUiAmountToAmountInstruction<TProgram>);
+export type ParsedTokenInstruction<TProgram extends string = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'> =
+    | ({ instructionType: TokenInstruction.InitializeMint } & ParsedInitializeMintInstruction<TProgram>)
+    | ({ instructionType: TokenInstruction.InitializeAccount } & ParsedInitializeAccountInstruction<TProgram>)
+    | ({ instructionType: TokenInstruction.InitializeMultisig } & ParsedInitializeMultisigInstruction<TProgram>)
+    | ({ instructionType: TokenInstruction.Transfer } & ParsedTransferInstruction<TProgram>)
+    | ({ instructionType: TokenInstruction.Approve } & ParsedApproveInstruction<TProgram>)
+    | ({ instructionType: TokenInstruction.Revoke } & ParsedRevokeInstruction<TProgram>)
+    | ({ instructionType: TokenInstruction.SetAuthority } & ParsedSetAuthorityInstruction<TProgram>)
+    | ({ instructionType: TokenInstruction.MintTo } & ParsedMintToInstruction<TProgram>)
+    | ({ instructionType: TokenInstruction.Burn } & ParsedBurnInstruction<TProgram>)
+    | ({ instructionType: TokenInstruction.CloseAccount } & ParsedCloseAccountInstruction<TProgram>)
+    | ({ instructionType: TokenInstruction.FreezeAccount } & ParsedFreezeAccountInstruction<TProgram>)
+    | ({ instructionType: TokenInstruction.ThawAccount } & ParsedThawAccountInstruction<TProgram>)
+    | ({ instructionType: TokenInstruction.TransferChecked } & ParsedTransferCheckedInstruction<TProgram>)
+    | ({ instructionType: TokenInstruction.ApproveChecked } & ParsedApproveCheckedInstruction<TProgram>)
+    | ({ instructionType: TokenInstruction.MintToChecked } & ParsedMintToCheckedInstruction<TProgram>)
+    | ({ instructionType: TokenInstruction.BurnChecked } & ParsedBurnCheckedInstruction<TProgram>)
+    | ({ instructionType: TokenInstruction.InitializeAccount2 } & ParsedInitializeAccount2Instruction<TProgram>)
+    | ({ instructionType: TokenInstruction.SyncNative } & ParsedSyncNativeInstruction<TProgram>)
+    | ({ instructionType: TokenInstruction.InitializeAccount3 } & ParsedInitializeAccount3Instruction<TProgram>)
+    | ({ instructionType: TokenInstruction.InitializeMultisig2 } & ParsedInitializeMultisig2Instruction<TProgram>)
+    | ({ instructionType: TokenInstruction.InitializeMint2 } & ParsedInitializeMint2Instruction<TProgram>)
+    | ({ instructionType: TokenInstruction.GetAccountDataSize } & ParsedGetAccountDataSizeInstruction<TProgram>)
+    | ({
+          instructionType: TokenInstruction.InitializeImmutableOwner;
+      } & ParsedInitializeImmutableOwnerInstruction<TProgram>)
+    | ({ instructionType: TokenInstruction.AmountToUiAmount } & ParsedAmountToUiAmountInstruction<TProgram>)
+    | ({ instructionType: TokenInstruction.UiAmountToAmount } & ParsedUiAmountToAmountInstruction<TProgram>);

--- a/test/e2e/token/src/generated/shared/index.ts
+++ b/test/e2e/token/src/generated/shared/index.ts
@@ -7,15 +7,15 @@
  */
 
 import {
-  AccountRole,
-  isProgramDerivedAddress,
-  isTransactionSigner as kitIsTransactionSigner,
-  type AccountMeta,
-  type AccountSignerMeta,
-  type Address,
-  type ProgramDerivedAddress,
-  type TransactionSigner,
-  upgradeRoleToSigner,
+    AccountRole,
+    isProgramDerivedAddress,
+    isTransactionSigner as kitIsTransactionSigner,
+    type AccountMeta,
+    type AccountSignerMeta,
+    type Address,
+    type ProgramDerivedAddress,
+    type TransactionSigner,
+    upgradeRoleToSigner,
 } from '@solana/kit';
 
 /**
@@ -23,10 +23,10 @@ import {
  * @internal
  */
 export function expectSome<T>(value: T | null | undefined): T {
-  if (value === null || value === undefined) {
-    throw new Error('Expected a value but received null or undefined.');
-  }
-  return value;
+    if (value === null || value === undefined) {
+        throw new Error('Expected a value but received null or undefined.');
+    }
+    return value;
 }
 
 /**
@@ -34,23 +34,18 @@ export function expectSome<T>(value: T | null | undefined): T {
  * @internal
  */
 export function expectAddress<T extends string = string>(
-  value:
-    | Address<T>
-    | ProgramDerivedAddress<T>
-    | TransactionSigner<T>
-    | null
-    | undefined
+    value: Address<T> | ProgramDerivedAddress<T> | TransactionSigner<T> | null | undefined
 ): Address<T> {
-  if (!value) {
-    throw new Error('Expected a Address.');
-  }
-  if (typeof value === 'object' && 'address' in value) {
-    return value.address;
-  }
-  if (Array.isArray(value)) {
-    return value[0] as Address<T>;
-  }
-  return value as Address<T>;
+    if (!value) {
+        throw new Error('Expected a Address.');
+    }
+    if (typeof value === 'object' && 'address' in value) {
+        return value.address;
+    }
+    if (Array.isArray(value)) {
+        return value[0] as Address<T>;
+    }
+    return value as Address<T>;
 }
 
 /**
@@ -58,17 +53,12 @@ export function expectAddress<T extends string = string>(
  * @internal
  */
 export function expectProgramDerivedAddress<T extends string = string>(
-  value:
-    | Address<T>
-    | ProgramDerivedAddress<T>
-    | TransactionSigner<T>
-    | null
-    | undefined
+    value: Address<T> | ProgramDerivedAddress<T> | TransactionSigner<T> | null | undefined
 ): ProgramDerivedAddress<T> {
-  if (!value || !Array.isArray(value) || !isProgramDerivedAddress(value)) {
-    throw new Error('Expected a ProgramDerivedAddress.');
-  }
-  return value;
+    if (!value || !Array.isArray(value) || !isProgramDerivedAddress(value)) {
+        throw new Error('Expected a ProgramDerivedAddress.');
+    }
+    return value;
 }
 
 /**
@@ -76,17 +66,12 @@ export function expectProgramDerivedAddress<T extends string = string>(
  * @internal
  */
 export function expectTransactionSigner<T extends string = string>(
-  value:
-    | Address<T>
-    | ProgramDerivedAddress<T>
-    | TransactionSigner<T>
-    | null
-    | undefined
+    value: Address<T> | ProgramDerivedAddress<T> | TransactionSigner<T> | null | undefined
 ): TransactionSigner<T> {
-  if (!value || !isTransactionSigner(value)) {
-    throw new Error('Expected a TransactionSigner.');
-  }
-  return value;
+    if (!value || !isTransactionSigner(value)) {
+        throw new Error('Expected a TransactionSigner.');
+    }
+    return value;
 }
 
 /**
@@ -94,19 +79,15 @@ export function expectTransactionSigner<T extends string = string>(
  * @internal
  */
 export type ResolvedAccount<
-  T extends string = string,
-  U extends
-    | Address<T>
-    | ProgramDerivedAddress<T>
-    | TransactionSigner<T>
-    | null =
-    | Address<T>
-    | ProgramDerivedAddress<T>
-    | TransactionSigner<T>
-    | null,
+    T extends string = string,
+    U extends Address<T> | ProgramDerivedAddress<T> | TransactionSigner<T> | null =
+        | Address<T>
+        | ProgramDerivedAddress<T>
+        | TransactionSigner<T>
+        | null,
 > = {
-  isWritable: boolean;
-  value: U;
+    isWritable: boolean;
+    value: U;
 };
 
 /**
@@ -114,51 +95,31 @@ export type ResolvedAccount<
  * @internal
  */
 export type InstructionWithByteDelta = {
-  byteDelta: number;
+    byteDelta: number;
 };
 
 /**
  * Get account metas and signers from resolved accounts.
  * @internal
  */
-export function getAccountMetaFactory(
-  programAddress: Address,
-  optionalAccountStrategy: 'omitted' | 'programId'
-) {
-  return (
-    account: ResolvedAccount
-  ): AccountMeta | AccountSignerMeta | undefined => {
-    if (!account.value) {
-      if (optionalAccountStrategy === 'omitted') return;
-      return Object.freeze({
-        address: programAddress,
-        role: AccountRole.READONLY,
-      });
-    }
+export function getAccountMetaFactory(programAddress: Address, optionalAccountStrategy: 'omitted' | 'programId') {
+    return (account: ResolvedAccount): AccountMeta | AccountSignerMeta | undefined => {
+        if (!account.value) {
+            if (optionalAccountStrategy === 'omitted') return;
+            return Object.freeze({ address: programAddress, role: AccountRole.READONLY });
+        }
 
-    const writableRole = account.isWritable
-      ? AccountRole.WRITABLE
-      : AccountRole.READONLY;
-    return Object.freeze({
-      address: expectAddress(account.value),
-      role: isTransactionSigner(account.value)
-        ? upgradeRoleToSigner(writableRole)
-        : writableRole,
-      ...(isTransactionSigner(account.value) ? { signer: account.value } : {}),
-    });
-  };
+        const writableRole = account.isWritable ? AccountRole.WRITABLE : AccountRole.READONLY;
+        return Object.freeze({
+            address: expectAddress(account.value),
+            role: isTransactionSigner(account.value) ? upgradeRoleToSigner(writableRole) : writableRole,
+            ...(isTransactionSigner(account.value) ? { signer: account.value } : {}),
+        });
+    };
 }
 
 export function isTransactionSigner<TAddress extends string = string>(
-  value:
-    | Address<TAddress>
-    | ProgramDerivedAddress<TAddress>
-    | TransactionSigner<TAddress>
+    value: Address<TAddress> | ProgramDerivedAddress<TAddress> | TransactionSigner<TAddress>
 ): value is TransactionSigner<TAddress> {
-  return (
-    !!value &&
-    typeof value === 'object' &&
-    'address' in value &&
-    kitIsTransactionSigner(value)
-  );
+    return !!value && typeof value === 'object' && 'address' in value && kitIsTransactionSigner(value);
 }

--- a/test/e2e/token/src/generated/types/accountState.ts
+++ b/test/e2e/token/src/generated/types/accountState.ts
@@ -7,33 +7,30 @@
  */
 
 import {
-  combineCodec,
-  getEnumDecoder,
-  getEnumEncoder,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
+    combineCodec,
+    getEnumDecoder,
+    getEnumEncoder,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
 } from '@solana/kit';
 
 export enum AccountState {
-  Uninitialized,
-  Initialized,
-  Frozen,
+    Uninitialized,
+    Initialized,
+    Frozen,
 }
 
 export type AccountStateArgs = AccountState;
 
 export function getAccountStateEncoder(): FixedSizeEncoder<AccountStateArgs> {
-  return getEnumEncoder(AccountState);
+    return getEnumEncoder(AccountState);
 }
 
 export function getAccountStateDecoder(): FixedSizeDecoder<AccountState> {
-  return getEnumDecoder(AccountState);
+    return getEnumDecoder(AccountState);
 }
 
-export function getAccountStateCodec(): FixedSizeCodec<
-  AccountStateArgs,
-  AccountState
-> {
-  return combineCodec(getAccountStateEncoder(), getAccountStateDecoder());
+export function getAccountStateCodec(): FixedSizeCodec<AccountStateArgs, AccountState> {
+    return combineCodec(getAccountStateEncoder(), getAccountStateDecoder());
 }

--- a/test/e2e/token/src/generated/types/authorityType.ts
+++ b/test/e2e/token/src/generated/types/authorityType.ts
@@ -7,34 +7,31 @@
  */
 
 import {
-  combineCodec,
-  getEnumDecoder,
-  getEnumEncoder,
-  type FixedSizeCodec,
-  type FixedSizeDecoder,
-  type FixedSizeEncoder,
+    combineCodec,
+    getEnumDecoder,
+    getEnumEncoder,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
 } from '@solana/kit';
 
 export enum AuthorityType {
-  MintTokens,
-  FreezeAccount,
-  AccountOwner,
-  CloseAccount,
+    MintTokens,
+    FreezeAccount,
+    AccountOwner,
+    CloseAccount,
 }
 
 export type AuthorityTypeArgs = AuthorityType;
 
 export function getAuthorityTypeEncoder(): FixedSizeEncoder<AuthorityTypeArgs> {
-  return getEnumEncoder(AuthorityType);
+    return getEnumEncoder(AuthorityType);
 }
 
 export function getAuthorityTypeDecoder(): FixedSizeDecoder<AuthorityType> {
-  return getEnumDecoder(AuthorityType);
+    return getEnumDecoder(AuthorityType);
 }
 
-export function getAuthorityTypeCodec(): FixedSizeCodec<
-  AuthorityTypeArgs,
-  AuthorityType
-> {
-  return combineCodec(getAuthorityTypeEncoder(), getAuthorityTypeDecoder());
+export function getAuthorityTypeCodec(): FixedSizeCodec<AuthorityTypeArgs, AuthorityType> {
+    return combineCodec(getAuthorityTypeEncoder(), getAuthorityTypeDecoder());
 }

--- a/test/e2e/token/test/_setup.ts
+++ b/test/e2e/token/test/_setup.ts
@@ -12,6 +12,7 @@ import {
   airdropFactory,
   appendTransactionMessageInstructions,
   assertIsSendableTransaction,
+  assertIsTransactionWithBlockhashLifetime,
   createSolanaRpc,
   createSolanaRpcSubscriptions,
   createTransactionMessage,
@@ -87,6 +88,7 @@ export const signAndSendTransaction = async (
     await signTransactionMessageWithSigners(transactionMessage);
   const signature = getSignatureFromTransaction(signedTransaction);
   assertIsSendableTransaction(signedTransaction);
+  assertIsTransactionWithBlockhashLifetime(signedTransaction);
   await sendAndConfirmTransactionFactory(client)(signedTransaction, {
     commitment,
   });


### PR DESCRIPTION
This PR refactors the logic around formatting the generated TypeScript code and introduces a new way of obtaining Prettier options by automatically resolving them from the `packageFolder` option when provided.

The large additions/removals count comes from the fact that all e2e generated clients now use 4 spaces instead of 2 when indenting because they use the `@solana/prettier-config-solana` config set instead of the default one.