### PR TITLE
fix: include source and dist files in generated package.json for IDE navigation

### DIFF
--- a/.changeset/include-src-in-package-json.md
+++ b/.changeset/include-src-in-package-json.md
@@ -1,0 +1,5 @@
+---
+"@codama/renderers-js": patch
+---
+
+Include source and dist files in generated package.json for IDE navigation

--- a/src/utils/packageJson.ts
+++ b/src/utils/packageJson.ts
@@ -14,6 +14,7 @@ type PackageJson = {
     dependencies?: DependencyVersions;
     description?: string;
     devDependencies?: DependencyVersions;
+    files?: string[];
     keywords?: string[];
     main?: string;
     name?: string;
@@ -81,6 +82,8 @@ export function createNewPackageJson(dependencyVersions: DependencyVersions): Pa
             // eslint-disable-next-line sort-keys-fix/sort-keys-fix
             description: '',
             main: 'src/index.ts',
+            // eslint-disable-next-line sort-keys-fix/sort-keys-fix
+            files: ['./dist/src', './dist/types', './src/'],
             scripts: { test: 'echo "Error: no test specified" && exit 1' },
             // eslint-disable-next-line sort-keys-fix/sort-keys-fix
             keywords: [],

--- a/test/utils/packageJson.test.ts
+++ b/test/utils/packageJson.test.ts
@@ -76,6 +76,13 @@ describe('createNewPackageJson', () => {
         });
     });
 
+    test('it includes source and dist files for IDE navigation', () => {
+        const packageJson = createNewPackageJson({
+            'foo-package': '^1.0.0',
+        });
+        expect(packageJson.files).toEqual(['./dist/src', './dist/types', './src/']);
+    });
+
     test('it saves @solana/kit as a peer dependency by default', () => {
         const packageJson = createNewPackageJson({
             '@solana/kit': '^5.0.0',


### PR DESCRIPTION
## Problem

"Go to Definition" (Cmd+Click / F12) on any import from a generated client package takes you to `.d.ts` type declarations instead of actual source code.

## Why

- `declarationMap: true` is set in tsconfig ✅
- `.d.ts.map` files reference source paths like `../../src/index.ts` ✅
- **Source files included in published npm package** ❌ — `files` doesn't include `src/`

Declaration maps point to `../../src/` but that path doesn't exist in `node_modules`. IDE can't follow the map, falls back to `.d.ts`.

## Fix

Add `files: ['./dist/src', './dist/types', './src/']` to the auto-generated `package.json` created by `createNewPackageJson`. No changes to existing package.json update logic — only affects newly generated clients.

## Size impact

- **npm install**: small increase (source files only)
- **App bundle size**: **zero impact** — bundlers resolve imports to compiled JS in `dist/` via `exports`/`main`/`module`

## Context

Same fix applied to `@solana/kit` ([anza-xyz/kit#1468](https://github.com/anza-xyz/kit/pull/1468)) and program clients ([solana-program/token#141](https://github.com/solana-program/token/pull/141)).