### PR TITLE
Make `ImportMap` support subpath exports

### DIFF
--- a/.changeset/icy-dancers-train.md
+++ b/.changeset/icy-dancers-train.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-js': patch
+---
+
+Add support for subpath exports in `ImportMap`. The `getExternalDependencies` function now correctly handles subpath exports (e.g. `@solana/kit/program-client-core`) by extracting the root package name when checking dependencies.

--- a/src/utils/importMap.ts
+++ b/src/utils/importMap.ts
@@ -6,8 +6,12 @@ const DEFAULT_EXTERNAL_MODULE_MAP: Record<string, string> = {
     solanaCodecsNumbers: '@solana/kit',
     solanaCodecsStrings: '@solana/kit',
     solanaErrors: '@solana/kit',
+    solanaInstructionPlans: '@solana/kit',
     solanaInstructions: '@solana/kit',
     solanaOptions: '@solana/kit',
+    solanaPluginCore: '@solana/kit',
+    solanaPluginInterfaces: '@solana/kit',
+    solanaProgramClientCore: '@solana/kit/program-client-core',
     solanaPrograms: '@solana/kit',
     solanaRpcTypes: '@solana/kit',
     solanaSigners: '@solana/kit',
@@ -21,8 +25,12 @@ const DEFAULT_GRANULAR_EXTERNAL_MODULE_MAP: Record<string, string> = {
     solanaCodecsNumbers: '@solana/codecs',
     solanaCodecsStrings: '@solana/codecs',
     solanaErrors: '@solana/errors',
+    solanaInstructionPlans: '@solana/instruction-plans',
     solanaInstructions: '@solana/instructions',
     solanaOptions: '@solana/codecs',
+    solanaPluginCore: '@solana/plugin-core',
+    solanaPluginInterfaces: '@solana/plugin-interfaces',
+    solanaProgramClientCore: '@solana/program-client-core',
     solanaPrograms: '@solana/programs',
     solanaRpcTypes: '@solana/rpc-types',
     solanaSigners: '@solana/signers',
@@ -150,7 +158,15 @@ export function getExternalDependencies(
     useGranularImports: boolean,
 ): Set<string> {
     const resolvedImports = resolveImportMapModules(importMap, dependencyMap, useGranularImports);
-    return new Set([...resolvedImports.keys()].filter(module => !module.startsWith('.')));
+    return new Set(
+        [...resolvedImports.keys()]
+            .filter(module => !module.startsWith('.'))
+            .map(module => {
+                // For subpath imports, we want to get the root package name to check against dependencies.
+                const subPathExportIndex = module.startsWith('@') ? 2 : 1;
+                return module.split('/').slice(0, subPathExportIndex).join('/');
+            }),
+    );
 }
 
 function resolveImportMapModules(

--- a/test/e2e/anchor/tsconfig.json
+++ b/test/e2e/anchor/tsconfig.json
@@ -9,7 +9,7 @@
     "inlineSources": false,
     "isolatedModules": true,
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/test/e2e/dummy/tsconfig.json
+++ b/test/e2e/dummy/tsconfig.json
@@ -9,7 +9,7 @@
     "inlineSources": false,
     "isolatedModules": true,
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/test/e2e/memo/tsconfig.json
+++ b/test/e2e/memo/tsconfig.json
@@ -9,7 +9,7 @@
     "inlineSources": false,
     "isolatedModules": true,
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/test/e2e/system/tsconfig.json
+++ b/test/e2e/system/tsconfig.json
@@ -9,7 +9,7 @@
     "inlineSources": false,
     "isolatedModules": true,
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/test/e2e/token/tsconfig.json
+++ b/test/e2e/token/tsconfig.json
@@ -9,7 +9,7 @@
     "inlineSources": false,
     "isolatedModules": true,
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/test/e2e/token/tsup.config.ts
+++ b/test/e2e/token/tsup.config.ts
@@ -1,6 +1,6 @@
 import { env } from 'node:process';
 import path from 'node:path';
-import { defineConfig, Options } from 'tsup';
+import { defineConfig, type Options } from 'tsup';
 
 const SHARED_OPTIONS: Options = {
   define: { __VERSION__: `"${env.npm_package_version}"` },


### PR DESCRIPTION
This PR adds support for subpath exports in the `ImportMap` utility.

Previously, when resolving external dependencies, the `getExternalDependencies` function would return the full import path including subpath exports. This caused issues when checking dependencies since package.json lists root package names, not subpaths.

Now, subpath exports like `@solana/kit/program-client-core` are correctly resolved to their root package name (`@solana/kit`) when determining external dependencies.