### PR TITLE
Add missing packages to `DEFAULT_DEPENDENCY_VERSIONS`

### DIFF
--- a/.changeset/late-cases-move.md
+++ b/.changeset/late-cases-move.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-js': patch
+---
+
+Add missing packages in `DEFAULT_DEPENDENCY_VERSIONS` and bump to 6.1.0

--- a/src/utils/packageJson.ts
+++ b/src/utils/packageJson.ts
@@ -23,15 +23,20 @@ type PackageJson = {
 };
 
 export const DEFAULT_DEPENDENCY_VERSIONS: DependencyVersions = {
-    '@solana/accounts': '^6.0.0',
-    '@solana/addresses': '^6.0.0',
-    '@solana/codecs': '^6.0.0',
-    '@solana/errors': '^6.0.0',
-    '@solana/instructions': '^6.0.0',
-    '@solana/kit': '^6.0.0',
-    '@solana/programs': '^6.0.0',
-    '@solana/rpc-types': '^6.0.0',
-    '@solana/signers': '^6.0.0',
+    '@solana/accounts': '^6.1.0',
+    '@solana/addresses': '^6.1.0',
+    '@solana/codecs': '^6.1.0',
+    '@solana/errors': '^6.1.0',
+    '@solana/instruction-plans': '^6.1.0',
+    '@solana/instructions': '^6.1.0',
+    '@solana/kit': '^6.1.0',
+    '@solana/plugin-core': '^6.1.0',
+    '@solana/plugin-interfaces': '^6.1.0',
+    '@solana/program-client-core': '^6.1.0',
+    '@solana/programs': '^6.1.0',
+    '@solana/rpc-api': '^6.1.0',
+    '@solana/rpc-types': '^6.1.0',
+    '@solana/signers': '^6.1.0',
 };
 
 export async function syncPackageJson(


### PR DESCRIPTION
This PR adds the newly used packages to the `DEFAULT_DEPENDENCY_VERSIONS` object and bumps their version from `6.0.0` to `6.1.0` which is required to access some of these new packages.