### PR TITLE
Move plugin instruction input types from function to type definition

### DIFF
--- a/test/e2e/anchor/src/generated/programs/wenTransferGuard.ts
+++ b/test/e2e/anchor/src/generated/programs/wenTransferGuard.ts
@@ -206,25 +206,23 @@ export function wenTransferGuardProgram() {
     return <T extends WenTransferGuardPluginRequirements>(client: T) => {
         return {
             ...client,
-            wenTransferGuard: {
+            wenTransferGuard: <WenTransferGuardPlugin>{
                 accounts: { guardV1: addSelfFetchFunctions(client, getGuardV1Codec()) },
                 instructions: {
-                    createGuard: (input: MakeOptional<CreateGuardAsyncInput, 'payer'>) =>
+                    createGuard: input =>
                         addSelfPlanAndSendFunctions(
                             client,
                             getCreateGuardInstructionAsync({ ...input, payer: input.payer ?? client.payer }),
                         ),
-                    execute: (input: ExecuteAsyncInput) =>
-                        addSelfPlanAndSendFunctions(client, getExecuteInstructionAsync(input)),
-                    initialize: (input: MakeOptional<InitializeAsyncInput, 'payer'>) =>
+                    execute: input => addSelfPlanAndSendFunctions(client, getExecuteInstructionAsync(input)),
+                    initialize: input =>
                         addSelfPlanAndSendFunctions(
                             client,
                             getInitializeInstructionAsync({ ...input, payer: input.payer ?? client.payer }),
                         ),
-                    updateGuard: (input: UpdateGuardAsyncInput) =>
-                        addSelfPlanAndSendFunctions(client, getUpdateGuardInstructionAsync(input)),
+                    updateGuard: input => addSelfPlanAndSendFunctions(client, getUpdateGuardInstructionAsync(input)),
                 },
-            } as WenTransferGuardPlugin,
+            },
         };
     };
 }

--- a/test/e2e/dummy/src/generated/programs/dummy.ts
+++ b/test/e2e/dummy/src/generated/programs/dummy.ts
@@ -181,25 +181,17 @@ export function dummyProgram() {
     return <T extends DummyPluginRequirements>(client: T) => {
         return {
             ...client,
-            dummy: {
+            dummy: <DummyPlugin>{
                 instructions: {
-                    instruction1: (input: Instruction1Input) =>
-                        addSelfPlanAndSendFunctions(client, getInstruction1Instruction(input)),
-                    instruction2: (input: Instruction2Input) =>
-                        addSelfPlanAndSendFunctions(client, getInstruction2Instruction(input)),
-                    instruction3: (input: Instruction3Input) =>
-                        addSelfPlanAndSendFunctions(client, getInstruction3Instruction(input)),
-                    instruction4: (input: Instruction4Input) =>
-                        addSelfPlanAndSendFunctions(client, getInstruction4Instruction(input)),
-                    instruction5: (input: Instruction5Input) =>
-                        addSelfPlanAndSendFunctions(client, getInstruction5Instruction(input)),
-                    instruction6: (input: Instruction6Input) =>
-                        addSelfPlanAndSendFunctions(client, getInstruction6Instruction(input)),
-                    instruction7: (input: Instruction7Input) =>
-                        addSelfPlanAndSendFunctions(client, getInstruction7Instruction(input)),
-                    instruction8: (input: Instruction8Input) =>
-                        addSelfPlanAndSendFunctions(client, getInstruction8Instruction(input)),
-                    instruction9: (input: MakeOptional<Instruction9Input, 'authority' | 'authorityArg'>) =>
+                    instruction1: input => addSelfPlanAndSendFunctions(client, getInstruction1Instruction(input)),
+                    instruction2: input => addSelfPlanAndSendFunctions(client, getInstruction2Instruction(input)),
+                    instruction3: input => addSelfPlanAndSendFunctions(client, getInstruction3Instruction(input)),
+                    instruction4: input => addSelfPlanAndSendFunctions(client, getInstruction4Instruction(input)),
+                    instruction5: input => addSelfPlanAndSendFunctions(client, getInstruction5Instruction(input)),
+                    instruction6: input => addSelfPlanAndSendFunctions(client, getInstruction6Instruction(input)),
+                    instruction7: input => addSelfPlanAndSendFunctions(client, getInstruction7Instruction(input)),
+                    instruction8: input => addSelfPlanAndSendFunctions(client, getInstruction8Instruction(input)),
+                    instruction9: input =>
                         addSelfPlanAndSendFunctions(
                             client,
                             getInstruction9Instruction({
@@ -209,7 +201,7 @@ export function dummyProgram() {
                             }),
                         ),
                 },
-            } as DummyPlugin,
+            },
         };
     };
 }

--- a/test/e2e/memo/src/generated/programs/memo.ts
+++ b/test/e2e/memo/src/generated/programs/memo.ts
@@ -33,11 +33,9 @@ export function memoProgram() {
     return <T extends MemoPluginRequirements>(client: T) => {
         return {
             ...client,
-            memo: {
-                instructions: {
-                    addMemo: (input: AddMemoInput) => addSelfPlanAndSendFunctions(client, getAddMemoInstruction(input)),
-                },
-            } as MemoPlugin,
+            memo: <MemoPlugin>{
+                instructions: { addMemo: input => addSelfPlanAndSendFunctions(client, getAddMemoInstruction(input)) },
+            },
         };
     };
 }

--- a/test/e2e/system/src/generated/programs/system.ts
+++ b/test/e2e/system/src/generated/programs/system.ts
@@ -315,42 +315,39 @@ export function systemProgram() {
     return <T extends SystemPluginRequirements>(client: T) => {
         return {
             ...client,
-            system: {
+            system: <SystemPlugin>{
                 accounts: { nonce: addSelfFetchFunctions(client, getNonceCodec()) },
                 instructions: {
-                    createAccount: (input: MakeOptional<CreateAccountInput, 'payer'>) =>
+                    createAccount: input =>
                         addSelfPlanAndSendFunctions(
                             client,
                             getCreateAccountInstruction({ ...input, payer: input.payer ?? client.payer }),
                         ),
-                    assign: (input: AssignInput) => addSelfPlanAndSendFunctions(client, getAssignInstruction(input)),
-                    transferSol: (input: TransferSolInput) =>
-                        addSelfPlanAndSendFunctions(client, getTransferSolInstruction(input)),
-                    createAccountWithSeed: (input: MakeOptional<CreateAccountWithSeedInput, 'payer'>) =>
+                    assign: input => addSelfPlanAndSendFunctions(client, getAssignInstruction(input)),
+                    transferSol: input => addSelfPlanAndSendFunctions(client, getTransferSolInstruction(input)),
+                    createAccountWithSeed: input =>
                         addSelfPlanAndSendFunctions(
                             client,
                             getCreateAccountWithSeedInstruction({ ...input, payer: input.payer ?? client.payer }),
                         ),
-                    advanceNonceAccount: (input: AdvanceNonceAccountInput) =>
+                    advanceNonceAccount: input =>
                         addSelfPlanAndSendFunctions(client, getAdvanceNonceAccountInstruction(input)),
-                    withdrawNonceAccount: (input: WithdrawNonceAccountInput) =>
+                    withdrawNonceAccount: input =>
                         addSelfPlanAndSendFunctions(client, getWithdrawNonceAccountInstruction(input)),
-                    initializeNonceAccount: (input: InitializeNonceAccountInput) =>
+                    initializeNonceAccount: input =>
                         addSelfPlanAndSendFunctions(client, getInitializeNonceAccountInstruction(input)),
-                    authorizeNonceAccount: (input: AuthorizeNonceAccountInput) =>
+                    authorizeNonceAccount: input =>
                         addSelfPlanAndSendFunctions(client, getAuthorizeNonceAccountInstruction(input)),
-                    allocate: (input: AllocateInput) =>
-                        addSelfPlanAndSendFunctions(client, getAllocateInstruction(input)),
-                    allocateWithSeed: (input: AllocateWithSeedInput) =>
+                    allocate: input => addSelfPlanAndSendFunctions(client, getAllocateInstruction(input)),
+                    allocateWithSeed: input =>
                         addSelfPlanAndSendFunctions(client, getAllocateWithSeedInstruction(input)),
-                    assignWithSeed: (input: AssignWithSeedInput) =>
-                        addSelfPlanAndSendFunctions(client, getAssignWithSeedInstruction(input)),
-                    transferSolWithSeed: (input: TransferSolWithSeedInput) =>
+                    assignWithSeed: input => addSelfPlanAndSendFunctions(client, getAssignWithSeedInstruction(input)),
+                    transferSolWithSeed: input =>
                         addSelfPlanAndSendFunctions(client, getTransferSolWithSeedInstruction(input)),
-                    upgradeNonceAccount: (input: UpgradeNonceAccountInput) =>
+                    upgradeNonceAccount: input =>
                         addSelfPlanAndSendFunctions(client, getUpgradeNonceAccountInstruction(input)),
                 },
-            } as SystemPlugin,
+            },
         };
     };
 }

--- a/test/e2e/token/src/generated/programs/associatedToken.ts
+++ b/test/e2e/token/src/generated/programs/associatedToken.ts
@@ -132,16 +132,14 @@ export function associatedTokenProgram() {
     return <T extends AssociatedTokenPluginRequirements>(client: T) => {
         return {
             ...client,
-            associatedToken: {
+            associatedToken: <AssociatedTokenPlugin>{
                 instructions: {
-                    createAssociatedToken: (input: MakeOptional<CreateAssociatedTokenAsyncInput, 'payer'>) =>
+                    createAssociatedToken: input =>
                         addSelfPlanAndSendFunctions(
                             client,
                             getCreateAssociatedTokenInstructionAsync({ ...input, payer: input.payer ?? client.payer }),
                         ),
-                    createAssociatedTokenIdempotent: (
-                        input: MakeOptional<CreateAssociatedTokenIdempotentAsyncInput, 'payer'>,
-                    ) =>
+                    createAssociatedTokenIdempotent: input =>
                         addSelfPlanAndSendFunctions(
                             client,
                             getCreateAssociatedTokenIdempotentInstructionAsync({
@@ -149,10 +147,10 @@ export function associatedTokenProgram() {
                                 payer: input.payer ?? client.payer,
                             }),
                         ),
-                    recoverNestedAssociatedToken: (input: RecoverNestedAssociatedTokenAsyncInput) =>
+                    recoverNestedAssociatedToken: input =>
                         addSelfPlanAndSendFunctions(client, getRecoverNestedAssociatedTokenInstructionAsync(input)),
                 },
-            } as AssociatedTokenPlugin,
+            },
         };
     };
 }

--- a/test/e2e/token/src/generated/programs/system.ts
+++ b/test/e2e/token/src/generated/programs/system.ts
@@ -83,15 +83,15 @@ export function systemProgram() {
     return <T extends SystemPluginRequirements>(client: T) => {
         return {
             ...client,
-            system: {
+            system: <SystemPlugin>{
                 instructions: {
-                    createAccount: (input: MakeOptional<CreateAccountInput, 'payer'>) =>
+                    createAccount: input =>
                         addSelfPlanAndSendFunctions(
                             client,
                             getCreateAccountInstruction({ ...input, payer: input.payer ?? client.payer }),
                         ),
                 },
-            } as SystemPlugin,
+            },
         };
     };
 }

--- a/test/e2e/token/src/generated/programs/token.ts
+++ b/test/e2e/token/src/generated/programs/token.ts
@@ -536,61 +536,49 @@ export function tokenProgram() {
     return <T extends TokenPluginRequirements>(client: T) => {
         return {
             ...client,
-            token: {
+            token: <TokenPlugin>{
                 accounts: {
                     mint: addSelfFetchFunctions(client, getMintCodec()),
                     token: addSelfFetchFunctions(client, getTokenCodec()),
                     multisig: addSelfFetchFunctions(client, getMultisigCodec()),
                 },
                 instructions: {
-                    initializeMint: (input: InitializeMintInput) =>
-                        addSelfPlanAndSendFunctions(client, getInitializeMintInstruction(input)),
-                    initializeAccount: (input: InitializeAccountInput) =>
+                    initializeMint: input => addSelfPlanAndSendFunctions(client, getInitializeMintInstruction(input)),
+                    initializeAccount: input =>
                         addSelfPlanAndSendFunctions(client, getInitializeAccountInstruction(input)),
-                    initializeMultisig: (input: InitializeMultisigInput) =>
+                    initializeMultisig: input =>
                         addSelfPlanAndSendFunctions(client, getInitializeMultisigInstruction(input)),
-                    transfer: (input: TransferInput) =>
-                        addSelfPlanAndSendFunctions(client, getTransferInstruction(input)),
-                    approve: (input: ApproveInput) => addSelfPlanAndSendFunctions(client, getApproveInstruction(input)),
-                    revoke: (input: RevokeInput) => addSelfPlanAndSendFunctions(client, getRevokeInstruction(input)),
-                    setAuthority: (input: SetAuthorityInput) =>
-                        addSelfPlanAndSendFunctions(client, getSetAuthorityInstruction(input)),
-                    mintTo: (input: MintToInput) => addSelfPlanAndSendFunctions(client, getMintToInstruction(input)),
-                    burn: (input: BurnInput) => addSelfPlanAndSendFunctions(client, getBurnInstruction(input)),
-                    closeAccount: (input: CloseAccountInput) =>
-                        addSelfPlanAndSendFunctions(client, getCloseAccountInstruction(input)),
-                    freezeAccount: (input: FreezeAccountInput) =>
-                        addSelfPlanAndSendFunctions(client, getFreezeAccountInstruction(input)),
-                    thawAccount: (input: ThawAccountInput) =>
-                        addSelfPlanAndSendFunctions(client, getThawAccountInstruction(input)),
-                    transferChecked: (input: TransferCheckedInput) =>
-                        addSelfPlanAndSendFunctions(client, getTransferCheckedInstruction(input)),
-                    approveChecked: (input: ApproveCheckedInput) =>
-                        addSelfPlanAndSendFunctions(client, getApproveCheckedInstruction(input)),
-                    mintToChecked: (input: MintToCheckedInput) =>
-                        addSelfPlanAndSendFunctions(client, getMintToCheckedInstruction(input)),
-                    burnChecked: (input: BurnCheckedInput) =>
-                        addSelfPlanAndSendFunctions(client, getBurnCheckedInstruction(input)),
-                    initializeAccount2: (input: InitializeAccount2Input) =>
+                    transfer: input => addSelfPlanAndSendFunctions(client, getTransferInstruction(input)),
+                    approve: input => addSelfPlanAndSendFunctions(client, getApproveInstruction(input)),
+                    revoke: input => addSelfPlanAndSendFunctions(client, getRevokeInstruction(input)),
+                    setAuthority: input => addSelfPlanAndSendFunctions(client, getSetAuthorityInstruction(input)),
+                    mintTo: input => addSelfPlanAndSendFunctions(client, getMintToInstruction(input)),
+                    burn: input => addSelfPlanAndSendFunctions(client, getBurnInstruction(input)),
+                    closeAccount: input => addSelfPlanAndSendFunctions(client, getCloseAccountInstruction(input)),
+                    freezeAccount: input => addSelfPlanAndSendFunctions(client, getFreezeAccountInstruction(input)),
+                    thawAccount: input => addSelfPlanAndSendFunctions(client, getThawAccountInstruction(input)),
+                    transferChecked: input => addSelfPlanAndSendFunctions(client, getTransferCheckedInstruction(input)),
+                    approveChecked: input => addSelfPlanAndSendFunctions(client, getApproveCheckedInstruction(input)),
+                    mintToChecked: input => addSelfPlanAndSendFunctions(client, getMintToCheckedInstruction(input)),
+                    burnChecked: input => addSelfPlanAndSendFunctions(client, getBurnCheckedInstruction(input)),
+                    initializeAccount2: input =>
                         addSelfPlanAndSendFunctions(client, getInitializeAccount2Instruction(input)),
-                    syncNative: (input: SyncNativeInput) =>
-                        addSelfPlanAndSendFunctions(client, getSyncNativeInstruction(input)),
-                    initializeAccount3: (input: InitializeAccount3Input) =>
+                    syncNative: input => addSelfPlanAndSendFunctions(client, getSyncNativeInstruction(input)),
+                    initializeAccount3: input =>
                         addSelfPlanAndSendFunctions(client, getInitializeAccount3Instruction(input)),
-                    initializeMultisig2: (input: InitializeMultisig2Input) =>
+                    initializeMultisig2: input =>
                         addSelfPlanAndSendFunctions(client, getInitializeMultisig2Instruction(input)),
-                    initializeMint2: (input: InitializeMint2Input) =>
-                        addSelfPlanAndSendFunctions(client, getInitializeMint2Instruction(input)),
-                    getAccountDataSize: (input: GetAccountDataSizeInput) =>
+                    initializeMint2: input => addSelfPlanAndSendFunctions(client, getInitializeMint2Instruction(input)),
+                    getAccountDataSize: input =>
                         addSelfPlanAndSendFunctions(client, getGetAccountDataSizeInstruction(input)),
-                    initializeImmutableOwner: (input: InitializeImmutableOwnerInput) =>
+                    initializeImmutableOwner: input =>
                         addSelfPlanAndSendFunctions(client, getInitializeImmutableOwnerInstruction(input)),
-                    amountToUiAmount: (input: AmountToUiAmountInput) =>
+                    amountToUiAmount: input =>
                         addSelfPlanAndSendFunctions(client, getAmountToUiAmountInstruction(input)),
-                    uiAmountToAmount: (input: UiAmountToAmountInput) =>
+                    uiAmountToAmount: input =>
                         addSelfPlanAndSendFunctions(client, getUiAmountToAmountInstruction(input)),
                 },
-            } as TokenPlugin,
+            },
         };
     };
 }


### PR DESCRIPTION
This PR moves plugin instruction input type annotations from the function implementation to the plugin type definition, so the function body uses untyped `input =>` arrows and relies on the `<PluginType>{...}` assertion for type inference.
