### PR TITLE
Use file path when formatting and format updated package.json

### DIFF
--- a/.changeset/khaki-pans-film.md
+++ b/.changeset/khaki-pans-film.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-js': patch
+---
+
+Use file path when formatting and format updated package.json

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "dependencies": {
         "@codama/errors": "^1.4.4",
         "@codama/nodes": "^1.4.4",
-        "@codama/renderers-core": "^1.3.3",
+        "@codama/renderers-core": "^1.3.4",
         "@codama/visitors-core": "^1.4.4",
         "@solana/codecs-strings": "^5.0.0",
         "prettier": "^3.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^1.4.4
         version: 1.4.4
       '@codama/renderers-core':
-        specifier: ^1.3.3
-        version: 1.3.3
+        specifier: ^1.3.4
+        version: 1.3.4
       '@codama/visitors-core':
         specifier: ^1.4.4
         version: 1.4.4
@@ -318,8 +318,8 @@ packages:
   '@codama/nodes@1.4.4':
     resolution: {integrity: sha512-JzlY5qLk3rhsnu0nerC/Vkc9/2HjdsLtEpBtST0dxC1j9kpfHvIc2uyIj+5hlB1YIBRJIDNo+UOHGla8hidkaA==}
 
-  '@codama/renderers-core@1.3.3':
-    resolution: {integrity: sha512-L2gvsgB9ZGwA0q2F9u8AgNJf2aqAWzyRjokhLNoS9IPEQaV6ALQ4Z9FQ7/snNzEg3OvFbCg21jUynMN0brfjcw==}
+  '@codama/renderers-core@1.3.4':
+    resolution: {integrity: sha512-+qEPsvpCjUElohgJTcVNsjy6u1LjoCcwo72NbcffLF9QU5mUjNwL8EhFouEq2K60H/QKmNaiVKLQfJcQ/xCT9A==}
 
   '@codama/visitors-core@1.4.4':
     resolution: {integrity: sha512-vk/4tczViAUHa7c8PF7FxN+JWbuTcDB0pIdrDbbO6eBPKDPQGZCUCEp6rXIYBVxfO129jWrNf2+CuyYre/c/vA==}
@@ -3564,7 +3564,7 @@ snapshots:
       '@codama/errors': 1.4.4
       '@codama/node-types': 1.4.4
 
-  '@codama/renderers-core@1.3.3':
+  '@codama/renderers-core@1.3.4':
     dependencies:
       '@codama/errors': 1.4.4
       '@codama/nodes': 1.4.4
@@ -4421,8 +4421,8 @@ snapshots:
 
   '@typescript-eslint/project-service@8.43.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.43.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.43.0
+      '@typescript-eslint/tsconfig-utils': 8.48.1(typescript@5.9.3)
+      '@typescript-eslint/types': 8.48.1
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:

--- a/src/visitors/renderVisitor.ts
+++ b/src/visitors/renderVisitor.ts
@@ -1,7 +1,7 @@
-import { deleteDirectory, writeRenderMap } from '@codama/renderers-core';
+import { deleteDirectory, mapRenderMapContentAsync, writeRenderMap } from '@codama/renderers-core';
 import { rootNodeVisitor, visit } from '@codama/visitors-core';
 
-import { formatCode, RenderOptions, syncPackageJson } from '../utils';
+import { getCodeFormatter, RenderOptions, syncPackageJson } from '../utils';
 import { getRenderMapVisitor } from './getRenderMapVisitor';
 
 export function renderVisitor(path: string, options: RenderOptions = {}) {
@@ -15,10 +15,11 @@ export function renderVisitor(path: string, options: RenderOptions = {}) {
         let renderMap = visit(root, getRenderMapVisitor(options));
 
         // Format the code, if requested.
-        renderMap = await formatCode(renderMap, options);
+        const formatCode = await getCodeFormatter(options);
+        renderMap = await mapRenderMapContentAsync(renderMap, formatCode);
 
         // Create or update package.json dependencies, if requested.
-        syncPackageJson(renderMap, options);
+        await syncPackageJson(renderMap, formatCode, options);
 
         // Write the rendered files to the output directory.
         writeRenderMap(renderMap, path);

--- a/test/e2e/anchor/package.json
+++ b/test/e2e/anchor/package.json
@@ -1,25 +1,25 @@
 {
-  "name": "@codama/renderers-js-e2e-anchor",
-  "private": true,
-  "version": "0.0.0",
-  "type": "commonjs",
-  "sideEffects": false,
-  "scripts": {
-    "build": "rimraf dist && tsup && tsc -p ./tsconfig.declarations.json",
-    "test": "ava",
-    "lint": "eslint --ext js,ts,tsx src && prettier --check src test",
-    "lint:fix": "eslint --fix --ext js,ts,tsx src && prettier --write src test"
-  },
-  "dependencies": {
-    "@solana/kit": "^5.0.0"
-  },
-  "license": "MIT",
-  "ava": {
-    "typescript": {
-      "compile": false,
-      "rewritePaths": {
-        "test/": "dist/test/"
-      }
+    "name": "@codama/renderers-js-e2e-anchor",
+    "private": true,
+    "version": "0.0.0",
+    "type": "commonjs",
+    "sideEffects": false,
+    "scripts": {
+        "build": "rimraf dist && tsup && tsc -p ./tsconfig.declarations.json",
+        "test": "ava",
+        "lint": "eslint --ext js,ts,tsx src && prettier --check src test",
+        "lint:fix": "eslint --fix --ext js,ts,tsx src && prettier --write src test"
+    },
+    "dependencies": {
+        "@solana/kit": "^5.0.0"
+    },
+    "license": "MIT",
+    "ava": {
+        "typescript": {
+            "compile": false,
+            "rewritePaths": {
+                "test/": "dist/test/"
+            }
+        }
     }
-  }
 }

--- a/test/e2e/dummy/package.json
+++ b/test/e2e/dummy/package.json
@@ -1,25 +1,25 @@
 {
-  "name": "@codama/renderers-js-e2e-dummy",
-  "private": true,
-  "version": "0.0.0",
-  "type": "commonjs",
-  "sideEffects": false,
-  "scripts": {
-    "build": "rimraf dist && tsup && tsc -p ./tsconfig.declarations.json",
-    "test": "ava",
-    "lint": "eslint --ext js,ts,tsx src && prettier --check src test",
-    "lint:fix": "eslint --fix --ext js,ts,tsx src && prettier --write src test"
-  },
-  "dependencies": {
-    "@solana/kit": "^5.0.0"
-  },
-  "license": "MIT",
-  "ava": {
-    "typescript": {
-      "compile": false,
-      "rewritePaths": {
-        "test/": "dist/test/"
-      }
+    "name": "@codama/renderers-js-e2e-dummy",
+    "private": true,
+    "version": "0.0.0",
+    "type": "commonjs",
+    "sideEffects": false,
+    "scripts": {
+        "build": "rimraf dist && tsup && tsc -p ./tsconfig.declarations.json",
+        "test": "ava",
+        "lint": "eslint --ext js,ts,tsx src && prettier --check src test",
+        "lint:fix": "eslint --fix --ext js,ts,tsx src && prettier --write src test"
+    },
+    "dependencies": {
+        "@solana/kit": "^5.0.0"
+    },
+    "license": "MIT",
+    "ava": {
+        "typescript": {
+            "compile": false,
+            "rewritePaths": {
+                "test/": "dist/test/"
+            }
+        }
     }
-  }
 }

--- a/test/e2e/memo/package.json
+++ b/test/e2e/memo/package.json
@@ -1,25 +1,25 @@
 {
-  "name": "@codama/renderers-js-e2e-memo",
-  "private": true,
-  "version": "0.0.0",
-  "type": "commonjs",
-  "sideEffects": false,
-  "scripts": {
-    "build": "rimraf dist && tsup && tsc -p ./tsconfig.declarations.json",
-    "test": "ava",
-    "lint": "eslint --ext js,ts,tsx src && prettier --check src test",
-    "lint:fix": "eslint --fix --ext js,ts,tsx src && prettier --write src test"
-  },
-  "dependencies": {
-    "@solana/kit": "^5.0.0"
-  },
-  "license": "MIT",
-  "ava": {
-    "typescript": {
-      "compile": false,
-      "rewritePaths": {
-        "test/": "dist/test/"
-      }
+    "name": "@codama/renderers-js-e2e-memo",
+    "private": true,
+    "version": "0.0.0",
+    "type": "commonjs",
+    "sideEffects": false,
+    "scripts": {
+        "build": "rimraf dist && tsup && tsc -p ./tsconfig.declarations.json",
+        "test": "ava",
+        "lint": "eslint --ext js,ts,tsx src && prettier --check src test",
+        "lint:fix": "eslint --fix --ext js,ts,tsx src && prettier --write src test"
+    },
+    "dependencies": {
+        "@solana/kit": "^5.0.0"
+    },
+    "license": "MIT",
+    "ava": {
+        "typescript": {
+            "compile": false,
+            "rewritePaths": {
+                "test/": "dist/test/"
+            }
+        }
     }
-  }
 }

--- a/test/e2e/system/package.json
+++ b/test/e2e/system/package.json
@@ -1,25 +1,25 @@
 {
-  "name": "@codama/renderers-js-e2e-system",
-  "private": true,
-  "version": "0.0.0",
-  "type": "commonjs",
-  "sideEffects": false,
-  "scripts": {
-    "build": "rimraf dist && tsup && tsc -p ./tsconfig.declarations.json",
-    "test": "ava",
-    "lint": "eslint --ext js,ts,tsx src && prettier --check src test",
-    "lint:fix": "eslint --fix --ext js,ts,tsx src && prettier --write src test"
-  },
-  "dependencies": {
-    "@solana/kit": "^5.0.0"
-  },
-  "license": "MIT",
-  "ava": {
-    "typescript": {
-      "compile": false,
-      "rewritePaths": {
-        "test/": "dist/test/"
-      }
+    "name": "@codama/renderers-js-e2e-system",
+    "private": true,
+    "version": "0.0.0",
+    "type": "commonjs",
+    "sideEffects": false,
+    "scripts": {
+        "build": "rimraf dist && tsup && tsc -p ./tsconfig.declarations.json",
+        "test": "ava",
+        "lint": "eslint --ext js,ts,tsx src && prettier --check src test",
+        "lint:fix": "eslint --fix --ext js,ts,tsx src && prettier --write src test"
+    },
+    "dependencies": {
+        "@solana/kit": "^5.0.0"
+    },
+    "license": "MIT",
+    "ava": {
+        "typescript": {
+            "compile": false,
+            "rewritePaths": {
+                "test/": "dist/test/"
+            }
+        }
     }
-  }
 }

--- a/test/e2e/token/package.json
+++ b/test/e2e/token/package.json
@@ -1,25 +1,25 @@
 {
-  "name": "@codama/renderers-js-e2e-token",
-  "private": true,
-  "version": "0.0.0",
-  "type": "commonjs",
-  "sideEffects": false,
-  "scripts": {
-    "build": "rimraf dist && tsup && tsc -p ./tsconfig.declarations.json",
-    "test": "ava",
-    "lint": "eslint --ext js,ts,tsx src && prettier --check src test",
-    "lint:fix": "eslint --fix --ext js,ts,tsx src && prettier --write src test"
-  },
-  "dependencies": {
-    "@solana/kit": "^5.0.0"
-  },
-  "license": "MIT",
-  "ava": {
-    "typescript": {
-      "compile": false,
-      "rewritePaths": {
-        "test/": "dist/test/"
-      }
+    "name": "@codama/renderers-js-e2e-token",
+    "private": true,
+    "version": "0.0.0",
+    "type": "commonjs",
+    "sideEffects": false,
+    "scripts": {
+        "build": "rimraf dist && tsup && tsc -p ./tsconfig.declarations.json",
+        "test": "ava",
+        "lint": "eslint --ext js,ts,tsx src && prettier --check src test",
+        "lint:fix": "eslint --fix --ext js,ts,tsx src && prettier --write src test"
+    },
+    "dependencies": {
+        "@solana/kit": "^5.0.0"
+    },
+    "license": "MIT",
+    "ava": {
+        "typescript": {
+            "compile": false,
+            "rewritePaths": {
+                "test/": "dist/test/"
+            }
+        }
     }
-  }
 }


### PR DESCRIPTION
This PR uses the `RenderMap` code formatting to also format the updated `package.json` using the same settings.