### PR TITLE
Use string interpolation for the Unrecognised instruction error

### DIFF
--- a/.changeset/stale-loops-joke.md
+++ b/.changeset/stale-loops-joke.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-js': patch
+---
+
+Use string interpolation for the Unrecognised instruction error

--- a/src/fragments/programInstructions.ts
+++ b/src/fragments/programInstructions.ts
@@ -167,7 +167,7 @@ function getProgramInstructionsParseFunctionFragment(
             const instructionType = ${programInstructionsIdentifierFunction}(instruction);
             switch (instructionType) {
                 ${switchCases}
-                default: throw new Error("Unrecognized instruction type: " + instructionType);
+                default: throw new Error(\`Unrecognized instruction type: \${instructionType}\`);
             }
         }`;
 }

--- a/test/e2e/anchor/src/generated/programs/wenTransferGuard.ts
+++ b/test/e2e/anchor/src/generated/programs/wenTransferGuard.ts
@@ -137,6 +137,6 @@ export function parseWenTransferGuardInstruction<TProgram extends string>(
             };
         }
         default:
-            throw new Error('Unrecognized instruction type: ' + instructionType);
+            throw new Error(`Unrecognized instruction type: ${instructionType}`);
     }
 }

--- a/test/e2e/dummy/src/generated/programs/dummy.ts
+++ b/test/e2e/dummy/src/generated/programs/dummy.ts
@@ -93,6 +93,6 @@ export function parseDummyInstruction<TProgram extends string>(
             return { instructionType: DummyInstruction.Instruction7, ...parseInstruction7Instruction(instruction) };
         }
         default:
-            throw new Error('Unrecognized instruction type: ' + instructionType);
+            throw new Error(`Unrecognized instruction type: ${instructionType}`);
     }
 }

--- a/test/e2e/system/src/generated/programs/system.ts
+++ b/test/e2e/system/src/generated/programs/system.ts
@@ -214,6 +214,6 @@ export function parseSystemInstruction<TProgram extends string>(
             };
         }
         default:
-            throw new Error('Unrecognized instruction type: ' + instructionType);
+            throw new Error(`Unrecognized instruction type: ${instructionType}`);
     }
 }

--- a/test/e2e/token/src/generated/programs/associatedToken.ts
+++ b/test/e2e/token/src/generated/programs/associatedToken.ts
@@ -87,6 +87,6 @@ export function parseAssociatedTokenInstruction<TProgram extends string>(
             };
         }
         default:
-            throw new Error('Unrecognized instruction type: ' + instructionType);
+            throw new Error(`Unrecognized instruction type: ${instructionType}`);
     }
 }

--- a/test/e2e/token/src/generated/programs/system.ts
+++ b/test/e2e/token/src/generated/programs/system.ts
@@ -47,6 +47,6 @@ export function parseSystemInstruction<TProgram extends string>(
             return { instructionType: SystemInstruction.CreateAccount, ...parseCreateAccountInstruction(instruction) };
         }
         default:
-            throw new Error('Unrecognized instruction type: ' + instructionType);
+            throw new Error(`Unrecognized instruction type: ${instructionType}`);
     }
 }

--- a/test/e2e/token/src/generated/programs/token.ts
+++ b/test/e2e/token/src/generated/programs/token.ts
@@ -369,6 +369,6 @@ export function parseTokenInstruction<TProgram extends string>(
             };
         }
         default:
-            throw new Error('Unrecognized instruction type: ' + instructionType);
+            throw new Error(`Unrecognized instruction type: ${instructionType}`);
     }
 }


### PR DESCRIPTION
Avoids an eslint rule that complains about using `+` on `never`