### PR TITLE
Remove ignore for tsup and e2e tests

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,7 +2,7 @@ import solanaConfig from '@solana/eslint-config-solana';
 import { defineConfig } from 'eslint/config';
 
 export default defineConfig([
-    { ignores: ['**/dist/**', '**/e2e/**/env-shim.ts', '**/e2e/**/tsup.config.ts', '**/e2e/**/test/**'] },
+    { ignores: ['**/dist/**', '**/e2e/**/env-shim.ts'] },
     { files: ['**/*.ts', '**/*.(c|m)?js'], ignores: ['**/e2e/**'], extends: [solanaConfig] },
     {
         files: ['**/e2e/**/*.ts', '**/e2e/**/*.(c|m)?js'],

--- a/test/e2e/anchor/tsconfig.json
+++ b/test/e2e/anchor/tsconfig.json
@@ -21,5 +21,5 @@
     "verbatimModuleSyntax": true
   },
   "exclude": ["node_modules"],
-  "include": ["src", "test"]
+  "include": ["src", "test", "env-shim.ts", "tsup.config.ts"]
 }

--- a/test/e2e/dummy/test/instructions.test.ts
+++ b/test/e2e/dummy/test/instructions.test.ts
@@ -4,7 +4,7 @@ import {
   getInstruction1Instruction,
 } from '../src/index.js';
 
-test('it can create instruction 1', async (t) => {
+test('it can create instruction 1', (t) => {
   // When we create a dummy instruction.
   const instruction = getInstruction1Instruction();
 

--- a/test/e2e/dummy/tsconfig.json
+++ b/test/e2e/dummy/tsconfig.json
@@ -21,5 +21,5 @@
     "verbatimModuleSyntax": true
   },
   "exclude": ["node_modules"],
-  "include": ["src", "test"]
+  "include": ["src", "test", "env-shim.ts", "tsup.config.ts"]
 }

--- a/test/e2e/memo/test/addMemo.test.ts
+++ b/test/e2e/memo/test/addMemo.test.ts
@@ -23,7 +23,7 @@ test('it adds custom text to the transaction logs', async (t) => {
   const signature = await pipe(
     await createDefaultTransaction(client, payer),
     (tx) => appendTransactionMessageInstruction(addMemo, tx),
-    async (tx) => signAndSendTransaction(client, tx)
+    async (tx) => await signAndSendTransaction(client, tx)
   );
 
   // Then the instruction data contains our memo.

--- a/test/e2e/memo/tsconfig.json
+++ b/test/e2e/memo/tsconfig.json
@@ -21,5 +21,5 @@
     "verbatimModuleSyntax": true
   },
   "exclude": ["node_modules"],
-  "include": ["src", "test"]
+  "include": ["src", "test", "env-shim.ts", "tsup.config.ts"]
 }

--- a/test/e2e/system/tsconfig.json
+++ b/test/e2e/system/tsconfig.json
@@ -21,5 +21,5 @@
     "verbatimModuleSyntax": true
   },
   "exclude": ["node_modules"],
-  "include": ["src", "test"]
+  "include": ["src", "test", "env-shim.ts", "tsup.config.ts"]
 }

--- a/test/e2e/token/tsconfig.json
+++ b/test/e2e/token/tsconfig.json
@@ -21,5 +21,5 @@
     "verbatimModuleSyntax": true
   },
   "exclude": ["node_modules"],
-  "include": ["src", "test"]
+  "include": ["src", "test", "env-shim.ts", "tsup.config.ts"]
 }


### PR DESCRIPTION
These are easy to remove from the ignore, might as well lint them going forward 

env-shim is still ignored because it's hacky, doubt we lint that anywhere! 