### PR TITLE
Bump `@solana/kit` to v6.1.0

### DIFF
--- a/test/e2e/anchor/package.json
+++ b/test/e2e/anchor/package.json
@@ -11,7 +11,7 @@
         "lint:fix": "eslint --fix --ext js,ts,tsx src && prettier --write src test"
     },
     "dependencies": {
-        "@solana/kit": "^6.0.0"
+        "@solana/kit": "^6.1.0"
     },
     "license": "MIT",
     "ava": {

--- a/test/e2e/dummy/package.json
+++ b/test/e2e/dummy/package.json
@@ -11,7 +11,7 @@
         "lint:fix": "eslint --fix --ext js,ts,tsx src && prettier --write src test"
     },
     "dependencies": {
-        "@solana/kit": "^6.0.0"
+        "@solana/kit": "^6.1.0"
     },
     "license": "MIT",
     "ava": {

--- a/test/e2e/memo/package.json
+++ b/test/e2e/memo/package.json
@@ -11,7 +11,7 @@
         "lint:fix": "eslint --fix --ext js,ts,tsx src && prettier --write src test"
     },
     "dependencies": {
-        "@solana/kit": "^6.0.0"
+        "@solana/kit": "^6.1.0"
     },
     "license": "MIT",
     "ava": {

--- a/test/e2e/pnpm-lock.yaml
+++ b/test/e2e/pnpm-lock.yaml
@@ -48,32 +48,32 @@ importers:
   anchor:
     dependencies:
       '@solana/kit':
-        specifier: ^6.0.0
-        version: 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+        specifier: ^6.1.0
+        version: 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
 
   dummy:
     dependencies:
       '@solana/kit':
-        specifier: ^6.0.0
-        version: 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+        specifier: ^6.1.0
+        version: 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
 
   memo:
     dependencies:
       '@solana/kit':
-        specifier: ^6.0.0
-        version: 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+        specifier: ^6.1.0
+        version: 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
 
   system:
     dependencies:
       '@solana/kit':
-        specifier: ^6.0.0
-        version: 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+        specifier: ^6.1.0
+        version: 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
 
   token:
     dependencies:
       '@solana/kit':
-        specifier: ^6.0.0
-        version: 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+        specifier: ^6.1.0
+        version: 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
 
 packages:
 
@@ -461,8 +461,8 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
-  '@solana/accounts@6.0.0':
-    resolution: {integrity: sha512-GXUYH8pjp5Z4dchhfjf1buO8Y0x9wlcfAHlKQLUmkFPcq6m9REpD+PKWuELC3v57mdwiR1sIj3V2lCwcWpoOQA==}
+  '@solana/accounts@6.1.0':
+    resolution: {integrity: sha512-0jhmhSSS71ClLtBQIDrLlhkiNER4M9RIXTl1eJ1yJoFlE608JaKHTjNWsdVKdke7uBD6exdjNZkIVmouQPHMcA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -470,8 +470,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/addresses@6.0.0':
-    resolution: {integrity: sha512-CLjTy1iPFaTf34JFn9yugAin4DVcFY4YzuCzUDazixehRW0w1022zpZpYBexCdl+koI0WrHi/rbiUYYFJN9HWw==}
+  '@solana/addresses@6.1.0':
+    resolution: {integrity: sha512-QT04Vie4iICaalQQRJFMGj/P56IxXiwFtVuZHu1qjZUNmuGTOvX6G98b27RaGtLzpJ3NIku/6OtKxLUBqAKAyQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -479,8 +479,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/assertions@6.0.0':
-    resolution: {integrity: sha512-9XUNDkDMrqd2+uYYFKTixQZ3w6PCmMmkScn/3Dv9RwDwl8v+T9tZUxUo1N06q+oQ8dhZPbjfqmvMh26204rNag==}
+  '@solana/assertions@6.1.0':
+    resolution: {integrity: sha512-pLgxB2xxTk2QfTaWpnRpSMYgaPkKYDQgptRvbwmuDQnOW1Zopg+42MT2UrDGd3UFMML1uOFPxIwKM6m51H0uXw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -488,8 +488,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-core@6.0.0':
-    resolution: {integrity: sha512-QAXMupK1nPaIeZgeLTwvC15zeMSbjgupHpcSRoAtcjEs1po4UVPSk7H+IAReRoK2ah2HXHARP3ktzY9x5LY2qQ==}
+  '@solana/codecs-core@6.1.0':
+    resolution: {integrity: sha512-5rNnDOOm2GRFMJbd9imYCPNvGOrQ+TZ53NCkFFWbbB7f+L9KkLeuuAsDMFN1lCziJFlymvN785YtDnMeWj2W+g==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -497,8 +497,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-data-structures@6.0.0':
-    resolution: {integrity: sha512-xv89Ap0o9zDF0cuBIMJwiLQydjRJYuELWJMpCJthmQWuQmUBlZsPlBra00x/c/W9dh0RRrDRF7PrwLyC0ONIyg==}
+  '@solana/codecs-data-structures@6.1.0':
+    resolution: {integrity: sha512-1cb9g5hrrucTuGkGxqVVq7dCwSMnn4YqwTe365iKkK8HBpLBmUl8XATf1MUs5UtDun1g9eNWOL72Psr8mIUqTQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -506,8 +506,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-numbers@6.0.0':
-    resolution: {integrity: sha512-OpnK2c9NGLQG3P8hec+rwHzOwe/H74NKxsWSpc87qJE0HpTZ9sPNtsjyjy9Lwt8Jl2zSR/WpEw77eikbCuNMzA==}
+  '@solana/codecs-numbers@6.1.0':
+    resolution: {integrity: sha512-YPQwwl6LE3igH23ah+d8kgpyE5xFcPbuwhxCDsLWqY/ESrvO/0YQSbsgIXahbhZxN59ZC4uq1LnHhBNbpCSVQg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -515,8 +515,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-strings@6.0.0':
-    resolution: {integrity: sha512-JZ+yPYMikkOzofbawnQ4OJ8LEusx2lspDXtUdZ6bf+99E+00x9HCbv0uiXykN8HPh5fampJVfC+6egaRgJl/dg==}
+  '@solana/codecs-strings@6.1.0':
+    resolution: {integrity: sha512-pRH5uAn4VCFUs2rYiDITyWsRnpvs3Uh/nhSc6OSP/kusghcCcCJcUzHBIjT4x08MVacXmGUlSLe/9qPQO+QK3Q==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
@@ -527,8 +527,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs@6.0.0':
-    resolution: {integrity: sha512-DOpHjVZnKLudP9T4kzHHkAi9HjZ3qKNYkQnX+0LzOCKY9pikjSJGBeSrsUTWTmcJCVug1z7FB2kPILAKYaIDHg==}
+  '@solana/codecs@6.1.0':
+    resolution: {integrity: sha512-VHBS3t8fyVjE0Nqo6b4TUnzdwdRaVo+B5ufHhPLbbjkEXzz8HB4E/OBjgasn+zWGlfScfQAiBFOsfZjbVWu4XA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -536,8 +536,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/errors@6.0.0':
-    resolution: {integrity: sha512-U/9vwUpUKnRsHGgoNwcoh8d/B4Y9LKBBfraUQcCG97duK7SfAlP2QTZQbNqVS/tcuIRXBuKCS81WPmMQL5r4Nw==}
+  '@solana/errors@6.1.0':
+    resolution: {integrity: sha512-cqSwcw3Rmn85UR7PyF5nKPdlQsRYBkx7YGRvFaJ6Sal1PM+bfolhL5iT7STQoXxdhXGYwHMPg7kZYxmMdjwnJA==}
     engines: {node: '>=20.18.0'}
     hasBin: true
     peerDependencies:
@@ -559,8 +559,8 @@ packages:
       eslint-plugin-typescript-sort-keys: ^3.2.0
       typescript: ^5.1.6
 
-  '@solana/fast-stable-stringify@6.0.0':
-    resolution: {integrity: sha512-wO0k7MaVXyk5bgeNnP8yu7EEGsuIamLd4RU9GOe1ztmykOZTloT4oGRIq1hLNAg4z6yOg17ejJMVJJuM7fHqJQ==}
+  '@solana/fast-stable-stringify@6.1.0':
+    resolution: {integrity: sha512-QXUfDFaJCFeARsxJgScWmJ153Tit7Cimk9y0UWWreNBr2Aphi67Nlcj/tr7UABTO0Qaw/0gwrK76zz3m1t3nIw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -568,8 +568,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/functional@6.0.0':
-    resolution: {integrity: sha512-n7S/Q/ZtPEAwIqp5PDUpStCXV7zgTveqma9liie16hSWDdrheabA4T2xfUgOxk/tdmOOt562yhgQ5Ltbcbs8Bw==}
+  '@solana/functional@6.1.0':
+    resolution: {integrity: sha512-+Sm8ldVxSTHIKaZDvcBu81FPjknXx6OMPlakkKmXjKxPgVLl86ruqMo2yEwoDUHV7DysLrLLcRNn13rfulomRw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -577,8 +577,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/instruction-plans@6.0.0':
-    resolution: {integrity: sha512-LTPZDzr9MBAzuzvYD9gh1Av51RrHz5JveoJ4wVSN/aFlJlsW2TVx2eM+ThirOyn5qx9mh7k4tVH1jeFBypt6pQ==}
+  '@solana/instruction-plans@6.1.0':
+    resolution: {integrity: sha512-zcsHg544t1zn7LLOVUxOWYlsKn9gvT7R+pL3cTiP2wFNoUN0h9En87H6nVqkZ8LWw23asgW0uM5uJGwfBx2h1Q==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -586,8 +586,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/instructions@6.0.0':
-    resolution: {integrity: sha512-C23F5l8hOeEEwsatDZsui0bykmqNU6WLrjpHmRFad6hNYbxTMEflxnY0nXmaVakZ788K6BpgCWL8kRNhPs2ftg==}
+  '@solana/instructions@6.1.0':
+    resolution: {integrity: sha512-w1LdbJ3yanESckNTYC5KPckgN/25FyGCm07WWrs+dCnnpRNeLiVHIytXCPmArOVAXVkOYidXzhWmqCzqKUjYaA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -595,8 +595,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/keys@6.0.0':
-    resolution: {integrity: sha512-tK65D8/Jcg+FDYm4a+MiiObjwba/8kpZiE5lpSEUfhtizPxMacIj90aUoYny9aWGJfz6bDVl9lx2Wubal8qJSQ==}
+  '@solana/keys@6.1.0':
+    resolution: {integrity: sha512-C/SGCl3VOgBQZ0mLrMxCcJYnMsGpgE8wbx29jqRY+R91m5YhS1f/GfXJPR1lN/h7QGrJ6YDm8eI0Y3AZ7goKHg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -604,8 +604,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/kit@6.0.0':
-    resolution: {integrity: sha512-on7r4V/MUTE4xTz0MFWJh3RVK/l5M2ZXh5diebH/HDP3VTSAh/RQYAamVZzzwhypCUREMVVo88Z2CZzeCO4r4Q==}
+  '@solana/kit@6.1.0':
+    resolution: {integrity: sha512-24exn11BPonquufyCkGgypVtmN4JOsdGMsbF3EZ4kFyk7ZNryCn/N8eELr1FCVrHWRXoc0xy/HFaESBULTMf6g==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -613,8 +613,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/nominal-types@6.0.0':
-    resolution: {integrity: sha512-YCu22EXj0CeTAbUrXLn4pmtWF/NXu1rAUIxmSdIUx6WGjzSqtpeExIfnyKkKoudYq1/cvqrPtzRIKQnze6uvAg==}
+  '@solana/nominal-types@6.1.0':
+    resolution: {integrity: sha512-+skHjN0arNNB9TLsGqA94VCx7euyGURI+qG6wck6E4D7hH6i6DxGiVrtKRghx+smJkkLtTm9BvdVKGoeNQYr7Q==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -622,8 +622,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/offchain-messages@6.0.0':
-    resolution: {integrity: sha512-6hnMD6PSItNwrYMk9dyN1T55vpsRXpN/vdryl2P2zVX0o7G01QpRcG8li9EBRomd+D9EYwbefGYG0eE3kYjJ8A==}
+  '@solana/offchain-messages@6.1.0':
+    resolution: {integrity: sha512-jrUb7HGUnRA+k44upcqKeevtEdqMxYRSlFdE0JTctZunGlP3GCcTl12tFOpbnFHvBLt8RwS62+nyeES8zzNwXA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -631,8 +631,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/options@6.0.0':
-    resolution: {integrity: sha512-xeRCgmQyIlgn05uCnNiBU59m8p7L+zBehNKpMxrDTzVxUJyTJ7wzG0uVAPOctKeIweIieL91C6rWxwtWdSB4Sw==}
+  '@solana/options@6.1.0':
+    resolution: {integrity: sha512-/4FtVfR6nkHkMCumyh7/lJ6jMqyES6tKUbOJRa6gJxcIUWeRDu+XrHTHLf3gRNUqDAbFvW8FMIrQm7PdreZgRA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -640,8 +640,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/plugin-core@6.0.0':
-    resolution: {integrity: sha512-s0mdwbs4Y8oGbdniF1uwmpNO5SaxFzmO59+LeFInkN8m4Dm3L4vd85/HB0GOn4LlEFytRGGZyFntBdwwqQVy2g==}
+  '@solana/plugin-core@6.1.0':
+    resolution: {integrity: sha512-2nmNCPa6B1QArqpAZHWUkK6K7UXLTrekfcfJm2V//ATEtLpKEBlv0c3mrhOYwNAKP2TpNuvEV33InXWKst9oXQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -649,8 +649,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/programs@6.0.0':
-    resolution: {integrity: sha512-8rZeE5C3uhirkxQoatKskx7bhhcDjFy8ZiwhrMV30TEros9yJ4a+NiRgaIz4ghrK7YXSqeLcZ8fSHO3m3i9bPw==}
+  '@solana/plugin-interfaces@6.1.0':
+    resolution: {integrity: sha512-eWSzfOuwtHUp8vljf5V24Tkz3WxqxiV0vD/BJZBNRZMdYRw3Cw3oeWcvEqHHxGUOie6AjIK8GrKggi8F73ZXbg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -658,8 +658,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/promises@6.0.0':
-    resolution: {integrity: sha512-QPgBMv3+AmAPP/V3qAwPdT/hUNF1SilsiGXOKNuBMEXNMehKxVSp9FSzFddTCThOh6wsEVORqaUWQiO2v73eQQ==}
+  '@solana/program-client-core@6.1.0':
+    resolution: {integrity: sha512-5Apka+ulWNfLNLYNR63pLnr5XvkXTQWeaftWED93iTWTZrZv9SyFWcmIsaes6eqGXMQ3RhlebnrWODtKuAA62g==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -667,8 +667,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-api@6.0.0':
-    resolution: {integrity: sha512-h5e2xmd06FTur5wD1L9lcHPyr50a1HUTGSCipHVbKtnl3Iv5wsw06cMHW4NFH+jowpFRFUBVpC6s3oe0xgqKgg==}
+  '@solana/programs@6.1.0':
+    resolution: {integrity: sha512-i4L4gSlIHDsdYRt3/YKVKMIN3UuYSKHRqK9B+AejcIc0y6Y/AXnHqzmpBRXEhvTXz18nt59MLXpVU4wu7ASjJA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -676,8 +676,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-parsed-types@6.0.0':
-    resolution: {integrity: sha512-mt2j6Eq5x59ByKddxgNQ6vXIG4t0V8cSbgL2ka5XIGtfjaTuMbUIQdJsVRKI9HGBzdtaq06vZrqefP1uwUaBFg==}
+  '@solana/promises@6.1.0':
+    resolution: {integrity: sha512-/mUW6peXQiEOaylLpGv4vtkvPzQvSbfhX9j5PNIK/ry4S3SHRQ3j3W/oGy4y3LR5alwo7NcVbubrkh4e4xwcww==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -685,8 +685,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-spec-types@6.0.0':
-    resolution: {integrity: sha512-uUve/blzr3Y4LLd/cPN9zvG7+Xbcf9RMzbWCMX/DcS/sdJwMIEzo120MOed3wSP55gPWZAy1ltCipfboQh15lQ==}
+  '@solana/rpc-api@6.1.0':
+    resolution: {integrity: sha512-+hO5+kZjJHuUNATUQxlJ1+ztXFkgn1j46zRwt3X7kF+VHkW3wsQ7up0JTS+Xsacmkrj1WKfymQweq8JTrsAG8A==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -694,8 +694,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-spec@6.0.0':
-    resolution: {integrity: sha512-C3u495/dyVifdIV80DEm1CkPLZMpXTSJKLuFo9qXKOttQlL1lAn0yB31YqQ4X0i3TXqBYoFCdd6OHMCjsgIOUg==}
+  '@solana/rpc-parsed-types@6.1.0':
+    resolution: {integrity: sha512-YKccynVgWt/gbs0tBYstNw6BSVuOeWdeAldTB2OgH95o2Q04DpO4v97X1MZDysA4SvSZM30Ek5Ni5ss3kskgdw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -703,8 +703,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-subscriptions-api@6.0.0':
-    resolution: {integrity: sha512-rY/QAUuohvhSF1DtvES6IeEcVQRZHQiMHkWgkUKmIZsE5V6dblaJdgCHeFgvA/mXqrHptvZHbXn64YL/eMZy8Q==}
+  '@solana/rpc-spec-types@6.1.0':
+    resolution: {integrity: sha512-tldMv1b6VGcvcRrY5MDWKlsyEKH6K96zE7gAIpKDX2G4T47ZOV+OMA3nh6xQpRgtyCUBsej0t80qmvTBDX/5IQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -712,8 +712,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-subscriptions-channel-websocket@6.0.0':
-    resolution: {integrity: sha512-TOVroi154jIdrxDLbKaUycl0bt4BiG7gq9gj6LBiyRfRmpyTmin/1oyu5DlzYK9mZwUPNprNSsY8HxKvdK5rdg==}
+  '@solana/rpc-spec@6.1.0':
+    resolution: {integrity: sha512-RxpkIGizCYhXGUcap7npV2S/rAXZ7P/liozY/ExjMmCxYTDwGIW33kp/uH/JRxuzrL8+f8FqY76VsqqIe+2VZw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -721,8 +721,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-subscriptions-spec@6.0.0':
-    resolution: {integrity: sha512-bGGJtqPxZ9i8AbxMparzQxv+R9NvASIJkiVvsK2fDH7RT3faiT5WsTUAsZwUgjMthAJ+DBzPsn8pIGZy0DSyGg==}
+  '@solana/rpc-subscriptions-api@6.1.0':
+    resolution: {integrity: sha512-I6J+3VU0dda6EySKbDyd+1urC7RGIRPRp0DcWRVcy68NOLbq0I5C40Dn9O2Zf8iCdK4PbQ7JKdCvZ/bDd45hdg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -730,8 +730,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-subscriptions@6.0.0':
-    resolution: {integrity: sha512-xygy7r1gs33aQSWVYoyINcVXAAl2qaeZ3vP83B9hQM8rTkkOCjHbBg0IqOJSZAAEDauAwyjgEf4W1uD/sJGuKA==}
+  '@solana/rpc-subscriptions-channel-websocket@6.1.0':
+    resolution: {integrity: sha512-vsx9b+uyCr9L3giao/BTiBFA8DxV5+gDNFq0t5uL21uQ17JXzBektwzHuHoth9IjkvXV/h+IhwXfuLE9Qm4GQg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -739,8 +739,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-transformers@6.0.0':
-    resolution: {integrity: sha512-oKXmnz/lyTh/s+fgfiPKMtld8UMQ3gZC4GVWbjVxpb4rW9AG0c3sG1GCLy8oR5gf3MBQ4GJL3hdB1qRuNjj5Bg==}
+  '@solana/rpc-subscriptions-spec@6.1.0':
+    resolution: {integrity: sha512-P06jhqzHpZGaLeJmIQkpDeMDD1xUp53ARpmXMsduMC+U5ZKQt29CLo+JrR18boNtls6WfttjVMEbzF25/4UPVA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -748,8 +748,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-transport-http@6.0.0':
-    resolution: {integrity: sha512-oMuJTipZ+Pc8BOBRlYDRzhCYuY2UiqATnaBBuQvOPrkyuLTagPfVeLLt2jWHbPaJGdyaA2ynZjdrr+2tyo8nsA==}
+  '@solana/rpc-subscriptions@6.1.0':
+    resolution: {integrity: sha512-sqwj+cQinWcZ7M/9+cudKxMPTkTQyGP73980vPCWM7vCpPkp2qzgrEie4DdgDGo+NMwIjeFgu2kdUuLHI3GD/g==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -757,8 +757,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-types@6.0.0':
-    resolution: {integrity: sha512-nVoJhpDkP2URAr2y2byVEpAVCpdu2a4YB5Q8oIOGx8ZArSoIOF6AslfBbsQ/o8z03vRTj4yImUqG5QlCpUbbGg==}
+  '@solana/rpc-transformers@6.1.0':
+    resolution: {integrity: sha512-OsSuuRPmsmS02eR9Zz+4iTsr+21hvEMEex5vwbwN6LAGPFlQ4ohqGkxgZCwmYd+Q5HWpnn9Uuf1MDTLLrKQkig==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -766,8 +766,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc@6.0.0':
-    resolution: {integrity: sha512-5Zj4AFQJ0EmjOPHqAFMEtz5QCIbaIlZvSV9J1PpcboYcLi76D/PsrVjGWd+fVGXtH7yQBGlvcqz8ii5SnC+94A==}
+  '@solana/rpc-transport-http@6.1.0':
+    resolution: {integrity: sha512-3ebaTYuglLJagaXtjwDPVI7SQeeeFN2fpetpGKsuMAiti4fzYqEkNN8FIo+nXBzqqG/cVc2421xKjXl6sO1k/g==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -775,8 +775,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/signers@6.0.0':
-    resolution: {integrity: sha512-exRckoX8lopatMkj57h4ZEpdGAlDhWdzEFjL0LCoIMToW6axj2KA2Y2Wy/3i6cON6utZ2Sw/qp2SStiA4sXt4g==}
+  '@solana/rpc-types@6.1.0':
+    resolution: {integrity: sha512-lR+Cb3v5Rpl49HsXWASy++TSE1AD86eRKabY+iuWnbBMYVGI4MamAvYwgBiygsCNc30nyO2TFNj9STMeSD/gAg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -784,8 +784,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/subscribable@6.0.0':
-    resolution: {integrity: sha512-7pHAmXiR4VM7gh2ewLd5ZFhiyj8w4Aog7PJm7DdXyu4W1zAqXhyfSkieXgAr7naTY5WMP88ksCO7Jr1IGwTBrA==}
+  '@solana/rpc@6.1.0':
+    resolution: {integrity: sha512-R3y5PklW9mPy5Y34hsXj40R28zN2N7AGLnHqYJVkXkllwVub/QCNpSdDxAnbbS5EGOYGoUOW8s5LFoXwMSr1LQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -793,8 +793,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/sysvars@6.0.0':
-    resolution: {integrity: sha512-sahWeO8XBqE07gCDG5vVTyQeNULZybu2f+e0+U5/ATMEbyzGlgmCpdee7hQb0rlAcctju11SdQqe+GbAjqI/Lg==}
+  '@solana/signers@6.1.0':
+    resolution: {integrity: sha512-WDPGZJr6jIe2dEChv/2KQBnaga8dqOjd6ceBj/HcDHxnCudo66t7GlyZ9+9jMO40AgOOb7EDE5FDqPMrHMg5Yw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -802,8 +802,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/transaction-confirmation@6.0.0':
-    resolution: {integrity: sha512-VOGET4uyddD15VQ3oBVibSv9aX9OKqm7IHp1Noz0It6K40rMKfXK3a1oq7fsARXz0hkaM1NURWmD+zDQ/YYqaQ==}
+  '@solana/subscribable@6.1.0':
+    resolution: {integrity: sha512-HiUfkxN7638uxPmY4t0gI4+yqnFLZYJKFaT9EpWIuGrOB1d9n+uOHNs3NU7cVMwWXgfZUbztTCKyCVTbcwesNg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -811,8 +811,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/transaction-messages@6.0.0':
-    resolution: {integrity: sha512-Io3KP6lV7AndF9jhMOzCgaLDeIT5Cf5tDl0aTPKtxHOOvqGwI5QQfdlrUsAi1eiQ3lBocgVyjzt8C0me7PKdog==}
+  '@solana/sysvars@6.1.0':
+    resolution: {integrity: sha512-KwJyBBrAOx0BgkiZqOKAaySDb/0JrUFSBQL9/O1kSKGy9TCRX55Ytr1HxNTcTPppWNpbM6JZVK+yW3Ruey0HRw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -820,8 +820,26 @@ packages:
       typescript:
         optional: true
 
-  '@solana/transactions@6.0.0':
-    resolution: {integrity: sha512-WevpHlekdsT5Jx1Emh3wmRLD8GgxvpE8pohcRItjD5Q0hquihYyIF/l3i3EIZb5D6JKn+FQpa2SmLVd0DDotwQ==}
+  '@solana/transaction-confirmation@6.1.0':
+    resolution: {integrity: sha512-akSjcqAMOGPFvKctFDSzhjcRc/45WbEVdVQ9mjgH6OYo7B11WZZZaeGPlzAw5KyuG34Px941xmICkBmNqEH47Q==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/transaction-messages@6.1.0':
+    resolution: {integrity: sha512-Dpv54LRVcfFbFEa/uB53LaY/TRfKuPGMKR7Z4F290zBgkj9xkpZkI+WLiJBiSloI7Qo2KZqXj3514BIeZvJLcg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/transactions@6.1.0':
+    resolution: {integrity: sha512-1dkiNJcTtlHm4Fvs5VohNVpv7RbvbUYYKV7lYXMPIskoLF1eZp0tVlEqD/cRl91RNz7HEysfHqBAwlcJcRmrRg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -2132,8 +2150,8 @@ packages:
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
-  undici-types@7.20.0:
-    resolution: {integrity: sha512-PZDAAlMkNw5ZzN/ebfyrwzrMWfIf7Jbn9iM/I6SF456OKrb2wnfqVowaxEY/cMAM8MjFu1zhdpJyA0L+rTYwNw==}
+  undici-types@7.21.0:
+    resolution: {integrity: sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==}
 
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
@@ -2511,80 +2529,80 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@solana/accounts@6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+  '@solana/accounts@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
     dependencies:
-      '@solana/addresses': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/codecs-core': 6.0.0(typescript@5.9.2)
-      '@solana/codecs-strings': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/errors': 6.0.0(typescript@5.9.2)
-      '@solana/rpc-spec': 6.0.0(typescript@5.9.2)
-      '@solana/rpc-types': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/addresses': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/codecs-core': 6.1.0(typescript@5.9.2)
+      '@solana/codecs-strings': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/errors': 6.1.0(typescript@5.9.2)
+      '@solana/rpc-spec': 6.1.0(typescript@5.9.2)
+      '@solana/rpc-types': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/addresses@6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+  '@solana/addresses@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
     dependencies:
-      '@solana/assertions': 6.0.0(typescript@5.9.2)
-      '@solana/codecs-core': 6.0.0(typescript@5.9.2)
-      '@solana/codecs-strings': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/errors': 6.0.0(typescript@5.9.2)
-      '@solana/nominal-types': 6.0.0(typescript@5.9.2)
+      '@solana/assertions': 6.1.0(typescript@5.9.2)
+      '@solana/codecs-core': 6.1.0(typescript@5.9.2)
+      '@solana/codecs-strings': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/errors': 6.1.0(typescript@5.9.2)
+      '@solana/nominal-types': 6.1.0(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/assertions@6.0.0(typescript@5.9.2)':
+  '@solana/assertions@6.1.0(typescript@5.9.2)':
     dependencies:
-      '@solana/errors': 6.0.0(typescript@5.9.2)
+      '@solana/errors': 6.1.0(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
 
-  '@solana/codecs-core@6.0.0(typescript@5.9.2)':
+  '@solana/codecs-core@6.1.0(typescript@5.9.2)':
     dependencies:
-      '@solana/errors': 6.0.0(typescript@5.9.2)
+      '@solana/errors': 6.1.0(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
 
-  '@solana/codecs-data-structures@6.0.0(typescript@5.9.2)':
+  '@solana/codecs-data-structures@6.1.0(typescript@5.9.2)':
     dependencies:
-      '@solana/codecs-core': 6.0.0(typescript@5.9.2)
-      '@solana/codecs-numbers': 6.0.0(typescript@5.9.2)
-      '@solana/errors': 6.0.0(typescript@5.9.2)
+      '@solana/codecs-core': 6.1.0(typescript@5.9.2)
+      '@solana/codecs-numbers': 6.1.0(typescript@5.9.2)
+      '@solana/errors': 6.1.0(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
 
-  '@solana/codecs-numbers@6.0.0(typescript@5.9.2)':
+  '@solana/codecs-numbers@6.1.0(typescript@5.9.2)':
     dependencies:
-      '@solana/codecs-core': 6.0.0(typescript@5.9.2)
-      '@solana/errors': 6.0.0(typescript@5.9.2)
+      '@solana/codecs-core': 6.1.0(typescript@5.9.2)
+      '@solana/errors': 6.1.0(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
 
-  '@solana/codecs-strings@6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+  '@solana/codecs-strings@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
     dependencies:
-      '@solana/codecs-core': 6.0.0(typescript@5.9.2)
-      '@solana/codecs-numbers': 6.0.0(typescript@5.9.2)
-      '@solana/errors': 6.0.0(typescript@5.9.2)
+      '@solana/codecs-core': 6.1.0(typescript@5.9.2)
+      '@solana/codecs-numbers': 6.1.0(typescript@5.9.2)
+      '@solana/errors': 6.1.0(typescript@5.9.2)
     optionalDependencies:
       fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.9.2
 
-  '@solana/codecs@6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+  '@solana/codecs@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
     dependencies:
-      '@solana/codecs-core': 6.0.0(typescript@5.9.2)
-      '@solana/codecs-data-structures': 6.0.0(typescript@5.9.2)
-      '@solana/codecs-numbers': 6.0.0(typescript@5.9.2)
-      '@solana/codecs-strings': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/options': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/codecs-core': 6.1.0(typescript@5.9.2)
+      '@solana/codecs-data-structures': 6.1.0(typescript@5.9.2)
+      '@solana/codecs-numbers': 6.1.0(typescript@5.9.2)
+      '@solana/codecs-strings': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/options': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/errors@6.0.0(typescript@5.9.2)':
+  '@solana/errors@6.1.0(typescript@5.9.2)':
     dependencies:
       chalk: 5.6.2
       commander: 14.0.3
@@ -2603,70 +2621,72 @@ snapshots:
       eslint-plugin-typescript-sort-keys: 3.3.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2)
       typescript: 5.9.2
 
-  '@solana/fast-stable-stringify@6.0.0(typescript@5.9.2)':
+  '@solana/fast-stable-stringify@6.1.0(typescript@5.9.2)':
     optionalDependencies:
       typescript: 5.9.2
 
-  '@solana/functional@6.0.0(typescript@5.9.2)':
+  '@solana/functional@6.1.0(typescript@5.9.2)':
     optionalDependencies:
       typescript: 5.9.2
 
-  '@solana/instruction-plans@6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+  '@solana/instruction-plans@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
     dependencies:
-      '@solana/errors': 6.0.0(typescript@5.9.2)
-      '@solana/instructions': 6.0.0(typescript@5.9.2)
-      '@solana/keys': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/promises': 6.0.0(typescript@5.9.2)
-      '@solana/transaction-messages': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/transactions': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/errors': 6.1.0(typescript@5.9.2)
+      '@solana/instructions': 6.1.0(typescript@5.9.2)
+      '@solana/keys': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/promises': 6.1.0(typescript@5.9.2)
+      '@solana/transaction-messages': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/transactions': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/instructions@6.0.0(typescript@5.9.2)':
+  '@solana/instructions@6.1.0(typescript@5.9.2)':
     dependencies:
-      '@solana/codecs-core': 6.0.0(typescript@5.9.2)
-      '@solana/errors': 6.0.0(typescript@5.9.2)
+      '@solana/codecs-core': 6.1.0(typescript@5.9.2)
+      '@solana/errors': 6.1.0(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
 
-  '@solana/keys@6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+  '@solana/keys@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
     dependencies:
-      '@solana/assertions': 6.0.0(typescript@5.9.2)
-      '@solana/codecs-core': 6.0.0(typescript@5.9.2)
-      '@solana/codecs-strings': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/errors': 6.0.0(typescript@5.9.2)
-      '@solana/nominal-types': 6.0.0(typescript@5.9.2)
+      '@solana/assertions': 6.1.0(typescript@5.9.2)
+      '@solana/codecs-core': 6.1.0(typescript@5.9.2)
+      '@solana/codecs-strings': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/errors': 6.1.0(typescript@5.9.2)
+      '@solana/nominal-types': 6.1.0(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/kit@6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+  '@solana/kit@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
     dependencies:
-      '@solana/accounts': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/addresses': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/codecs': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/errors': 6.0.0(typescript@5.9.2)
-      '@solana/functional': 6.0.0(typescript@5.9.2)
-      '@solana/instruction-plans': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/instructions': 6.0.0(typescript@5.9.2)
-      '@solana/keys': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/offchain-messages': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/plugin-core': 6.0.0(typescript@5.9.2)
-      '@solana/programs': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/rpc': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/rpc-api': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/rpc-parsed-types': 6.0.0(typescript@5.9.2)
-      '@solana/rpc-spec-types': 6.0.0(typescript@5.9.2)
-      '@solana/rpc-subscriptions': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/rpc-types': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/signers': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/sysvars': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/transaction-confirmation': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/transaction-messages': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/transactions': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/accounts': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/addresses': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/codecs': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/errors': 6.1.0(typescript@5.9.2)
+      '@solana/functional': 6.1.0(typescript@5.9.2)
+      '@solana/instruction-plans': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/instructions': 6.1.0(typescript@5.9.2)
+      '@solana/keys': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/offchain-messages': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/plugin-core': 6.1.0(typescript@5.9.2)
+      '@solana/plugin-interfaces': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/program-client-core': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/programs': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/rpc': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/rpc-api': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/rpc-parsed-types': 6.1.0(typescript@5.9.2)
+      '@solana/rpc-spec-types': 6.1.0(typescript@5.9.2)
+      '@solana/rpc-subscriptions': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/rpc-types': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/signers': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/sysvars': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/transaction-confirmation': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/transaction-messages': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/transactions': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -2674,107 +2694,137 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/nominal-types@6.0.0(typescript@5.9.2)':
+  '@solana/nominal-types@6.1.0(typescript@5.9.2)':
     optionalDependencies:
       typescript: 5.9.2
 
-  '@solana/offchain-messages@6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+  '@solana/offchain-messages@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
     dependencies:
-      '@solana/addresses': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/codecs-core': 6.0.0(typescript@5.9.2)
-      '@solana/codecs-data-structures': 6.0.0(typescript@5.9.2)
-      '@solana/codecs-numbers': 6.0.0(typescript@5.9.2)
-      '@solana/codecs-strings': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/errors': 6.0.0(typescript@5.9.2)
-      '@solana/keys': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/nominal-types': 6.0.0(typescript@5.9.2)
+      '@solana/addresses': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/codecs-core': 6.1.0(typescript@5.9.2)
+      '@solana/codecs-data-structures': 6.1.0(typescript@5.9.2)
+      '@solana/codecs-numbers': 6.1.0(typescript@5.9.2)
+      '@solana/codecs-strings': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/errors': 6.1.0(typescript@5.9.2)
+      '@solana/keys': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/nominal-types': 6.1.0(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/options@6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+  '@solana/options@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
     dependencies:
-      '@solana/codecs-core': 6.0.0(typescript@5.9.2)
-      '@solana/codecs-data-structures': 6.0.0(typescript@5.9.2)
-      '@solana/codecs-numbers': 6.0.0(typescript@5.9.2)
-      '@solana/codecs-strings': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/errors': 6.0.0(typescript@5.9.2)
+      '@solana/codecs-core': 6.1.0(typescript@5.9.2)
+      '@solana/codecs-data-structures': 6.1.0(typescript@5.9.2)
+      '@solana/codecs-numbers': 6.1.0(typescript@5.9.2)
+      '@solana/codecs-strings': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/errors': 6.1.0(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/plugin-core@6.0.0(typescript@5.9.2)':
+  '@solana/plugin-core@6.1.0(typescript@5.9.2)':
     optionalDependencies:
       typescript: 5.9.2
 
-  '@solana/programs@6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+  '@solana/plugin-interfaces@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
     dependencies:
-      '@solana/addresses': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/errors': 6.0.0(typescript@5.9.2)
+      '@solana/addresses': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/instruction-plans': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/keys': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/rpc-spec': 6.1.0(typescript@5.9.2)
+      '@solana/rpc-subscriptions-spec': 6.1.0(typescript@5.9.2)
+      '@solana/rpc-types': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/signers': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/promises@6.0.0(typescript@5.9.2)':
-    optionalDependencies:
-      typescript: 5.9.2
-
-  '@solana/rpc-api@6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+  '@solana/program-client-core@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
     dependencies:
-      '@solana/addresses': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/codecs-core': 6.0.0(typescript@5.9.2)
-      '@solana/codecs-strings': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/errors': 6.0.0(typescript@5.9.2)
-      '@solana/keys': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/rpc-parsed-types': 6.0.0(typescript@5.9.2)
-      '@solana/rpc-spec': 6.0.0(typescript@5.9.2)
-      '@solana/rpc-transformers': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/rpc-types': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/transaction-messages': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/transactions': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/accounts': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/addresses': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/codecs-core': 6.1.0(typescript@5.9.2)
+      '@solana/errors': 6.1.0(typescript@5.9.2)
+      '@solana/instruction-plans': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/instructions': 6.1.0(typescript@5.9.2)
+      '@solana/plugin-interfaces': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/rpc-api': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/signers': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-parsed-types@6.0.0(typescript@5.9.2)':
-    optionalDependencies:
-      typescript: 5.9.2
-
-  '@solana/rpc-spec-types@6.0.0(typescript@5.9.2)':
-    optionalDependencies:
-      typescript: 5.9.2
-
-  '@solana/rpc-spec@6.0.0(typescript@5.9.2)':
+  '@solana/programs@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
     dependencies:
-      '@solana/errors': 6.0.0(typescript@5.9.2)
-      '@solana/rpc-spec-types': 6.0.0(typescript@5.9.2)
-    optionalDependencies:
-      typescript: 5.9.2
-
-  '@solana/rpc-subscriptions-api@6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
-    dependencies:
-      '@solana/addresses': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/keys': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/rpc-subscriptions-spec': 6.0.0(typescript@5.9.2)
-      '@solana/rpc-transformers': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/rpc-types': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/transaction-messages': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/transactions': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/addresses': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/errors': 6.1.0(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-subscriptions-channel-websocket@6.0.0(typescript@5.9.2)':
+  '@solana/promises@6.1.0(typescript@5.9.2)':
+    optionalDependencies:
+      typescript: 5.9.2
+
+  '@solana/rpc-api@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
     dependencies:
-      '@solana/errors': 6.0.0(typescript@5.9.2)
-      '@solana/functional': 6.0.0(typescript@5.9.2)
-      '@solana/rpc-subscriptions-spec': 6.0.0(typescript@5.9.2)
-      '@solana/subscribable': 6.0.0(typescript@5.9.2)
+      '@solana/addresses': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/codecs-core': 6.1.0(typescript@5.9.2)
+      '@solana/codecs-strings': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/errors': 6.1.0(typescript@5.9.2)
+      '@solana/keys': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/rpc-parsed-types': 6.1.0(typescript@5.9.2)
+      '@solana/rpc-spec': 6.1.0(typescript@5.9.2)
+      '@solana/rpc-transformers': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/rpc-types': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/transaction-messages': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/transactions': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-parsed-types@6.1.0(typescript@5.9.2)':
+    optionalDependencies:
+      typescript: 5.9.2
+
+  '@solana/rpc-spec-types@6.1.0(typescript@5.9.2)':
+    optionalDependencies:
+      typescript: 5.9.2
+
+  '@solana/rpc-spec@6.1.0(typescript@5.9.2)':
+    dependencies:
+      '@solana/errors': 6.1.0(typescript@5.9.2)
+      '@solana/rpc-spec-types': 6.1.0(typescript@5.9.2)
+    optionalDependencies:
+      typescript: 5.9.2
+
+  '@solana/rpc-subscriptions-api@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+    dependencies:
+      '@solana/addresses': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/keys': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/rpc-subscriptions-spec': 6.1.0(typescript@5.9.2)
+      '@solana/rpc-transformers': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/rpc-types': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/transaction-messages': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/transactions': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-subscriptions-channel-websocket@6.1.0(typescript@5.9.2)':
+    dependencies:
+      '@solana/errors': 6.1.0(typescript@5.9.2)
+      '@solana/functional': 6.1.0(typescript@5.9.2)
+      '@solana/rpc-subscriptions-spec': 6.1.0(typescript@5.9.2)
+      '@solana/subscribable': 6.1.0(typescript@5.9.2)
       ws: 8.19.0
     optionalDependencies:
       typescript: 5.9.2
@@ -2782,130 +2832,28 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@solana/rpc-subscriptions-spec@6.0.0(typescript@5.9.2)':
+  '@solana/rpc-subscriptions-spec@6.1.0(typescript@5.9.2)':
     dependencies:
-      '@solana/errors': 6.0.0(typescript@5.9.2)
-      '@solana/promises': 6.0.0(typescript@5.9.2)
-      '@solana/rpc-spec-types': 6.0.0(typescript@5.9.2)
-      '@solana/subscribable': 6.0.0(typescript@5.9.2)
+      '@solana/errors': 6.1.0(typescript@5.9.2)
+      '@solana/promises': 6.1.0(typescript@5.9.2)
+      '@solana/rpc-spec-types': 6.1.0(typescript@5.9.2)
+      '@solana/subscribable': 6.1.0(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
 
-  '@solana/rpc-subscriptions@6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+  '@solana/rpc-subscriptions@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
     dependencies:
-      '@solana/errors': 6.0.0(typescript@5.9.2)
-      '@solana/fast-stable-stringify': 6.0.0(typescript@5.9.2)
-      '@solana/functional': 6.0.0(typescript@5.9.2)
-      '@solana/promises': 6.0.0(typescript@5.9.2)
-      '@solana/rpc-spec-types': 6.0.0(typescript@5.9.2)
-      '@solana/rpc-subscriptions-api': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/rpc-subscriptions-channel-websocket': 6.0.0(typescript@5.9.2)
-      '@solana/rpc-subscriptions-spec': 6.0.0(typescript@5.9.2)
-      '@solana/rpc-transformers': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/rpc-types': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/subscribable': 6.0.0(typescript@5.9.2)
-    optionalDependencies:
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - bufferutil
-      - fastestsmallesttextencoderdecoder
-      - utf-8-validate
-
-  '@solana/rpc-transformers@6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
-    dependencies:
-      '@solana/errors': 6.0.0(typescript@5.9.2)
-      '@solana/functional': 6.0.0(typescript@5.9.2)
-      '@solana/nominal-types': 6.0.0(typescript@5.9.2)
-      '@solana/rpc-spec-types': 6.0.0(typescript@5.9.2)
-      '@solana/rpc-types': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-    optionalDependencies:
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/rpc-transport-http@6.0.0(typescript@5.9.2)':
-    dependencies:
-      '@solana/errors': 6.0.0(typescript@5.9.2)
-      '@solana/rpc-spec': 6.0.0(typescript@5.9.2)
-      '@solana/rpc-spec-types': 6.0.0(typescript@5.9.2)
-      undici-types: 7.20.0
-    optionalDependencies:
-      typescript: 5.9.2
-
-  '@solana/rpc-types@6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
-    dependencies:
-      '@solana/addresses': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/codecs-core': 6.0.0(typescript@5.9.2)
-      '@solana/codecs-numbers': 6.0.0(typescript@5.9.2)
-      '@solana/codecs-strings': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/errors': 6.0.0(typescript@5.9.2)
-      '@solana/nominal-types': 6.0.0(typescript@5.9.2)
-    optionalDependencies:
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/rpc@6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
-    dependencies:
-      '@solana/errors': 6.0.0(typescript@5.9.2)
-      '@solana/fast-stable-stringify': 6.0.0(typescript@5.9.2)
-      '@solana/functional': 6.0.0(typescript@5.9.2)
-      '@solana/rpc-api': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/rpc-spec': 6.0.0(typescript@5.9.2)
-      '@solana/rpc-spec-types': 6.0.0(typescript@5.9.2)
-      '@solana/rpc-transformers': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/rpc-transport-http': 6.0.0(typescript@5.9.2)
-      '@solana/rpc-types': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-    optionalDependencies:
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/signers@6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
-    dependencies:
-      '@solana/addresses': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/codecs-core': 6.0.0(typescript@5.9.2)
-      '@solana/errors': 6.0.0(typescript@5.9.2)
-      '@solana/instructions': 6.0.0(typescript@5.9.2)
-      '@solana/keys': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/nominal-types': 6.0.0(typescript@5.9.2)
-      '@solana/offchain-messages': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/transaction-messages': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/transactions': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-    optionalDependencies:
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/subscribable@6.0.0(typescript@5.9.2)':
-    dependencies:
-      '@solana/errors': 6.0.0(typescript@5.9.2)
-    optionalDependencies:
-      typescript: 5.9.2
-
-  '@solana/sysvars@6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
-    dependencies:
-      '@solana/accounts': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/codecs': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/errors': 6.0.0(typescript@5.9.2)
-      '@solana/rpc-types': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-    optionalDependencies:
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/transaction-confirmation@6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
-    dependencies:
-      '@solana/addresses': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/codecs-strings': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/errors': 6.0.0(typescript@5.9.2)
-      '@solana/keys': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/promises': 6.0.0(typescript@5.9.2)
-      '@solana/rpc': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/rpc-subscriptions': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/rpc-types': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/transaction-messages': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/transactions': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/errors': 6.1.0(typescript@5.9.2)
+      '@solana/fast-stable-stringify': 6.1.0(typescript@5.9.2)
+      '@solana/functional': 6.1.0(typescript@5.9.2)
+      '@solana/promises': 6.1.0(typescript@5.9.2)
+      '@solana/rpc-spec-types': 6.1.0(typescript@5.9.2)
+      '@solana/rpc-subscriptions-api': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/rpc-subscriptions-channel-websocket': 6.1.0(typescript@5.9.2)
+      '@solana/rpc-subscriptions-spec': 6.1.0(typescript@5.9.2)
+      '@solana/rpc-transformers': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/rpc-types': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/subscribable': 6.1.0(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -2913,36 +2861,138 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/transaction-messages@6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+  '@solana/rpc-transformers@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
     dependencies:
-      '@solana/addresses': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/codecs-core': 6.0.0(typescript@5.9.2)
-      '@solana/codecs-data-structures': 6.0.0(typescript@5.9.2)
-      '@solana/codecs-numbers': 6.0.0(typescript@5.9.2)
-      '@solana/errors': 6.0.0(typescript@5.9.2)
-      '@solana/functional': 6.0.0(typescript@5.9.2)
-      '@solana/instructions': 6.0.0(typescript@5.9.2)
-      '@solana/nominal-types': 6.0.0(typescript@5.9.2)
-      '@solana/rpc-types': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/errors': 6.1.0(typescript@5.9.2)
+      '@solana/functional': 6.1.0(typescript@5.9.2)
+      '@solana/nominal-types': 6.1.0(typescript@5.9.2)
+      '@solana/rpc-spec-types': 6.1.0(typescript@5.9.2)
+      '@solana/rpc-types': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transactions@6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+  '@solana/rpc-transport-http@6.1.0(typescript@5.9.2)':
     dependencies:
-      '@solana/addresses': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/codecs-core': 6.0.0(typescript@5.9.2)
-      '@solana/codecs-data-structures': 6.0.0(typescript@5.9.2)
-      '@solana/codecs-numbers': 6.0.0(typescript@5.9.2)
-      '@solana/codecs-strings': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/errors': 6.0.0(typescript@5.9.2)
-      '@solana/functional': 6.0.0(typescript@5.9.2)
-      '@solana/instructions': 6.0.0(typescript@5.9.2)
-      '@solana/keys': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/nominal-types': 6.0.0(typescript@5.9.2)
-      '@solana/rpc-types': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/transaction-messages': 6.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/errors': 6.1.0(typescript@5.9.2)
+      '@solana/rpc-spec': 6.1.0(typescript@5.9.2)
+      '@solana/rpc-spec-types': 6.1.0(typescript@5.9.2)
+      undici-types: 7.21.0
+    optionalDependencies:
+      typescript: 5.9.2
+
+  '@solana/rpc-types@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+    dependencies:
+      '@solana/addresses': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/codecs-core': 6.1.0(typescript@5.9.2)
+      '@solana/codecs-numbers': 6.1.0(typescript@5.9.2)
+      '@solana/codecs-strings': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/errors': 6.1.0(typescript@5.9.2)
+      '@solana/nominal-types': 6.1.0(typescript@5.9.2)
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+    dependencies:
+      '@solana/errors': 6.1.0(typescript@5.9.2)
+      '@solana/fast-stable-stringify': 6.1.0(typescript@5.9.2)
+      '@solana/functional': 6.1.0(typescript@5.9.2)
+      '@solana/rpc-api': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/rpc-spec': 6.1.0(typescript@5.9.2)
+      '@solana/rpc-spec-types': 6.1.0(typescript@5.9.2)
+      '@solana/rpc-transformers': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/rpc-transport-http': 6.1.0(typescript@5.9.2)
+      '@solana/rpc-types': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/signers@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+    dependencies:
+      '@solana/addresses': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/codecs-core': 6.1.0(typescript@5.9.2)
+      '@solana/errors': 6.1.0(typescript@5.9.2)
+      '@solana/instructions': 6.1.0(typescript@5.9.2)
+      '@solana/keys': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/nominal-types': 6.1.0(typescript@5.9.2)
+      '@solana/offchain-messages': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/transaction-messages': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/transactions': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/subscribable@6.1.0(typescript@5.9.2)':
+    dependencies:
+      '@solana/errors': 6.1.0(typescript@5.9.2)
+    optionalDependencies:
+      typescript: 5.9.2
+
+  '@solana/sysvars@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+    dependencies:
+      '@solana/accounts': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/codecs': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/errors': 6.1.0(typescript@5.9.2)
+      '@solana/rpc-types': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transaction-confirmation@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+    dependencies:
+      '@solana/addresses': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/codecs-strings': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/errors': 6.1.0(typescript@5.9.2)
+      '@solana/keys': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/promises': 6.1.0(typescript@5.9.2)
+      '@solana/rpc': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/rpc-subscriptions': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/rpc-types': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/transaction-messages': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/transactions': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - bufferutil
+      - fastestsmallesttextencoderdecoder
+      - utf-8-validate
+
+  '@solana/transaction-messages@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+    dependencies:
+      '@solana/addresses': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/codecs-core': 6.1.0(typescript@5.9.2)
+      '@solana/codecs-data-structures': 6.1.0(typescript@5.9.2)
+      '@solana/codecs-numbers': 6.1.0(typescript@5.9.2)
+      '@solana/errors': 6.1.0(typescript@5.9.2)
+      '@solana/functional': 6.1.0(typescript@5.9.2)
+      '@solana/instructions': 6.1.0(typescript@5.9.2)
+      '@solana/nominal-types': 6.1.0(typescript@5.9.2)
+      '@solana/rpc-types': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transactions@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
+    dependencies:
+      '@solana/addresses': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/codecs-core': 6.1.0(typescript@5.9.2)
+      '@solana/codecs-data-structures': 6.1.0(typescript@5.9.2)
+      '@solana/codecs-numbers': 6.1.0(typescript@5.9.2)
+      '@solana/codecs-strings': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/errors': 6.1.0(typescript@5.9.2)
+      '@solana/functional': 6.1.0(typescript@5.9.2)
+      '@solana/instructions': 6.1.0(typescript@5.9.2)
+      '@solana/keys': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/nominal-types': 6.1.0(typescript@5.9.2)
+      '@solana/rpc-types': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
+      '@solana/transaction-messages': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -4262,7 +4312,7 @@ snapshots:
 
   ufo@1.6.1: {}
 
-  undici-types@7.20.0: {}
+  undici-types@7.21.0: {}
 
   unicorn-magic@0.3.0: {}
 

--- a/test/e2e/system/package.json
+++ b/test/e2e/system/package.json
@@ -11,7 +11,7 @@
         "lint:fix": "eslint --fix --ext js,ts,tsx src && prettier --write src test"
     },
     "dependencies": {
-        "@solana/kit": "^6.0.0"
+        "@solana/kit": "^6.1.0"
     },
     "license": "MIT",
     "ava": {

--- a/test/e2e/token/package.json
+++ b/test/e2e/token/package.json
@@ -11,7 +11,7 @@
         "lint:fix": "eslint --fix --ext js,ts,tsx src && prettier --write src test"
     },
     "dependencies": {
-        "@solana/kit": "^6.0.0"
+        "@solana/kit": "^6.1.0"
     },
     "license": "MIT",
     "ava": {


### PR DESCRIPTION
This PR bumps the e2e tests to use the latest version of `@solana/kit` — version 6.1.0.