### PR TITLE
Fix plugin instruction type

### DIFF
--- a/.changeset/silver-pillows-stand.md
+++ b/.changeset/silver-pillows-stand.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-js': patch
+---
+
+Fix the generated plugin instruction type to use `ReturnType<typeof instructionFunction>` instead of manually constructing the return type, and make payer default values optional in the plugin's instruction input type.

--- a/test/e2e/anchor/src/generated/programs/wenTransferGuard.ts
+++ b/test/e2e/anchor/src/generated/programs/wenTransferGuard.ts
@@ -43,17 +43,13 @@ import {
     parseInitializeInstruction,
     parseUpdateGuardInstruction,
     type CreateGuardAsyncInput,
-    type CreateGuardInstruction,
     type ExecuteAsyncInput,
-    type ExecuteInstruction,
     type InitializeAsyncInput,
-    type InitializeInstruction,
     type ParsedCreateGuardInstruction,
     type ParsedExecuteInstruction,
     type ParsedInitializeInstruction,
     type ParsedUpdateGuardInstruction,
     type UpdateGuardAsyncInput,
-    type UpdateGuardInstruction,
 } from '../instructions';
 
 export const WEN_TRANSFER_GUARD_PROGRAM_ADDRESS =
@@ -189,10 +185,16 @@ export type WenTransferGuardPluginAccounts = {
 };
 
 export type WenTransferGuardPluginInstructions = {
-    createGuard: (input: CreateGuardAsyncInput) => Promise<CreateGuardInstruction> & SelfPlanAndSendFunctions;
-    execute: (input: ExecuteAsyncInput) => Promise<ExecuteInstruction> & SelfPlanAndSendFunctions;
-    initialize: (input: InitializeAsyncInput) => Promise<InitializeInstruction> & SelfPlanAndSendFunctions;
-    updateGuard: (input: UpdateGuardAsyncInput) => Promise<UpdateGuardInstruction> & SelfPlanAndSendFunctions;
+    createGuard: (
+        input: MakeOptional<CreateGuardAsyncInput, 'payer'>,
+    ) => ReturnType<typeof getCreateGuardInstructionAsync> & SelfPlanAndSendFunctions;
+    execute: (input: ExecuteAsyncInput) => ReturnType<typeof getExecuteInstructionAsync> & SelfPlanAndSendFunctions;
+    initialize: (
+        input: MakeOptional<InitializeAsyncInput, 'payer'>,
+    ) => ReturnType<typeof getInitializeInstructionAsync> & SelfPlanAndSendFunctions;
+    updateGuard: (
+        input: UpdateGuardAsyncInput,
+    ) => ReturnType<typeof getUpdateGuardInstructionAsync> & SelfPlanAndSendFunctions;
 };
 
 export type WenTransferGuardPluginRequirements = ClientWithRpc<GetAccountInfoApi & GetMultipleAccountsApi> &

--- a/test/e2e/dummy/src/generated/programs/dummy.ts
+++ b/test/e2e/dummy/src/generated/programs/dummy.ts
@@ -42,23 +42,14 @@ import {
     parseInstruction8Instruction,
     parseInstruction9Instruction,
     type Instruction1Input,
-    type Instruction1Instruction,
     type Instruction2Input,
-    type Instruction2Instruction,
     type Instruction3Input,
-    type Instruction3Instruction,
     type Instruction4Input,
-    type Instruction4Instruction,
     type Instruction5Input,
-    type Instruction5Instruction,
     type Instruction6Input,
-    type Instruction6Instruction,
     type Instruction7Input,
-    type Instruction7Instruction,
     type Instruction8Input,
-    type Instruction8Instruction,
     type Instruction9Input,
-    type Instruction9Instruction,
     type ParsedInstruction1Instruction,
     type ParsedInstruction2Instruction,
     type ParsedInstruction3Instruction,
@@ -155,15 +146,33 @@ export function parseDummyInstruction<TProgram extends string>(
 export type DummyPlugin = { instructions: DummyPluginInstructions };
 
 export type DummyPluginInstructions = {
-    instruction1: (input: Instruction1Input) => Instruction1Instruction & SelfPlanAndSendFunctions;
-    instruction2: (input: Instruction2Input) => Instruction2Instruction & SelfPlanAndSendFunctions;
-    instruction3: (input: Instruction3Input) => Instruction3Instruction & SelfPlanAndSendFunctions;
-    instruction4: (input: Instruction4Input) => Instruction4Instruction & SelfPlanAndSendFunctions;
-    instruction5: (input: Instruction5Input) => Instruction5Instruction & SelfPlanAndSendFunctions;
-    instruction6: (input: Instruction6Input) => Instruction6Instruction & SelfPlanAndSendFunctions;
-    instruction7: (input: Instruction7Input) => Instruction7Instruction & SelfPlanAndSendFunctions;
-    instruction8: (input: Instruction8Input) => Instruction8Instruction & SelfPlanAndSendFunctions;
-    instruction9: (input: Instruction9Input) => Instruction9Instruction & SelfPlanAndSendFunctions;
+    instruction1: (
+        input: Instruction1Input,
+    ) => ReturnType<typeof getInstruction1Instruction> & SelfPlanAndSendFunctions;
+    instruction2: (
+        input: Instruction2Input,
+    ) => ReturnType<typeof getInstruction2Instruction> & SelfPlanAndSendFunctions;
+    instruction3: (
+        input: Instruction3Input,
+    ) => ReturnType<typeof getInstruction3Instruction> & SelfPlanAndSendFunctions;
+    instruction4: (
+        input: Instruction4Input,
+    ) => ReturnType<typeof getInstruction4Instruction> & SelfPlanAndSendFunctions;
+    instruction5: (
+        input: Instruction5Input,
+    ) => ReturnType<typeof getInstruction5Instruction> & SelfPlanAndSendFunctions;
+    instruction6: (
+        input: Instruction6Input,
+    ) => ReturnType<typeof getInstruction6Instruction> & SelfPlanAndSendFunctions;
+    instruction7: (
+        input: Instruction7Input,
+    ) => ReturnType<typeof getInstruction7Instruction> & SelfPlanAndSendFunctions;
+    instruction8: (
+        input: Instruction8Input,
+    ) => ReturnType<typeof getInstruction8Instruction> & SelfPlanAndSendFunctions;
+    instruction9: (
+        input: MakeOptional<Instruction9Input, 'authority' | 'authorityArg'>,
+    ) => ReturnType<typeof getInstruction9Instruction> & SelfPlanAndSendFunctions;
 };
 
 export type DummyPluginRequirements = ClientWithPayer & ClientWithTransactionPlanning & ClientWithTransactionSending;

--- a/test/e2e/memo/src/generated/programs/memo.ts
+++ b/test/e2e/memo/src/generated/programs/memo.ts
@@ -8,12 +8,7 @@
 
 import { type Address, type ClientWithTransactionPlanning, type ClientWithTransactionSending } from '@solana/kit';
 import { addSelfPlanAndSendFunctions, type SelfPlanAndSendFunctions } from '@solana/kit/program-client-core';
-import {
-    getAddMemoInstruction,
-    type AddMemoInput,
-    type AddMemoInstruction,
-    type ParsedAddMemoInstruction,
-} from '../instructions';
+import { getAddMemoInstruction, type AddMemoInput, type ParsedAddMemoInstruction } from '../instructions';
 
 export const MEMO_PROGRAM_ADDRESS =
     'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr' as Address<'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr'>;
@@ -29,7 +24,7 @@ export type ParsedMemoInstruction<TProgram extends string = 'MemoSq4gqABAXKb96qn
 export type MemoPlugin = { instructions: MemoPluginInstructions };
 
 export type MemoPluginInstructions = {
-    addMemo: (input: AddMemoInput) => AddMemoInstruction & SelfPlanAndSendFunctions;
+    addMemo: (input: AddMemoInput) => ReturnType<typeof getAddMemoInstruction> & SelfPlanAndSendFunctions;
 };
 
 export type MemoPluginRequirements = ClientWithTransactionPlanning & ClientWithTransactionSending;

--- a/test/e2e/system/src/generated/programs/system.ts
+++ b/test/e2e/system/src/generated/programs/system.ts
@@ -59,23 +59,14 @@ import {
     parseUpgradeNonceAccountInstruction,
     parseWithdrawNonceAccountInstruction,
     type AdvanceNonceAccountInput,
-    type AdvanceNonceAccountInstruction,
     type AllocateInput,
-    type AllocateInstruction,
     type AllocateWithSeedInput,
-    type AllocateWithSeedInstruction,
     type AssignInput,
-    type AssignInstruction,
     type AssignWithSeedInput,
-    type AssignWithSeedInstruction,
     type AuthorizeNonceAccountInput,
-    type AuthorizeNonceAccountInstruction,
     type CreateAccountInput,
-    type CreateAccountInstruction,
     type CreateAccountWithSeedInput,
-    type CreateAccountWithSeedInstruction,
     type InitializeNonceAccountInput,
-    type InitializeNonceAccountInstruction,
     type ParsedAdvanceNonceAccountInstruction,
     type ParsedAllocateInstruction,
     type ParsedAllocateWithSeedInstruction,
@@ -90,13 +81,9 @@ import {
     type ParsedUpgradeNonceAccountInstruction,
     type ParsedWithdrawNonceAccountInstruction,
     type TransferSolInput,
-    type TransferSolInstruction,
     type TransferSolWithSeedInput,
-    type TransferSolWithSeedInstruction,
     type UpgradeNonceAccountInput,
-    type UpgradeNonceAccountInstruction,
     type WithdrawNonceAccountInput,
-    type WithdrawNonceAccountInstruction,
 } from '../instructions';
 
 export const SYSTEM_PROGRAM_ADDRESS = '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
@@ -284,27 +271,39 @@ export type SystemPlugin = { accounts: SystemPluginAccounts; instructions: Syste
 export type SystemPluginAccounts = { nonce: ReturnType<typeof getNonceCodec> & SelfFetchFunctions<NonceArgs, Nonce> };
 
 export type SystemPluginInstructions = {
-    createAccount: (input: CreateAccountInput) => CreateAccountInstruction & SelfPlanAndSendFunctions;
-    assign: (input: AssignInput) => AssignInstruction & SelfPlanAndSendFunctions;
-    transferSol: (input: TransferSolInput) => TransferSolInstruction & SelfPlanAndSendFunctions;
+    createAccount: (
+        input: MakeOptional<CreateAccountInput, 'payer'>,
+    ) => ReturnType<typeof getCreateAccountInstruction> & SelfPlanAndSendFunctions;
+    assign: (input: AssignInput) => ReturnType<typeof getAssignInstruction> & SelfPlanAndSendFunctions;
+    transferSol: (input: TransferSolInput) => ReturnType<typeof getTransferSolInstruction> & SelfPlanAndSendFunctions;
     createAccountWithSeed: (
-        input: CreateAccountWithSeedInput,
-    ) => CreateAccountWithSeedInstruction & SelfPlanAndSendFunctions;
-    advanceNonceAccount: (input: AdvanceNonceAccountInput) => AdvanceNonceAccountInstruction & SelfPlanAndSendFunctions;
+        input: MakeOptional<CreateAccountWithSeedInput, 'payer'>,
+    ) => ReturnType<typeof getCreateAccountWithSeedInstruction> & SelfPlanAndSendFunctions;
+    advanceNonceAccount: (
+        input: AdvanceNonceAccountInput,
+    ) => ReturnType<typeof getAdvanceNonceAccountInstruction> & SelfPlanAndSendFunctions;
     withdrawNonceAccount: (
         input: WithdrawNonceAccountInput,
-    ) => WithdrawNonceAccountInstruction & SelfPlanAndSendFunctions;
+    ) => ReturnType<typeof getWithdrawNonceAccountInstruction> & SelfPlanAndSendFunctions;
     initializeNonceAccount: (
         input: InitializeNonceAccountInput,
-    ) => InitializeNonceAccountInstruction & SelfPlanAndSendFunctions;
+    ) => ReturnType<typeof getInitializeNonceAccountInstruction> & SelfPlanAndSendFunctions;
     authorizeNonceAccount: (
         input: AuthorizeNonceAccountInput,
-    ) => AuthorizeNonceAccountInstruction & SelfPlanAndSendFunctions;
-    allocate: (input: AllocateInput) => AllocateInstruction & SelfPlanAndSendFunctions;
-    allocateWithSeed: (input: AllocateWithSeedInput) => AllocateWithSeedInstruction & SelfPlanAndSendFunctions;
-    assignWithSeed: (input: AssignWithSeedInput) => AssignWithSeedInstruction & SelfPlanAndSendFunctions;
-    transferSolWithSeed: (input: TransferSolWithSeedInput) => TransferSolWithSeedInstruction & SelfPlanAndSendFunctions;
-    upgradeNonceAccount: (input: UpgradeNonceAccountInput) => UpgradeNonceAccountInstruction & SelfPlanAndSendFunctions;
+    ) => ReturnType<typeof getAuthorizeNonceAccountInstruction> & SelfPlanAndSendFunctions;
+    allocate: (input: AllocateInput) => ReturnType<typeof getAllocateInstruction> & SelfPlanAndSendFunctions;
+    allocateWithSeed: (
+        input: AllocateWithSeedInput,
+    ) => ReturnType<typeof getAllocateWithSeedInstruction> & SelfPlanAndSendFunctions;
+    assignWithSeed: (
+        input: AssignWithSeedInput,
+    ) => ReturnType<typeof getAssignWithSeedInstruction> & SelfPlanAndSendFunctions;
+    transferSolWithSeed: (
+        input: TransferSolWithSeedInput,
+    ) => ReturnType<typeof getTransferSolWithSeedInstruction> & SelfPlanAndSendFunctions;
+    upgradeNonceAccount: (
+        input: UpgradeNonceAccountInput,
+    ) => ReturnType<typeof getUpgradeNonceAccountInstruction> & SelfPlanAndSendFunctions;
 };
 
 export type SystemPluginRequirements = ClientWithRpc<GetAccountInfoApi & GetMultipleAccountsApi> &

--- a/test/e2e/token/src/generated/programs/associatedToken.ts
+++ b/test/e2e/token/src/generated/programs/associatedToken.ts
@@ -31,13 +31,10 @@ import {
     parseRecoverNestedAssociatedTokenInstruction,
     type CreateAssociatedTokenAsyncInput,
     type CreateAssociatedTokenIdempotentAsyncInput,
-    type CreateAssociatedTokenIdempotentInstruction,
-    type CreateAssociatedTokenInstruction,
     type ParsedCreateAssociatedTokenIdempotentInstruction,
     type ParsedCreateAssociatedTokenInstruction,
     type ParsedRecoverNestedAssociatedTokenInstruction,
     type RecoverNestedAssociatedTokenAsyncInput,
-    type RecoverNestedAssociatedTokenInstruction,
 } from '../instructions';
 
 export const ASSOCIATED_TOKEN_PROGRAM_ADDRESS =
@@ -117,14 +114,14 @@ export type AssociatedTokenPlugin = { instructions: AssociatedTokenPluginInstruc
 
 export type AssociatedTokenPluginInstructions = {
     createAssociatedToken: (
-        input: CreateAssociatedTokenAsyncInput,
-    ) => Promise<CreateAssociatedTokenInstruction> & SelfPlanAndSendFunctions;
+        input: MakeOptional<CreateAssociatedTokenAsyncInput, 'payer'>,
+    ) => ReturnType<typeof getCreateAssociatedTokenInstructionAsync> & SelfPlanAndSendFunctions;
     createAssociatedTokenIdempotent: (
-        input: CreateAssociatedTokenIdempotentAsyncInput,
-    ) => Promise<CreateAssociatedTokenIdempotentInstruction> & SelfPlanAndSendFunctions;
+        input: MakeOptional<CreateAssociatedTokenIdempotentAsyncInput, 'payer'>,
+    ) => ReturnType<typeof getCreateAssociatedTokenIdempotentInstructionAsync> & SelfPlanAndSendFunctions;
     recoverNestedAssociatedToken: (
         input: RecoverNestedAssociatedTokenAsyncInput,
-    ) => Promise<RecoverNestedAssociatedTokenInstruction> & SelfPlanAndSendFunctions;
+    ) => ReturnType<typeof getRecoverNestedAssociatedTokenInstructionAsync> & SelfPlanAndSendFunctions;
 };
 
 export type AssociatedTokenPluginRequirements = ClientWithPayer &

--- a/test/e2e/token/src/generated/programs/system.ts
+++ b/test/e2e/token/src/generated/programs/system.ts
@@ -26,7 +26,6 @@ import {
     getCreateAccountInstruction,
     parseCreateAccountInstruction,
     type CreateAccountInput,
-    type CreateAccountInstruction,
     type ParsedCreateAccountInstruction,
 } from '../instructions';
 
@@ -73,7 +72,9 @@ export function parseSystemInstruction<TProgram extends string>(
 export type SystemPlugin = { instructions: SystemPluginInstructions };
 
 export type SystemPluginInstructions = {
-    createAccount: (input: CreateAccountInput) => CreateAccountInstruction & SelfPlanAndSendFunctions;
+    createAccount: (
+        input: MakeOptional<CreateAccountInput, 'payer'>,
+    ) => ReturnType<typeof getCreateAccountInstruction> & SelfPlanAndSendFunctions;
 };
 
 export type SystemPluginRequirements = ClientWithPayer & ClientWithTransactionPlanning & ClientWithTransactionSending;

--- a/test/e2e/token/src/generated/programs/token.ts
+++ b/test/e2e/token/src/generated/programs/token.ts
@@ -93,41 +93,23 @@ import {
     parseTransferInstruction,
     parseUiAmountToAmountInstruction,
     type AmountToUiAmountInput,
-    type AmountToUiAmountInstruction,
     type ApproveCheckedInput,
-    type ApproveCheckedInstruction,
     type ApproveInput,
-    type ApproveInstruction,
     type BurnCheckedInput,
-    type BurnCheckedInstruction,
     type BurnInput,
-    type BurnInstruction,
     type CloseAccountInput,
-    type CloseAccountInstruction,
     type FreezeAccountInput,
-    type FreezeAccountInstruction,
     type GetAccountDataSizeInput,
-    type GetAccountDataSizeInstruction,
     type InitializeAccount2Input,
-    type InitializeAccount2Instruction,
     type InitializeAccount3Input,
-    type InitializeAccount3Instruction,
     type InitializeAccountInput,
-    type InitializeAccountInstruction,
     type InitializeImmutableOwnerInput,
-    type InitializeImmutableOwnerInstruction,
     type InitializeMint2Input,
-    type InitializeMint2Instruction,
     type InitializeMintInput,
-    type InitializeMintInstruction,
     type InitializeMultisig2Input,
-    type InitializeMultisig2Instruction,
     type InitializeMultisigInput,
-    type InitializeMultisigInstruction,
     type MintToCheckedInput,
-    type MintToCheckedInstruction,
     type MintToInput,
-    type MintToInstruction,
     type ParsedAmountToUiAmountInstruction,
     type ParsedApproveCheckedInstruction,
     type ParsedApproveInstruction,
@@ -154,19 +136,12 @@ import {
     type ParsedTransferInstruction,
     type ParsedUiAmountToAmountInstruction,
     type RevokeInput,
-    type RevokeInstruction,
     type SetAuthorityInput,
-    type SetAuthorityInstruction,
     type SyncNativeInput,
-    type SyncNativeInstruction,
     type ThawAccountInput,
-    type ThawAccountInstruction,
     type TransferCheckedInput,
-    type TransferCheckedInstruction,
     type TransferInput,
-    type TransferInstruction,
     type UiAmountToAmountInput,
-    type UiAmountToAmountInstruction,
 } from '../instructions';
 
 export const TOKEN_PROGRAM_ADDRESS =
@@ -492,33 +467,65 @@ export type TokenPluginAccounts = {
 };
 
 export type TokenPluginInstructions = {
-    initializeMint: (input: InitializeMintInput) => InitializeMintInstruction & SelfPlanAndSendFunctions;
-    initializeAccount: (input: InitializeAccountInput) => InitializeAccountInstruction & SelfPlanAndSendFunctions;
-    initializeMultisig: (input: InitializeMultisigInput) => InitializeMultisigInstruction & SelfPlanAndSendFunctions;
-    transfer: (input: TransferInput) => TransferInstruction & SelfPlanAndSendFunctions;
-    approve: (input: ApproveInput) => ApproveInstruction & SelfPlanAndSendFunctions;
-    revoke: (input: RevokeInput) => RevokeInstruction & SelfPlanAndSendFunctions;
-    setAuthority: (input: SetAuthorityInput) => SetAuthorityInstruction & SelfPlanAndSendFunctions;
-    mintTo: (input: MintToInput) => MintToInstruction & SelfPlanAndSendFunctions;
-    burn: (input: BurnInput) => BurnInstruction & SelfPlanAndSendFunctions;
-    closeAccount: (input: CloseAccountInput) => CloseAccountInstruction & SelfPlanAndSendFunctions;
-    freezeAccount: (input: FreezeAccountInput) => FreezeAccountInstruction & SelfPlanAndSendFunctions;
-    thawAccount: (input: ThawAccountInput) => ThawAccountInstruction & SelfPlanAndSendFunctions;
-    transferChecked: (input: TransferCheckedInput) => TransferCheckedInstruction & SelfPlanAndSendFunctions;
-    approveChecked: (input: ApproveCheckedInput) => ApproveCheckedInstruction & SelfPlanAndSendFunctions;
-    mintToChecked: (input: MintToCheckedInput) => MintToCheckedInstruction & SelfPlanAndSendFunctions;
-    burnChecked: (input: BurnCheckedInput) => BurnCheckedInstruction & SelfPlanAndSendFunctions;
-    initializeAccount2: (input: InitializeAccount2Input) => InitializeAccount2Instruction & SelfPlanAndSendFunctions;
-    syncNative: (input: SyncNativeInput) => SyncNativeInstruction & SelfPlanAndSendFunctions;
-    initializeAccount3: (input: InitializeAccount3Input) => InitializeAccount3Instruction & SelfPlanAndSendFunctions;
-    initializeMultisig2: (input: InitializeMultisig2Input) => InitializeMultisig2Instruction & SelfPlanAndSendFunctions;
-    initializeMint2: (input: InitializeMint2Input) => InitializeMint2Instruction & SelfPlanAndSendFunctions;
-    getAccountDataSize: (input: GetAccountDataSizeInput) => GetAccountDataSizeInstruction & SelfPlanAndSendFunctions;
+    initializeMint: (
+        input: InitializeMintInput,
+    ) => ReturnType<typeof getInitializeMintInstruction> & SelfPlanAndSendFunctions;
+    initializeAccount: (
+        input: InitializeAccountInput,
+    ) => ReturnType<typeof getInitializeAccountInstruction> & SelfPlanAndSendFunctions;
+    initializeMultisig: (
+        input: InitializeMultisigInput,
+    ) => ReturnType<typeof getInitializeMultisigInstruction> & SelfPlanAndSendFunctions;
+    transfer: (input: TransferInput) => ReturnType<typeof getTransferInstruction> & SelfPlanAndSendFunctions;
+    approve: (input: ApproveInput) => ReturnType<typeof getApproveInstruction> & SelfPlanAndSendFunctions;
+    revoke: (input: RevokeInput) => ReturnType<typeof getRevokeInstruction> & SelfPlanAndSendFunctions;
+    setAuthority: (
+        input: SetAuthorityInput,
+    ) => ReturnType<typeof getSetAuthorityInstruction> & SelfPlanAndSendFunctions;
+    mintTo: (input: MintToInput) => ReturnType<typeof getMintToInstruction> & SelfPlanAndSendFunctions;
+    burn: (input: BurnInput) => ReturnType<typeof getBurnInstruction> & SelfPlanAndSendFunctions;
+    closeAccount: (
+        input: CloseAccountInput,
+    ) => ReturnType<typeof getCloseAccountInstruction> & SelfPlanAndSendFunctions;
+    freezeAccount: (
+        input: FreezeAccountInput,
+    ) => ReturnType<typeof getFreezeAccountInstruction> & SelfPlanAndSendFunctions;
+    thawAccount: (input: ThawAccountInput) => ReturnType<typeof getThawAccountInstruction> & SelfPlanAndSendFunctions;
+    transferChecked: (
+        input: TransferCheckedInput,
+    ) => ReturnType<typeof getTransferCheckedInstruction> & SelfPlanAndSendFunctions;
+    approveChecked: (
+        input: ApproveCheckedInput,
+    ) => ReturnType<typeof getApproveCheckedInstruction> & SelfPlanAndSendFunctions;
+    mintToChecked: (
+        input: MintToCheckedInput,
+    ) => ReturnType<typeof getMintToCheckedInstruction> & SelfPlanAndSendFunctions;
+    burnChecked: (input: BurnCheckedInput) => ReturnType<typeof getBurnCheckedInstruction> & SelfPlanAndSendFunctions;
+    initializeAccount2: (
+        input: InitializeAccount2Input,
+    ) => ReturnType<typeof getInitializeAccount2Instruction> & SelfPlanAndSendFunctions;
+    syncNative: (input: SyncNativeInput) => ReturnType<typeof getSyncNativeInstruction> & SelfPlanAndSendFunctions;
+    initializeAccount3: (
+        input: InitializeAccount3Input,
+    ) => ReturnType<typeof getInitializeAccount3Instruction> & SelfPlanAndSendFunctions;
+    initializeMultisig2: (
+        input: InitializeMultisig2Input,
+    ) => ReturnType<typeof getInitializeMultisig2Instruction> & SelfPlanAndSendFunctions;
+    initializeMint2: (
+        input: InitializeMint2Input,
+    ) => ReturnType<typeof getInitializeMint2Instruction> & SelfPlanAndSendFunctions;
+    getAccountDataSize: (
+        input: GetAccountDataSizeInput,
+    ) => ReturnType<typeof getGetAccountDataSizeInstruction> & SelfPlanAndSendFunctions;
     initializeImmutableOwner: (
         input: InitializeImmutableOwnerInput,
-    ) => InitializeImmutableOwnerInstruction & SelfPlanAndSendFunctions;
-    amountToUiAmount: (input: AmountToUiAmountInput) => AmountToUiAmountInstruction & SelfPlanAndSendFunctions;
-    uiAmountToAmount: (input: UiAmountToAmountInput) => UiAmountToAmountInstruction & SelfPlanAndSendFunctions;
+    ) => ReturnType<typeof getInitializeImmutableOwnerInstruction> & SelfPlanAndSendFunctions;
+    amountToUiAmount: (
+        input: AmountToUiAmountInput,
+    ) => ReturnType<typeof getAmountToUiAmountInstruction> & SelfPlanAndSendFunctions;
+    uiAmountToAmount: (
+        input: UiAmountToAmountInput,
+    ) => ReturnType<typeof getUiAmountToAmountInstruction> & SelfPlanAndSendFunctions;
 };
 
 export type TokenPluginRequirements = ClientWithRpc<GetAccountInfoApi & GetMultipleAccountsApi> &

--- a/test/fragments/programPlugin.test.ts
+++ b/test/fragments/programPlugin.test.ts
@@ -85,8 +85,8 @@ test('it renders program plugin instruction types', async () => {
     // Then we expect the following type to be rendered.
     await fragmentContains(fragment, [
         'export type SplTokenPluginInstructions = {',
-        'initializeToken: ( input: InitializeTokenInput ) => InitializeTokenInstruction & SelfPlanAndSendFunctions;',
-        'initializeMint: ( input: InitializeMintInput ) => InitializeMintInstruction & SelfPlanAndSendFunctions;',
+        'initializeToken: ( input: InitializeTokenInput ) => ReturnType<typeof getInitializeTokenInstruction> & SelfPlanAndSendFunctions;',
+        'initializeMint: ( input: InitializeMintInput ) => ReturnType<typeof getInitializeMintInstruction> & SelfPlanAndSendFunctions;',
     ]);
 
     // And we expect the necessary imports to be included.
@@ -137,8 +137,8 @@ test('it renders program plugin instruction types with async builders', async ()
     // Then we expect the `initializeAssociatedToken` instruction to be using the async input type.
     await fragmentContains(fragment, [
         'export type SplTokenPluginInstructions = {',
-        'initializeAssociatedToken: ( input: InitializeAssociatedTokenAsyncInput ) => Promise<InitializeAssociatedTokenInstruction> & SelfPlanAndSendFunctions;',
-        'initializeMint: ( input: InitializeMintInput ) => InitializeMintInstruction & SelfPlanAndSendFunctions;',
+        'initializeAssociatedToken: ( input: InitializeAssociatedTokenAsyncInput ) => ReturnType<typeof getInitializeAssociatedTokenInstructionAsync> & SelfPlanAndSendFunctions;',
+        'initializeMint: ( input: InitializeMintInput ) => ReturnType<typeof getInitializeMintInstruction> & SelfPlanAndSendFunctions;',
     ]);
 });
 


### PR DESCRIPTION
This PR fixes the generated plugin instruction type in two ways:

1. The return type now uses `ReturnType<typeof instructionFunction>` instead of manually constructing it from the instruction type (with or without `Promise` wrapping). This ensures the plugin type always stays in sync with the actual instruction function signature (we had issues with instruction that say add `InstructionWithByteDeltas` in the mix).

2. Payer default values are now marked as optional in the plugin's type definition (the `Instructions` type alias), not just in the runtime implementation. Previously, the type required all payer fields even though the implementation filled them in automatically.
