### PR TITLE
Use `SolanaErrors` for generated errors

### DIFF
--- a/.changeset/strong-breads-spend.md
+++ b/.changeset/strong-breads-spend.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-js': minor
+---
+
+Use `SolanaError` for generated errors. Generated program clients now throw `SolanaError` with specific error codes instead of generic `Error` objects. This provides better error handling with structured context including the program name and relevant data.

--- a/src/fragments/discriminatorCondition.ts
+++ b/src/fragments/discriminatorCondition.ts
@@ -91,7 +91,6 @@ function getFieldConditionFragment(
 ): Fragment {
     const field = scope.struct.fields.find(f => f.name === discriminator.name);
     if (!field || !field.defaultValue) {
-        // TODO: Coded error.
         throw new Error(
             `Field discriminator "${discriminator.name}" does not have a matching argument with default value.`,
         );

--- a/src/fragments/instructionParseFunction.ts
+++ b/src/fragments/instructionParseFunction.ts
@@ -120,9 +120,10 @@ function getFunctionFragment(
 
     let accountHelpers: Fragment | undefined;
     if (hasAccounts) {
+        const solanaError = use('SolanaError', 'solanaErrors');
+        const solanaErrorCode = use('SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS', 'solanaErrors');
         accountHelpers = fragment`if (instruction.accounts.length < ${minimumNumberOfAccounts}) {
-  // TODO: Coded error.
-  throw new Error('Not enough accounts');
+  throw new ${solanaError}(${solanaErrorCode}, { actualAccountMetas: instruction.accounts.length, expectedAccountMetas: ${minimumNumberOfAccounts} });
 }
 let accountIndex = 0;
 const getNextAccount = () => {

--- a/test/e2e/anchor/src/generated/instructions/createGuard.ts
+++ b/test/e2e/anchor/src/generated/instructions/createGuard.ts
@@ -26,6 +26,8 @@ import {
     getU32Encoder,
     getUtf8Decoder,
     getUtf8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type AccountSignerMeta,
@@ -457,8 +459,10 @@ export function parseCreateGuardInstruction<TProgram extends string, TAccountMet
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedCreateGuardInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 8) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 8,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/anchor/src/generated/instructions/execute.ts
+++ b/test/e2e/anchor/src/generated/instructions/execute.ts
@@ -18,6 +18,8 @@ import {
     getStructEncoder,
     getU64Decoder,
     getU64Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type Address,
@@ -334,8 +336,10 @@ export function parseExecuteInstruction<TProgram extends string, TAccountMetas e
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedExecuteInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 7) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 7,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/anchor/src/generated/instructions/initialize.ts
+++ b/test/e2e/anchor/src/generated/instructions/initialize.ts
@@ -16,6 +16,8 @@ import {
     getProgramDerivedAddress,
     getStructDecoder,
     getStructEncoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type AccountSignerMeta,
@@ -306,8 +308,10 @@ export function parseInitializeInstruction<TProgram extends string, TAccountMeta
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedInitializeInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 6) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 6,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/anchor/src/generated/instructions/updateGuard.ts
+++ b/test/e2e/anchor/src/generated/instructions/updateGuard.ts
@@ -20,6 +20,8 @@ import {
     getProgramDerivedAddress,
     getStructDecoder,
     getStructEncoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type AccountSignerMeta,
@@ -377,8 +379,10 @@ export function parseUpdateGuardInstruction<TProgram extends string, TAccountMet
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedUpdateGuardInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 6) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 6,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/anchor/src/generated/programs/wenTransferGuard.ts
+++ b/test/e2e/anchor/src/generated/programs/wenTransferGuard.ts
@@ -11,6 +11,10 @@ import {
     containsBytes,
     fixEncoderSize,
     getBytesEncoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_ACCOUNT,
+    SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_INSTRUCTION,
+    SOLANA_ERROR__PROGRAM_CLIENTS__UNRECOGNIZED_INSTRUCTION_TYPE,
+    SolanaError,
     type Address,
     type Instruction,
     type InstructionWithData,
@@ -47,7 +51,10 @@ export function identifyWenTransferGuardAccount(
     ) {
         return WenTransferGuardAccount.GuardV1;
     }
-    throw new Error('The provided account could not be identified as a wenTransferGuard account.');
+    throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_ACCOUNT, {
+        accountData: data,
+        programName: 'wenTransferGuard',
+    });
 }
 
 export enum WenTransferGuardInstruction {
@@ -97,7 +104,10 @@ export function identifyWenTransferGuardInstruction(
     ) {
         return WenTransferGuardInstruction.UpdateGuard;
     }
-    throw new Error('The provided instruction could not be identified as a wenTransferGuard instruction.');
+    throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_INSTRUCTION, {
+        instructionData: data,
+        programName: 'wenTransferGuard',
+    });
 }
 
 export type ParsedWenTransferGuardInstruction<TProgram extends string = 'LockdqYQ9X2kwtWB99ioSbxubAmEi8o9jqYwbXgrrRw'> =
@@ -137,6 +147,9 @@ export function parseWenTransferGuardInstruction<TProgram extends string>(
             };
         }
         default:
-            throw new Error(`Unrecognized instruction type: ${instructionType as string}`);
+            throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__UNRECOGNIZED_INSTRUCTION_TYPE, {
+                instructionType: instructionType as string,
+                programName: 'wenTransferGuard',
+            });
     }
 }

--- a/test/e2e/dummy/src/generated/instructions/instruction6.ts
+++ b/test/e2e/dummy/src/generated/instructions/instruction6.ts
@@ -7,6 +7,8 @@
  */
 
 import {
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     type AccountMeta,
     type Address,
     type Instruction,
@@ -67,8 +69,10 @@ export function parseInstruction6Instruction<TProgram extends string, TAccountMe
     instruction: Instruction<TProgram> & InstructionWithAccounts<TAccountMetas>,
 ): ParsedInstruction6Instruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 1) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 1,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/dummy/src/generated/instructions/instruction7.ts
+++ b/test/e2e/dummy/src/generated/instructions/instruction7.ts
@@ -7,6 +7,8 @@
  */
 
 import {
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     type AccountMeta,
     type Address,
     type Instruction,
@@ -67,8 +69,10 @@ export function parseInstruction7Instruction<TProgram extends string, TAccountMe
     instruction: Instruction<TProgram> & InstructionWithAccounts<TAccountMetas>,
 ): ParsedInstruction7Instruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 1) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 1,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/dummy/src/generated/programs/dummy.ts
+++ b/test/e2e/dummy/src/generated/programs/dummy.ts
@@ -10,6 +10,9 @@ import {
     assertIsInstructionWithAccounts,
     containsBytes,
     getU32Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_INSTRUCTION,
+    SOLANA_ERROR__PROGRAM_CLIENTS__UNRECOGNIZED_INSTRUCTION_TYPE,
+    SolanaError,
     type Address,
     type Instruction,
     type InstructionWithData,
@@ -55,7 +58,10 @@ export function identifyDummyInstruction(
     if (containsBytes(data, getU32Encoder().encode(42), 0)) {
         return DummyInstruction.Instruction3;
     }
-    throw new Error('The provided instruction could not be identified as a dummy instruction.');
+    throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_INSTRUCTION, {
+        instructionData: data,
+        programName: 'dummy',
+    });
 }
 
 export type ParsedDummyInstruction<TProgram extends string = 'Dummy1111111111111111111111111111111111'> =
@@ -100,6 +106,9 @@ export function parseDummyInstruction<TProgram extends string>(
             return { instructionType: DummyInstruction.Instruction8, ...parseInstruction8Instruction(instruction) };
         }
         default:
-            throw new Error(`Unrecognized instruction type: ${instructionType as string}`);
+            throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__UNRECOGNIZED_INSTRUCTION_TYPE, {
+                instructionType: instructionType as string,
+                programName: 'dummy',
+            });
     }
 }

--- a/test/e2e/system/src/generated/instructions/advanceNonceAccount.ts
+++ b/test/e2e/system/src/generated/instructions/advanceNonceAccount.ts
@@ -12,6 +12,8 @@ import {
     getStructEncoder,
     getU32Decoder,
     getU32Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type AccountSignerMeta,
@@ -161,8 +163,10 @@ export function parseAdvanceNonceAccountInstruction<
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedAdvanceNonceAccountInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 3) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 3,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/system/src/generated/instructions/allocate.ts
+++ b/test/e2e/system/src/generated/instructions/allocate.ts
@@ -14,6 +14,8 @@ import {
     getU32Encoder,
     getU64Decoder,
     getU64Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type AccountSignerMeta,
@@ -127,8 +129,10 @@ export function parseAllocateInstruction<TProgram extends string, TAccountMetas 
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedAllocateInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 1) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 1,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/system/src/generated/instructions/allocateWithSeed.ts
+++ b/test/e2e/system/src/generated/instructions/allocateWithSeed.ts
@@ -20,6 +20,8 @@ import {
     getU64Encoder,
     getUtf8Decoder,
     getUtf8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type AccountSignerMeta,
@@ -168,8 +170,10 @@ export function parseAllocateWithSeedInstruction<TProgram extends string, TAccou
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedAllocateWithSeedInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 2) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 2,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/system/src/generated/instructions/assign.ts
+++ b/test/e2e/system/src/generated/instructions/assign.ts
@@ -14,6 +14,8 @@ import {
     getStructEncoder,
     getU32Decoder,
     getU32Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type AccountSignerMeta,
@@ -124,8 +126,10 @@ export function parseAssignInstruction<TProgram extends string, TAccountMetas ex
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedAssignInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 1) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 1,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/system/src/generated/instructions/assignWithSeed.ts
+++ b/test/e2e/system/src/generated/instructions/assignWithSeed.ts
@@ -18,6 +18,8 @@ import {
     getU32Encoder,
     getUtf8Decoder,
     getUtf8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type AccountSignerMeta,
@@ -154,8 +156,10 @@ export function parseAssignWithSeedInstruction<TProgram extends string, TAccount
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedAssignWithSeedInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 2) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 2,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/system/src/generated/instructions/authorizeNonceAccount.ts
+++ b/test/e2e/system/src/generated/instructions/authorizeNonceAccount.ts
@@ -14,6 +14,8 @@ import {
     getStructEncoder,
     getU32Decoder,
     getU32Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type AccountSignerMeta,
@@ -148,8 +150,10 @@ export function parseAuthorizeNonceAccountInstruction<
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedAuthorizeNonceAccountInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 2) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 2,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/system/src/generated/instructions/createAccount.ts
+++ b/test/e2e/system/src/generated/instructions/createAccount.ts
@@ -19,6 +19,8 @@ import {
     getU32Encoder,
     getU64Decoder,
     getU64Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type AccountSignerMeta,
@@ -162,8 +164,10 @@ export function parseCreateAccountInstruction<TProgram extends string, TAccountM
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedCreateAccountInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 2) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 2,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/system/src/generated/instructions/createAccountWithSeed.ts
+++ b/test/e2e/system/src/generated/instructions/createAccountWithSeed.ts
@@ -20,6 +20,8 @@ import {
     getU64Encoder,
     getUtf8Decoder,
     getUtf8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type AccountSignerMeta,
@@ -190,8 +192,10 @@ export function parseCreateAccountWithSeedInstruction<
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedCreateAccountWithSeedInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 3) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 3,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/system/src/generated/instructions/initializeNonceAccount.ts
+++ b/test/e2e/system/src/generated/instructions/initializeNonceAccount.ts
@@ -14,6 +14,8 @@ import {
     getStructEncoder,
     getU32Decoder,
     getU32Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type Address,
@@ -177,8 +179,10 @@ export function parseInitializeNonceAccountInstruction<
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedInitializeNonceAccountInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 3) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 3,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/system/src/generated/instructions/transferSol.ts
+++ b/test/e2e/system/src/generated/instructions/transferSol.ts
@@ -14,6 +14,8 @@ import {
     getU32Encoder,
     getU64Decoder,
     getU64Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type AccountSignerMeta,
@@ -136,8 +138,10 @@ export function parseTransferSolInstruction<TProgram extends string, TAccountMet
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedTransferSolInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 2) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 2,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/system/src/generated/instructions/transferSolWithSeed.ts
+++ b/test/e2e/system/src/generated/instructions/transferSolWithSeed.ts
@@ -20,6 +20,8 @@ import {
     getU64Encoder,
     getUtf8Decoder,
     getUtf8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type AccountSignerMeta,
@@ -170,8 +172,10 @@ export function parseTransferSolWithSeedInstruction<
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedTransferSolWithSeedInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 3) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 3,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/system/src/generated/instructions/upgradeNonceAccount.ts
+++ b/test/e2e/system/src/generated/instructions/upgradeNonceAccount.ts
@@ -12,6 +12,8 @@ import {
     getStructEncoder,
     getU32Decoder,
     getU32Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type Address,
@@ -114,8 +116,10 @@ export function parseUpgradeNonceAccountInstruction<
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedUpgradeNonceAccountInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 1) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 1,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/system/src/generated/instructions/withdrawNonceAccount.ts
+++ b/test/e2e/system/src/generated/instructions/withdrawNonceAccount.ts
@@ -14,6 +14,8 @@ import {
     getU32Encoder,
     getU64Decoder,
     getU64Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type AccountSignerMeta,
@@ -208,8 +210,10 @@ export function parseWithdrawNonceAccountInstruction<
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedWithdrawNonceAccountInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 5) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 5,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/system/src/generated/programs/system.ts
+++ b/test/e2e/system/src/generated/programs/system.ts
@@ -10,6 +10,9 @@ import {
     assertIsInstructionWithAccounts,
     containsBytes,
     getU32Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_INSTRUCTION,
+    SOLANA_ERROR__PROGRAM_CLIENTS__UNRECOGNIZED_INSTRUCTION_TYPE,
+    SolanaError,
     type Address,
     type Instruction,
     type InstructionWithData,
@@ -109,7 +112,10 @@ export function identifySystemInstruction(
     if (containsBytes(data, getU32Encoder().encode(12), 0)) {
         return SystemInstruction.UpgradeNonceAccount;
     }
-    throw new Error('The provided instruction could not be identified as a system instruction.');
+    throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_INSTRUCTION, {
+        instructionData: data,
+        programName: 'system',
+    });
 }
 
 export type ParsedSystemInstruction<TProgram extends string = '11111111111111111111111111111111'> =
@@ -214,6 +220,9 @@ export function parseSystemInstruction<TProgram extends string>(
             };
         }
         default:
-            throw new Error(`Unrecognized instruction type: ${instructionType as string}`);
+            throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__UNRECOGNIZED_INSTRUCTION_TYPE, {
+                instructionType: instructionType as string,
+                programName: 'system',
+            });
     }
 }

--- a/test/e2e/token/src/generated/instructions/amountToUiAmount.ts
+++ b/test/e2e/token/src/generated/instructions/amountToUiAmount.ts
@@ -14,6 +14,8 @@ import {
     getU64Encoder,
     getU8Decoder,
     getU8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type Address,
@@ -129,8 +131,10 @@ export function parseAmountToUiAmountInstruction<TProgram extends string, TAccou
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedAmountToUiAmountInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 1) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 1,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/token/src/generated/instructions/approve.ts
+++ b/test/e2e/token/src/generated/instructions/approve.ts
@@ -15,6 +15,8 @@ import {
     getU64Encoder,
     getU8Decoder,
     getU8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type AccountSignerMeta,
@@ -183,8 +185,10 @@ export function parseApproveInstruction<TProgram extends string, TAccountMetas e
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedApproveInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 3) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 3,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/token/src/generated/instructions/approveChecked.ts
+++ b/test/e2e/token/src/generated/instructions/approveChecked.ts
@@ -15,6 +15,8 @@ import {
     getU64Encoder,
     getU8Decoder,
     getU8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type AccountSignerMeta,
@@ -205,8 +207,10 @@ export function parseApproveCheckedInstruction<TProgram extends string, TAccount
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedApproveCheckedInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 4) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 4,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/token/src/generated/instructions/burn.ts
+++ b/test/e2e/token/src/generated/instructions/burn.ts
@@ -15,6 +15,8 @@ import {
     getU64Encoder,
     getU8Decoder,
     getU8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type AccountSignerMeta,
@@ -180,8 +182,10 @@ export function parseBurnInstruction<TProgram extends string, TAccountMetas exte
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedBurnInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 3) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 3,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/token/src/generated/instructions/burnChecked.ts
+++ b/test/e2e/token/src/generated/instructions/burnChecked.ts
@@ -15,6 +15,8 @@ import {
     getU64Encoder,
     getU8Decoder,
     getU8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type AccountSignerMeta,
@@ -193,8 +195,10 @@ export function parseBurnCheckedInstruction<TProgram extends string, TAccountMet
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedBurnCheckedInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 3) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 3,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/token/src/generated/instructions/closeAccount.ts
+++ b/test/e2e/token/src/generated/instructions/closeAccount.ts
@@ -13,6 +13,8 @@ import {
     getStructEncoder,
     getU8Decoder,
     getU8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type AccountSignerMeta,
@@ -170,8 +172,10 @@ export function parseCloseAccountInstruction<TProgram extends string, TAccountMe
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedCloseAccountInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 3) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 3,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/token/src/generated/instructions/createAccount.ts
+++ b/test/e2e/token/src/generated/instructions/createAccount.ts
@@ -19,6 +19,8 @@ import {
     getU32Encoder,
     getU64Decoder,
     getU64Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type AccountSignerMeta,
@@ -162,8 +164,10 @@ export function parseCreateAccountInstruction<TProgram extends string, TAccountM
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedCreateAccountInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 2) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 2,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/token/src/generated/instructions/createAssociatedToken.ts
+++ b/test/e2e/token/src/generated/instructions/createAssociatedToken.ts
@@ -12,6 +12,8 @@ import {
     getStructEncoder,
     getU8Decoder,
     getU8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type AccountSignerMeta,
@@ -324,8 +326,10 @@ export function parseCreateAssociatedTokenInstruction<
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedCreateAssociatedTokenInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 6) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 6,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/token/src/generated/instructions/createAssociatedTokenIdempotent.ts
+++ b/test/e2e/token/src/generated/instructions/createAssociatedTokenIdempotent.ts
@@ -12,6 +12,8 @@ import {
     getStructEncoder,
     getU8Decoder,
     getU8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type AccountSignerMeta,
@@ -324,8 +326,10 @@ export function parseCreateAssociatedTokenIdempotentInstruction<
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedCreateAssociatedTokenIdempotentInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 6) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 6,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/token/src/generated/instructions/freezeAccount.ts
+++ b/test/e2e/token/src/generated/instructions/freezeAccount.ts
@@ -13,6 +13,8 @@ import {
     getStructEncoder,
     getU8Decoder,
     getU8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type AccountSignerMeta,
@@ -170,8 +172,10 @@ export function parseFreezeAccountInstruction<TProgram extends string, TAccountM
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedFreezeAccountInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 3) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 3,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/token/src/generated/instructions/getAccountDataSize.ts
+++ b/test/e2e/token/src/generated/instructions/getAccountDataSize.ts
@@ -12,6 +12,8 @@ import {
     getStructEncoder,
     getU8Decoder,
     getU8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type Address,
@@ -113,8 +115,10 @@ export function parseGetAccountDataSizeInstruction<
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedGetAccountDataSizeInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 1) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 1,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/token/src/generated/instructions/initializeAccount.ts
+++ b/test/e2e/token/src/generated/instructions/initializeAccount.ts
@@ -12,6 +12,8 @@ import {
     getStructEncoder,
     getU8Decoder,
     getU8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type Address,
@@ -159,8 +161,10 @@ export function parseInitializeAccountInstruction<
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedInitializeAccountInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 4) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 4,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/token/src/generated/instructions/initializeAccount2.ts
+++ b/test/e2e/token/src/generated/instructions/initializeAccount2.ts
@@ -14,6 +14,8 @@ import {
     getStructEncoder,
     getU8Decoder,
     getU8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type Address,
@@ -168,8 +170,10 @@ export function parseInitializeAccount2Instruction<
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedInitializeAccount2Instruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 3) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 3,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/token/src/generated/instructions/initializeAccount3.ts
+++ b/test/e2e/token/src/generated/instructions/initializeAccount3.ts
@@ -14,6 +14,8 @@ import {
     getStructEncoder,
     getU8Decoder,
     getU8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type Address,
@@ -146,8 +148,10 @@ export function parseInitializeAccount3Instruction<
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedInitializeAccount3Instruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 2) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 2,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/token/src/generated/instructions/initializeImmutableOwner.ts
+++ b/test/e2e/token/src/generated/instructions/initializeImmutableOwner.ts
@@ -12,6 +12,8 @@ import {
     getStructEncoder,
     getU8Decoder,
     getU8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type Address,
@@ -116,8 +118,10 @@ export function parseInitializeImmutableOwnerInstruction<
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedInitializeImmutableOwnerInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 1) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 1,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/token/src/generated/instructions/initializeMint.ts
+++ b/test/e2e/token/src/generated/instructions/initializeMint.ts
@@ -17,6 +17,8 @@ import {
     getU8Decoder,
     getU8Encoder,
     none,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type Address,
@@ -172,8 +174,10 @@ export function parseInitializeMintInstruction<TProgram extends string, TAccount
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedInitializeMintInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 2) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 2,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/token/src/generated/instructions/initializeMint2.ts
+++ b/test/e2e/token/src/generated/instructions/initializeMint2.ts
@@ -17,6 +17,8 @@ import {
     getU8Decoder,
     getU8Encoder,
     none,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type Address,
@@ -152,8 +154,10 @@ export function parseInitializeMint2Instruction<TProgram extends string, TAccoun
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedInitializeMint2Instruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 1) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 1,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/token/src/generated/instructions/initializeMultisig.ts
+++ b/test/e2e/token/src/generated/instructions/initializeMultisig.ts
@@ -13,6 +13,8 @@ import {
     getStructEncoder,
     getU8Decoder,
     getU8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type Address,
@@ -159,8 +161,10 @@ export function parseInitializeMultisigInstruction<
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedInitializeMultisigInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 2) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 2,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/token/src/generated/instructions/initializeMultisig2.ts
+++ b/test/e2e/token/src/generated/instructions/initializeMultisig2.ts
@@ -13,6 +13,8 @@ import {
     getStructEncoder,
     getU8Decoder,
     getU8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type Address,
@@ -135,8 +137,10 @@ export function parseInitializeMultisig2Instruction<
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedInitializeMultisig2Instruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 1) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 1,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/token/src/generated/instructions/mintTo.ts
+++ b/test/e2e/token/src/generated/instructions/mintTo.ts
@@ -15,6 +15,8 @@ import {
     getU64Encoder,
     getU8Decoder,
     getU8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type AccountSignerMeta,
@@ -183,8 +185,10 @@ export function parseMintToInstruction<TProgram extends string, TAccountMetas ex
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedMintToInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 3) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 3,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/token/src/generated/instructions/mintToChecked.ts
+++ b/test/e2e/token/src/generated/instructions/mintToChecked.ts
@@ -15,6 +15,8 @@ import {
     getU64Encoder,
     getU8Decoder,
     getU8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type AccountSignerMeta,
@@ -193,8 +195,10 @@ export function parseMintToCheckedInstruction<TProgram extends string, TAccountM
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedMintToCheckedInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 3) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 3,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/token/src/generated/instructions/recoverNestedAssociatedToken.ts
+++ b/test/e2e/token/src/generated/instructions/recoverNestedAssociatedToken.ts
@@ -12,6 +12,8 @@ import {
     getStructEncoder,
     getU8Decoder,
     getU8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type AccountSignerMeta,
@@ -380,8 +382,10 @@ export function parseRecoverNestedAssociatedTokenInstruction<
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedRecoverNestedAssociatedTokenInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 7) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 7,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/token/src/generated/instructions/revoke.ts
+++ b/test/e2e/token/src/generated/instructions/revoke.ts
@@ -13,6 +13,8 @@ import {
     getStructEncoder,
     getU8Decoder,
     getU8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type AccountSignerMeta,
@@ -152,8 +154,10 @@ export function parseRevokeInstruction<TProgram extends string, TAccountMetas ex
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedRevokeInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 2) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 2,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/token/src/generated/instructions/setAuthority.ts
+++ b/test/e2e/token/src/generated/instructions/setAuthority.ts
@@ -17,6 +17,8 @@ import {
     getStructEncoder,
     getU8Decoder,
     getU8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type AccountSignerMeta,
@@ -183,8 +185,10 @@ export function parseSetAuthorityInstruction<TProgram extends string, TAccountMe
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedSetAuthorityInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 2) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 2,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/token/src/generated/instructions/syncNative.ts
+++ b/test/e2e/token/src/generated/instructions/syncNative.ts
@@ -12,6 +12,8 @@ import {
     getStructEncoder,
     getU8Decoder,
     getU8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type Address,
@@ -110,8 +112,10 @@ export function parseSyncNativeInstruction<TProgram extends string, TAccountMeta
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedSyncNativeInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 1) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 1,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/token/src/generated/instructions/thawAccount.ts
+++ b/test/e2e/token/src/generated/instructions/thawAccount.ts
@@ -13,6 +13,8 @@ import {
     getStructEncoder,
     getU8Decoder,
     getU8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type AccountSignerMeta,
@@ -170,8 +172,10 @@ export function parseThawAccountInstruction<TProgram extends string, TAccountMet
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedThawAccountInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 3) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 3,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/token/src/generated/instructions/transfer.ts
+++ b/test/e2e/token/src/generated/instructions/transfer.ts
@@ -15,6 +15,8 @@ import {
     getU64Encoder,
     getU8Decoder,
     getU8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type AccountSignerMeta,
@@ -186,8 +188,10 @@ export function parseTransferInstruction<TProgram extends string, TAccountMetas 
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedTransferInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 3) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 3,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/token/src/generated/instructions/transferChecked.ts
+++ b/test/e2e/token/src/generated/instructions/transferChecked.ts
@@ -15,6 +15,8 @@ import {
     getU64Encoder,
     getU8Decoder,
     getU8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type AccountSignerMeta,
@@ -205,8 +207,10 @@ export function parseTransferCheckedInstruction<TProgram extends string, TAccoun
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedTransferCheckedInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 4) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 4,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/token/src/generated/instructions/uiAmountToAmount.ts
+++ b/test/e2e/token/src/generated/instructions/uiAmountToAmount.ts
@@ -14,6 +14,8 @@ import {
     getU8Encoder,
     getUtf8Decoder,
     getUtf8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+    SolanaError,
     transformEncoder,
     type AccountMeta,
     type Address,
@@ -129,8 +131,10 @@ export function parseUiAmountToAmountInstruction<TProgram extends string, TAccou
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedUiAmountToAmountInstruction<TProgram, TAccountMetas> {
     if (instruction.accounts.length < 1) {
-        // TODO: Coded error.
-        throw new Error('Not enough accounts');
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
+            actualAccountMetas: instruction.accounts.length,
+            expectedAccountMetas: 1,
+        });
     }
     let accountIndex = 0;
     const getNextAccount = () => {

--- a/test/e2e/token/src/generated/programs/associatedToken.ts
+++ b/test/e2e/token/src/generated/programs/associatedToken.ts
@@ -10,6 +10,9 @@ import {
     assertIsInstructionWithAccounts,
     containsBytes,
     getU8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_INSTRUCTION,
+    SOLANA_ERROR__PROGRAM_CLIENTS__UNRECOGNIZED_INSTRUCTION_TYPE,
+    SolanaError,
     type Address,
     type Instruction,
     type InstructionWithData,
@@ -46,7 +49,10 @@ export function identifyAssociatedTokenInstruction(
     if (containsBytes(data, getU8Encoder().encode(2), 0)) {
         return AssociatedTokenInstruction.RecoverNestedAssociatedToken;
     }
-    throw new Error('The provided instruction could not be identified as a associatedToken instruction.');
+    throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_INSTRUCTION, {
+        instructionData: data,
+        programName: 'associatedToken',
+    });
 }
 
 export type ParsedAssociatedTokenInstruction<TProgram extends string = 'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL'> =
@@ -87,6 +93,9 @@ export function parseAssociatedTokenInstruction<TProgram extends string>(
             };
         }
         default:
-            throw new Error(`Unrecognized instruction type: ${instructionType as string}`);
+            throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__UNRECOGNIZED_INSTRUCTION_TYPE, {
+                instructionType: instructionType as string,
+                programName: 'associatedToken',
+            });
     }
 }

--- a/test/e2e/token/src/generated/programs/system.ts
+++ b/test/e2e/token/src/generated/programs/system.ts
@@ -10,6 +10,9 @@ import {
     assertIsInstructionWithAccounts,
     containsBytes,
     getU32Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_INSTRUCTION,
+    SOLANA_ERROR__PROGRAM_CLIENTS__UNRECOGNIZED_INSTRUCTION_TYPE,
+    SolanaError,
     type Address,
     type Instruction,
     type InstructionWithData,
@@ -30,7 +33,10 @@ export function identifySystemInstruction(
     if (containsBytes(data, getU32Encoder().encode(0), 0)) {
         return SystemInstruction.CreateAccount;
     }
-    throw new Error('The provided instruction could not be identified as a system instruction.');
+    throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_INSTRUCTION, {
+        instructionData: data,
+        programName: 'system',
+    });
 }
 
 export type ParsedSystemInstruction<TProgram extends string = '11111111111111111111111111111111'> = {
@@ -47,6 +53,9 @@ export function parseSystemInstruction<TProgram extends string>(
             return { instructionType: SystemInstruction.CreateAccount, ...parseCreateAccountInstruction(instruction) };
         }
         default:
-            throw new Error(`Unrecognized instruction type: ${instructionType as string}`);
+            throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__UNRECOGNIZED_INSTRUCTION_TYPE, {
+                instructionType: instructionType as string,
+                programName: 'system',
+            });
     }
 }

--- a/test/e2e/token/src/generated/programs/token.ts
+++ b/test/e2e/token/src/generated/programs/token.ts
@@ -10,6 +10,10 @@ import {
     assertIsInstructionWithAccounts,
     containsBytes,
     getU8Encoder,
+    SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_ACCOUNT,
+    SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_INSTRUCTION,
+    SOLANA_ERROR__PROGRAM_CLIENTS__UNRECOGNIZED_INSTRUCTION_TYPE,
+    SolanaError,
     type Address,
     type Instruction,
     type InstructionWithData,
@@ -88,7 +92,10 @@ export function identifyTokenAccount(account: { data: ReadonlyUint8Array } | Rea
     if (data.length === 355) {
         return TokenAccount.Multisig;
     }
-    throw new Error('The provided account could not be identified as a token account.');
+    throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_ACCOUNT, {
+        accountData: data,
+        programName: 'token',
+    });
 }
 
 export enum TokenInstruction {
@@ -198,7 +205,10 @@ export function identifyTokenInstruction(
     if (containsBytes(data, getU8Encoder().encode(24), 0)) {
         return TokenInstruction.UiAmountToAmount;
     }
-    throw new Error('The provided instruction could not be identified as a token instruction.');
+    throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_INSTRUCTION, {
+        instructionData: data,
+        programName: 'token',
+    });
 }
 
 export type ParsedTokenInstruction<TProgram extends string = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'> =
@@ -369,6 +379,9 @@ export function parseTokenInstruction<TProgram extends string>(
             };
         }
         default:
-            throw new Error(`Unrecognized instruction type: ${instructionType as string}`);
+            throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__UNRECOGNIZED_INSTRUCTION_TYPE, {
+                instructionType: instructionType as string,
+                programName: 'token',
+            });
     }
 }

--- a/test/programsPage.test.ts
+++ b/test/programsPage.test.ts
@@ -95,13 +95,18 @@ test('it renders an function that identifies accounts in a program', async () =>
             `const data = 'data' in account ? account.data : account; ` +
             `if ( containsBytes(data, getU8Encoder().encode(5), 0) ) { return SplTokenAccount.Metadata; } ` +
             `if ( data.length === 72 && containsBytes(data, new Uint8Array([1, 2, 3]), 4) ) { return SplTokenAccount.Token; } ` +
-            `throw new Error ( 'The provided account could not be identified as a splToken account.' ); ` +
+            `throw new SolanaError( SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_ACCOUNT, { accountData: data, programName: 'splToken' } ); ` +
             `}`,
     ]);
 
     // And we expect the following imports.
     await renderMapContainsImports(renderMap, 'programs/splToken.ts', {
-        '@solana/kit': ['containsBytes', 'ReadonlyUint8Array'],
+        '@solana/kit': [
+            'containsBytes',
+            'ReadonlyUint8Array',
+            'SolanaError',
+            'SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_ACCOUNT',
+        ],
     });
 });
 
@@ -167,7 +172,7 @@ test('it renders an function that identifies instructions in a program', async (
             `const data = 'data' in instruction ? instruction.data : instruction; ` +
             `if ( containsBytes(data, getU8Encoder().encode(1), 0) ) { return SplTokenInstruction.MintTokens; } ` +
             `if ( data.length === 72 && containsBytes(data, new Uint8Array([1, 2, 3]), 4) ) { return SplTokenInstruction.TransferTokens; } ` +
-            `throw new Error( 'The provided instruction could not be identified as a splToken instruction.' ); ` +
+            `throw new SolanaError( SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_INSTRUCTION, { instructionData: data, programName: 'splToken' } ); ` +
             `}`,
     ]);
 


### PR DESCRIPTION
This PR updates generated program clients to use `SolanaError` from `@solana/kit` instead of throwing generic `Error` objects. This improves error handling by providing specific error codes and structured context.