### PR TITLE
Add PDA derivation to generated program plugin

### DIFF
--- a/.changeset/add-pdas-to-plugin.md
+++ b/.changeset/add-pdas-to-plugin.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-js': minor
+---
+
+Add PDA derivation to generated program plugin

--- a/src/fragments/programPlugin.ts
+++ b/src/fragments/programPlugin.ts
@@ -14,7 +14,12 @@ import { getRenamedArgsMap } from './instructionPage';
 export function getProgramPluginFragment(
     scope: Pick<RenderScope, 'asyncResolvers' | 'nameApi'> & { programNode: ProgramNode },
 ): Fragment | undefined {
-    if (scope.programNode.accounts.length === 0 && scope.programNode.instructions.length === 0) return;
+    if (
+        scope.programNode.accounts.length === 0 &&
+        scope.programNode.instructions.length === 0 &&
+        scope.programNode.pdas.length === 0
+    )
+        return;
 
     const resolvedInstructionInputVisitor = getResolvedInstructionInputsVisitor();
     const asyncInstructions: CamelCaseString[] = scope.programNode.instructions
@@ -28,6 +33,7 @@ export function getProgramPluginFragment(
             getProgramPluginTypeFragment(scope),
             getProgramPluginAccountsTypeFragment(scope),
             getProgramPluginInstructionsTypeFragment({ ...scope, asyncInstructions }),
+            getProgramPluginPdasTypeFragment(scope),
             getProgramPluginRequirementsTypeFragment(scope),
             getProgramPluginFunctionFragment({ ...scope, asyncInstructions }),
             getMakeOptionalHelperTypeFragment(scope),
@@ -41,11 +47,13 @@ function getProgramPluginTypeFragment(scope: Pick<RenderScope, 'nameApi'> & { pr
     const programPluginType = nameApi.programPluginType(programNode.name);
     const programPluginAccountsType = nameApi.programPluginAccountsType(programNode.name);
     const programPluginInstructionsType = nameApi.programPluginInstructionsType(programNode.name);
+    const programPluginPdasType = nameApi.programPluginPdasType(programNode.name);
 
     const fields = mergeFragments(
         [
             programNode.accounts.length > 0 ? fragment`accounts: ${programPluginAccountsType};` : undefined,
             programNode.instructions.length > 0 ? fragment`instructions: ${programPluginInstructionsType};` : undefined,
+            programNode.pdas.length > 0 ? fragment`pdas: ${programPluginPdasType};` : undefined,
         ],
         c => c.join(' '),
     );
@@ -108,6 +116,43 @@ function getProgramPluginInstructionsTypeFragment(
     return fragment`export type ${programPluginInstructionsType} = { ${fields} }`;
 }
 
+function getProgramPluginPdasTypeFragment(
+    scope: Pick<RenderScope, 'nameApi'> & { programNode: ProgramNode },
+): Fragment | undefined {
+    const { programNode, nameApi } = scope;
+    if (programNode.pdas.length === 0) return;
+    const programPluginPdasType = nameApi.programPluginPdasType(programNode.name);
+
+    const fields = mergeFragments(
+        programNode.pdas.map(pda => {
+            const name = nameApi.programPluginPdaKey(pda.name);
+            const pdaFindFunction = use('type ' + nameApi.pdaFindFunction(pda.name), 'generatedPdas');
+            return fragment`${name}: typeof ${pdaFindFunction};`;
+        }),
+        c => c.join(' '),
+    );
+
+    return fragment`export type ${programPluginPdasType} = { ${fields} }`;
+}
+
+function getProgramPluginPdasObjectFragment(
+    scope: Pick<RenderScope, 'nameApi'> & { programNode: ProgramNode },
+): Fragment | undefined {
+    const { programNode, nameApi } = scope;
+    if (programNode.pdas.length === 0) return;
+
+    const fields = mergeFragments(
+        programNode.pdas.map(pda => {
+            const name = nameApi.programPluginPdaKey(pda.name);
+            const pdaFindFunction = use(nameApi.pdaFindFunction(pda.name), 'generatedPdas');
+            return fragment`${name}: ${pdaFindFunction}`;
+        }),
+        c => c.join(', '),
+    );
+
+    return fragment`pdas: { ${fields} }`;
+}
+
 function getProgramPluginRequirementsTypeFragment(
     scope: Pick<RenderScope, 'nameApi'> & { programNode: ProgramNode },
 ): Fragment {
@@ -120,15 +165,18 @@ function getProgramPluginRequirementsTypeFragment(
     const hasAccounts = programNode.accounts.length > 0;
     const hasInstructions = programNode.instructions.length > 0;
 
-    const requirements = mergeFragments(
-        [
-            hasAccounts ? clientWithRpc : undefined,
-            hasPayerDefaultValues(programNode) ? clientWithPayer : undefined,
-            hasInstructions ? clientWithTransactionPlanning : undefined,
-            hasInstructions ? clientWithTransactionSending : undefined,
-        ],
-        c => c.join(' & '),
-    );
+    const requirementList = [
+        hasAccounts ? clientWithRpc : undefined,
+        hasPayerDefaultValues(programNode) ? clientWithPayer : undefined,
+        hasInstructions ? clientWithTransactionPlanning : undefined,
+        hasInstructions ? clientWithTransactionSending : undefined,
+    ].filter((r): r is Fragment => r !== undefined);
+
+    if (requirementList.length === 0) {
+        return fragment`export type ${programRequirementsType} = object`;
+    }
+
+    const requirements = mergeFragments(requirementList, c => c.join(' & '));
 
     return fragment`export type ${programRequirementsType} = ${requirements}`;
 }
@@ -143,7 +191,11 @@ function getProgramPluginFunctionFragment(
     const programPluginKey = nameApi.programPluginKey(programNode.name);
 
     const fields = mergeFragments(
-        [getProgramPluginAccountsObjectFragment(scope), getProgramPluginInstructionsObjectFragment(scope)],
+        [
+            getProgramPluginAccountsObjectFragment(scope),
+            getProgramPluginInstructionsObjectFragment(scope),
+            getProgramPluginPdasObjectFragment(scope),
+        ],
         c => c.join(', '),
     );
 

--- a/src/utils/nameTransformers.ts
+++ b/src/utils/nameTransformers.ts
@@ -64,6 +64,8 @@ export type NameTransformerKey =
     | 'programPluginInstructionKey'
     | 'programPluginInstructionsType'
     | 'programPluginKey'
+    | 'programPluginPdaKey'
+    | 'programPluginPdasType'
     | 'programPluginRequirementsType'
     | 'programPluginType'
     | 'resolverFunction';
@@ -139,6 +141,8 @@ export const DEFAULT_NAME_TRANSFORMERS: NameTransformers = {
     programPluginInstructionKey: name => `${camelCase(name)}`,
     programPluginInstructionsType: name => `${pascalCase(name)}PluginInstructions`,
     programPluginKey: name => `${camelCase(name)}`,
+    programPluginPdaKey: name => `${camelCase(name)}`,
+    programPluginPdasType: name => `${pascalCase(name)}PluginPdas`,
     programPluginRequirementsType: name => `${pascalCase(name)}PluginRequirements`,
     programPluginType: name => `${pascalCase(name)}Plugin`,
     resolverFunction: name => `${camelCase(name)}`,

--- a/test/e2e/token/src/generated/programs/associatedToken.ts
+++ b/test/e2e/token/src/generated/programs/associatedToken.ts
@@ -36,6 +36,7 @@ import {
     type ParsedRecoverNestedAssociatedTokenInstruction,
     type RecoverNestedAssociatedTokenAsyncInput,
 } from '../instructions';
+import { findAssociatedTokenPda } from '../pdas';
 
 export const ASSOCIATED_TOKEN_PROGRAM_ADDRESS =
     'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL' as Address<'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL'>;
@@ -110,7 +111,10 @@ export function parseAssociatedTokenInstruction<TProgram extends string>(
     }
 }
 
-export type AssociatedTokenPlugin = { instructions: AssociatedTokenPluginInstructions };
+export type AssociatedTokenPlugin = {
+    instructions: AssociatedTokenPluginInstructions;
+    pdas: AssociatedTokenPluginPdas;
+};
 
 export type AssociatedTokenPluginInstructions = {
     createAssociatedToken: (
@@ -123,6 +127,8 @@ export type AssociatedTokenPluginInstructions = {
         input: RecoverNestedAssociatedTokenAsyncInput,
     ) => ReturnType<typeof getRecoverNestedAssociatedTokenInstructionAsync> & SelfPlanAndSendFunctions;
 };
+
+export type AssociatedTokenPluginPdas = { associatedToken: typeof findAssociatedTokenPda };
 
 export type AssociatedTokenPluginRequirements = ClientWithPayer &
     ClientWithTransactionPlanning &
@@ -150,6 +156,7 @@ export function associatedTokenProgram() {
                     recoverNestedAssociatedToken: input =>
                         addSelfPlanAndSendFunctions(client, getRecoverNestedAssociatedTokenInstructionAsync(input)),
                 },
+                pdas: { associatedToken: findAssociatedTokenPda },
             },
         };
     };

--- a/test/fragments/programPlugin.test.ts
+++ b/test/fragments/programPlugin.test.ts
@@ -417,9 +417,7 @@ test('it renders program plugin function with pdas object', async () => {
     const fragment = getProgramPluginFragment({ ...getDefaultScope(), programNode: node });
 
     // Then we expect the plugin function to include pdas.
-    await fragmentContains(fragment, [
-        'pdas: { associatedTokenAccount: findAssociatedTokenAccountPda }',
-    ]);
+    await fragmentContains(fragment, ['pdas: { associatedTokenAccount: findAssociatedTokenAccountPda }']);
 
     // And we expect the necessary imports to be included.
     await fragmentContainsImports(fragment, {
@@ -447,15 +445,11 @@ test('it renders a plugin with only PDAs', async () => {
     expect(fragment).toBeDefined();
 
     // And we expect the plugin type to have only the pdas field.
-    await fragmentContains(fragment, [
-        'export type SplTokenPlugin = { pdas: SplTokenPluginPdas }',
-    ]);
+    await fragmentContains(fragment, ['export type SplTokenPlugin = { pdas: SplTokenPluginPdas }']);
     await fragmentContains(fragment, [
         'export type SplTokenPluginPdas = { associatedTokenAccount: typeof findAssociatedTokenAccountPda; }',
     ]);
-    await fragmentContains(fragment, [
-        'pdas: { associatedTokenAccount: findAssociatedTokenAccountPda }',
-    ]);
+    await fragmentContains(fragment, ['pdas: { associatedTokenAccount: findAssociatedTokenAccountPda }']);
 });
 
 test('it renders the requirements as object for a PDA-only program', async () => {
@@ -519,8 +513,6 @@ test('it omits the pdas field when program has no PDAs', async () => {
     const fragment = getProgramPluginFragment({ ...getDefaultScope(), programNode: node });
 
     // Then we expect the plugin type to NOT include a pdas field.
-    await fragmentContains(fragment, [
-        'export type SplTokenPlugin = { accounts: SplTokenPluginAccounts }',
-    ]);
+    await fragmentContains(fragment, ['export type SplTokenPlugin = { accounts: SplTokenPluginAccounts }']);
     await fragmentDoesNotContain(fragment, ['SplTokenPluginPdas']);
 });

--- a/test/fragments/programPlugin.test.ts
+++ b/test/fragments/programPlugin.test.ts
@@ -15,7 +15,7 @@ import {
 import { expect, test } from 'vitest';
 
 import { getProgramPluginFragment } from '../../src/fragments';
-import { fragmentContains, fragmentContainsImports, getDefaultScope } from '../_setup';
+import { fragmentContains, fragmentContainsImports, fragmentDoesNotContain, getDefaultScope } from '../_setup';
 
 test('it renders nothing is a program has no accounts or instructions', () => {
     // Given an empty program.
@@ -340,4 +340,187 @@ test('it tackles arguments and accounts with conflicting names', async () => {
         "input: MakeOptional< InitializeMintInput, 'authority' | 'authorityArg' >",
         '{ ...input, authority: input.authority ?? client.payer.address, authorityArg: input.authorityArg ?? client.payer.address }',
     ]);
+});
+
+test('it renders the plugin type with pdas field when program has PDAs', async () => {
+    // Given a program with accounts, instructions and PDAs.
+    const node = programNode({
+        accounts: [accountNode({ name: 'mint' })],
+        instructions: [instructionNode({ name: 'initializeMint' })],
+        name: 'splToken',
+        pdas: [
+            pdaNode({
+                name: 'associatedTokenAccount',
+                seeds: [variablePdaSeedNode('owner', publicKeyTypeNode())],
+            }),
+        ],
+        publicKey: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    });
+
+    // When we get the program plugin fragment.
+    const fragment = getProgramPluginFragment({ ...getDefaultScope(), programNode: node });
+
+    // Then we expect the plugin type to include a pdas field.
+    await fragmentContains(fragment, [
+        'export type SplTokenPlugin = { accounts: SplTokenPluginAccounts; instructions: SplTokenPluginInstructions; pdas: SplTokenPluginPdas; };',
+    ]);
+});
+
+test('it renders program plugin PDA types', async () => {
+    // Given a program with PDAs.
+    const node = programNode({
+        name: 'splToken',
+        pdas: [
+            pdaNode({
+                name: 'associatedTokenAccount',
+                seeds: [variablePdaSeedNode('owner', publicKeyTypeNode())],
+            }),
+            pdaNode({
+                name: 'mintAuthority',
+                seeds: [variablePdaSeedNode('mint', publicKeyTypeNode())],
+            }),
+        ],
+        publicKey: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    });
+
+    // When we get the program plugin fragment.
+    const fragment = getProgramPluginFragment({ ...getDefaultScope(), programNode: node });
+
+    // Then we expect the following PDA type to be rendered.
+    await fragmentContains(fragment, [
+        'export type SplTokenPluginPdas = {',
+        'associatedTokenAccount: typeof findAssociatedTokenAccountPda;',
+        'mintAuthority: typeof findMintAuthorityPda;',
+    ]);
+
+    // And we expect the necessary imports to be included.
+    await fragmentContainsImports(fragment, {
+        '../pdas': ['findAssociatedTokenAccountPda', 'findMintAuthorityPda'],
+    });
+});
+
+test('it renders program plugin function with pdas object', async () => {
+    // Given a program with a PDA and an account.
+    const node = programNode({
+        accounts: [accountNode({ name: 'mint' })],
+        name: 'splToken',
+        pdas: [
+            pdaNode({
+                name: 'associatedTokenAccount',
+                seeds: [variablePdaSeedNode('owner', publicKeyTypeNode())],
+            }),
+        ],
+        publicKey: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    });
+
+    // When we get the program plugin fragment.
+    const fragment = getProgramPluginFragment({ ...getDefaultScope(), programNode: node });
+
+    // Then we expect the plugin function to include pdas.
+    await fragmentContains(fragment, [
+        'pdas: { associatedTokenAccount: findAssociatedTokenAccountPda }',
+    ]);
+
+    // And we expect the necessary imports to be included.
+    await fragmentContainsImports(fragment, {
+        '../pdas': ['findAssociatedTokenAccountPda'],
+    });
+});
+
+test('it renders a plugin with only PDAs', async () => {
+    // Given a program with only PDAs (no accounts or instructions).
+    const node = programNode({
+        name: 'splToken',
+        pdas: [
+            pdaNode({
+                name: 'associatedTokenAccount',
+                seeds: [variablePdaSeedNode('owner', publicKeyTypeNode())],
+            }),
+        ],
+        publicKey: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    });
+
+    // When we get the program plugin fragment.
+    const fragment = getProgramPluginFragment({ ...getDefaultScope(), programNode: node });
+
+    // Then we expect the fragment to be defined.
+    expect(fragment).toBeDefined();
+
+    // And we expect the plugin type to have only the pdas field.
+    await fragmentContains(fragment, [
+        'export type SplTokenPlugin = { pdas: SplTokenPluginPdas }',
+    ]);
+    await fragmentContains(fragment, [
+        'export type SplTokenPluginPdas = { associatedTokenAccount: typeof findAssociatedTokenAccountPda; }',
+    ]);
+    await fragmentContains(fragment, [
+        'pdas: { associatedTokenAccount: findAssociatedTokenAccountPda }',
+    ]);
+});
+
+test('it renders the requirements as object for a PDA-only program', async () => {
+    // Given a program with only PDAs (no accounts or instructions).
+    const node = programNode({
+        name: 'splToken',
+        pdas: [
+            pdaNode({
+                name: 'associatedTokenAccount',
+                seeds: [variablePdaSeedNode('owner', publicKeyTypeNode())],
+            }),
+        ],
+        publicKey: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    });
+
+    // When we get the program plugin fragment.
+    const fragment = getProgramPluginFragment({ ...getDefaultScope(), programNode: node });
+
+    // Then we expect the requirements to be `object` since PDAs need no client capabilities.
+    await fragmentContains(fragment, ['export type SplTokenPluginRequirements = object']);
+});
+
+test('it renders the plugin function with instructions and PDAs but no accounts', async () => {
+    // Given a program with instructions and PDAs but no accounts.
+    const node = programNode({
+        instructions: [instructionNode({ name: 'initializeMint' })],
+        name: 'splToken',
+        pdas: [
+            pdaNode({
+                name: 'associatedTokenAccount',
+                seeds: [variablePdaSeedNode('owner', publicKeyTypeNode())],
+            }),
+        ],
+        publicKey: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    });
+
+    // When we get the program plugin fragment.
+    const fragment = getProgramPluginFragment({ ...getDefaultScope(), programNode: node });
+
+    // Then we expect the plugin type to include both instructions and pdas.
+    await fragmentContains(fragment, [
+        'export type SplTokenPlugin = { instructions: SplTokenPluginInstructions; pdas: SplTokenPluginPdas; }',
+    ]);
+
+    // And we expect the plugin function to include both.
+    await fragmentContains(fragment, [
+        'instructions: { initializeMint: ( input ) => addSelfPlanAndSendFunctions( client, getInitializeMintInstruction( input ) ) }',
+        'pdas: { associatedTokenAccount: findAssociatedTokenAccountPda }',
+    ]);
+});
+
+test('it omits the pdas field when program has no PDAs', async () => {
+    // Given a program with accounts but no PDAs.
+    const node = programNode({
+        accounts: [accountNode({ name: 'mint' })],
+        name: 'splToken',
+        publicKey: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    });
+
+    // When we get the program plugin fragment.
+    const fragment = getProgramPluginFragment({ ...getDefaultScope(), programNode: node });
+
+    // Then we expect the plugin type to NOT include a pdas field.
+    await fragmentContains(fragment, [
+        'export type SplTokenPlugin = { accounts: SplTokenPluginAccounts }',
+    ]);
+    await fragmentDoesNotContain(fragment, ['SplTokenPluginPdas']);
 });


### PR DESCRIPTION
## Summary
- Adds `pdas` field to plugin type and factory function, following the existing accounts/instructions pattern
- PDA find functions are passed through directly (no runtime wrapper needed since they're stateless)
- Programs with only PDAs now generate a valid plugin with `object` requirements type
- Regenerated e2e fixtures (associated token program now includes `pdas` field)

## Test plan
- [x] 8 new unit tests covering: PDA types, PDA objects, import verification, PDA-only programs, no-PDAs negative assertion, instructions+PDAs combo, requirements for PDA-only
- [x] All 447 unit tests pass across node/browser/react-native
- [x] All e2e tests pass
- [x] TypeScript compilation clean

Ref: https://x.com/redacted_noah/status/2034008748130505087