### PR TITLE
Use bracket notation for index signature property access

### DIFF
--- a/.changeset/bracket-notation-index-signature.md
+++ b/.changeset/bracket-notation-index-signature.md
@@ -1,0 +1,5 @@
+---
+"@codama/renderers-js": patch
+---
+
+Use bracket notation for index signature property access

--- a/src/fragments/errorPage.ts
+++ b/src/fragments/errorPage.ts
@@ -58,7 +58,7 @@ function getErrorMessagesFragment(scope: Pick<RenderScope, 'nameApi'> & { progra
     );
 
     return fragment`let ${mapName}: Record<${errorUnionType}, string> | undefined;
-if (process.env.NODE_ENV !== 'production') {
+if (process.env['NODE_ENV'] !== 'production') {
   ${mapName} = { ${messageEntries} };
 }`;
 }
@@ -69,7 +69,7 @@ function getErrorMessageFunctionFragment(scope: Pick<RenderScope, 'nameApi'> & {
     const messageMapName = scope.nameApi.programErrorMessagesMap(scope.programNode.name);
 
     return fragment`export function ${functionName}(code: ${errorUnionType}): string {
-  if (process.env.NODE_ENV !== 'production') {
+  if (process.env['NODE_ENV'] !== 'production') {
     return (${messageMapName} as Record<${errorUnionType}, string>)[code];
   }
 

--- a/test/e2e/anchor/src/generated/errors/wenTransferGuard.ts
+++ b/test/e2e/anchor/src/generated/errors/wenTransferGuard.ts
@@ -42,7 +42,7 @@ export type WenTransferGuardError =
     | typeof WEN_TRANSFER_GUARD_ERROR__TRANSFER_AMOUNT_RULE_ENFORCE_FAILED;
 
 let wenTransferGuardErrorMessages: Record<WenTransferGuardError, string> | undefined;
-if (process.env.NODE_ENV !== 'production') {
+if (process.env['NODE_ENV'] !== 'production') {
     wenTransferGuardErrorMessages = {
         [WEN_TRANSFER_GUARD_ERROR__CPI_RULE_ENFORCEMENT_FAILED]: `Cpi Rule Enforcement Failed`,
         [WEN_TRANSFER_GUARD_ERROR__GUARD_TOKEN_AMOUNT_SHOULD_BE_AT_LEAST_ONE]: `Guard token amount should be at least 1`,
@@ -56,7 +56,7 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 export function getWenTransferGuardErrorMessage(code: WenTransferGuardError): string {
-    if (process.env.NODE_ENV !== 'production') {
+    if (process.env['NODE_ENV'] !== 'production') {
         return (wenTransferGuardErrorMessages as Record<WenTransferGuardError, string>)[code];
     }
 

--- a/test/e2e/anchor/tsconfig.json
+++ b/test/e2e/anchor/tsconfig.json
@@ -11,6 +11,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "outDir": "./dist",

--- a/test/e2e/anchor/tsup.config.ts
+++ b/test/e2e/anchor/tsup.config.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { defineConfig, type Options } from 'tsup';
 
 const SHARED_OPTIONS: Options = {
-  define: { __VERSION__: `"${env.npm_package_version}"` },
+  define: { __VERSION__: `"${env['npm_package_version']}"` },
   entry: ['./src/index.ts'],
   inject: [path.resolve(__dirname, 'env-shim.ts')],
   outDir: './dist/src',

--- a/test/e2e/dummy/tsconfig.json
+++ b/test/e2e/dummy/tsconfig.json
@@ -11,6 +11,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "outDir": "./dist",

--- a/test/e2e/dummy/tsup.config.ts
+++ b/test/e2e/dummy/tsup.config.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { defineConfig, type Options } from 'tsup';
 
 const SHARED_OPTIONS: Options = {
-  define: { __VERSION__: `"${env.npm_package_version}"` },
+  define: { __VERSION__: `"${env['npm_package_version']}"` },
   entry: ['./src/index.ts'],
   inject: [path.resolve(__dirname, 'env-shim.ts')],
   outDir: './dist/src',

--- a/test/e2e/memo/tsconfig.json
+++ b/test/e2e/memo/tsconfig.json
@@ -11,6 +11,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "outDir": "./dist",

--- a/test/e2e/memo/tsup.config.ts
+++ b/test/e2e/memo/tsup.config.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { defineConfig, type Options } from 'tsup';
 
 const SHARED_OPTIONS: Options = {
-  define: { __VERSION__: `"${env.npm_package_version}"` },
+  define: { __VERSION__: `"${env['npm_package_version']}"` },
   entry: ['./src/index.ts'],
   inject: [path.resolve(__dirname, 'env-shim.ts')],
   outDir: './dist/src',

--- a/test/e2e/system/src/generated/errors/system.ts
+++ b/test/e2e/system/src/generated/errors/system.ts
@@ -45,7 +45,7 @@ export type SystemError =
     | typeof SYSTEM_ERROR__RESULT_WITH_NEGATIVE_LAMPORTS;
 
 let systemErrorMessages: Record<SystemError, string> | undefined;
-if (process.env.NODE_ENV !== 'production') {
+if (process.env['NODE_ENV'] !== 'production') {
     systemErrorMessages = {
         [SYSTEM_ERROR__ACCOUNT_ALREADY_IN_USE]: `an account with the same address already exists`,
         [SYSTEM_ERROR__ADDRESS_WITH_SEED_MISMATCH]: `provided address does not match addressed derived from seed`,
@@ -60,7 +60,7 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 export function getSystemErrorMessage(code: SystemError): string {
-    if (process.env.NODE_ENV !== 'production') {
+    if (process.env['NODE_ENV'] !== 'production') {
         return (systemErrorMessages as Record<SystemError, string>)[code];
     }
 

--- a/test/e2e/system/tsconfig.json
+++ b/test/e2e/system/tsconfig.json
@@ -11,6 +11,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "outDir": "./dist",

--- a/test/e2e/system/tsup.config.ts
+++ b/test/e2e/system/tsup.config.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { defineConfig, type Options } from 'tsup';
 
 const SHARED_OPTIONS: Options = {
-  define: { __VERSION__: `"${env.npm_package_version}"` },
+  define: { __VERSION__: `"${env['npm_package_version']}"` },
   entry: ['./src/index.ts'],
   inject: [path.resolve(__dirname, 'env-shim.ts')],
   outDir: './dist/src',

--- a/test/e2e/token/src/generated/errors/associatedToken.ts
+++ b/test/e2e/token/src/generated/errors/associatedToken.ts
@@ -20,14 +20,14 @@ export const ASSOCIATED_TOKEN_ERROR__INVALID_OWNER = 0x0; // 0
 export type AssociatedTokenError = typeof ASSOCIATED_TOKEN_ERROR__INVALID_OWNER;
 
 let associatedTokenErrorMessages: Record<AssociatedTokenError, string> | undefined;
-if (process.env.NODE_ENV !== 'production') {
+if (process.env['NODE_ENV'] !== 'production') {
     associatedTokenErrorMessages = {
         [ASSOCIATED_TOKEN_ERROR__INVALID_OWNER]: `Associated token account owner does not match address derivation`,
     };
 }
 
 export function getAssociatedTokenErrorMessage(code: AssociatedTokenError): string {
-    if (process.env.NODE_ENV !== 'production') {
+    if (process.env['NODE_ENV'] !== 'production') {
         return (associatedTokenErrorMessages as Record<AssociatedTokenError, string>)[code];
     }
 

--- a/test/e2e/token/src/generated/errors/token.ts
+++ b/test/e2e/token/src/generated/errors/token.ts
@@ -78,7 +78,7 @@ export type TokenError =
     | typeof TOKEN_ERROR__UNINITIALIZED_STATE;
 
 let tokenErrorMessages: Record<TokenError, string> | undefined;
-if (process.env.NODE_ENV !== 'production') {
+if (process.env['NODE_ENV'] !== 'production') {
     tokenErrorMessages = {
         [TOKEN_ERROR__ACCOUNT_FROZEN]: `Account is frozen`,
         [TOKEN_ERROR__ALREADY_IN_USE]: `Already in use`,
@@ -104,7 +104,7 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 export function getTokenErrorMessage(code: TokenError): string {
-    if (process.env.NODE_ENV !== 'production') {
+    if (process.env['NODE_ENV'] !== 'production') {
         return (tokenErrorMessages as Record<TokenError, string>)[code];
     }
 

--- a/test/e2e/token/tsconfig.json
+++ b/test/e2e/token/tsconfig.json
@@ -11,6 +11,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "outDir": "./dist",

--- a/test/e2e/token/tsup.config.ts
+++ b/test/e2e/token/tsup.config.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { defineConfig, type Options } from 'tsup';
 
 const SHARED_OPTIONS: Options = {
-  define: { __VERSION__: `"${env.npm_package_version}"` },
+  define: { __VERSION__: `"${env['npm_package_version']}"` },
   entry: ['./src/index.ts'],
   inject: [path.resolve(__dirname, 'env-shim.ts')],
   outDir: './dist/src',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
         "lib": [],
         "moduleResolution": "node",
         "noFallthroughCasesInSwitch": true,
+        "noPropertyAccessFromIndexSignature": true,
         "noUnusedLocals": true,
         "noUnusedParameters": true,
         "preserveWatchOutput": true,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -26,7 +26,7 @@ function getBuildConfig(options: BuildOptions): TsupConfig {
             __NODEJS__: `${platform === 'node'}`,
             __REACTNATIVE__: `${platform === 'react-native'}`,
             __TEST__: 'false',
-            __VERSION__: `"${env.npm_package_version}"`,
+            __VERSION__: `"${env['npm_package_version']}"`,
         },
         entry: [`./src/index.ts`],
         esbuildOptions(options) {


### PR DESCRIPTION
#2 

I ran into this issue and solved it using the post-processor below without this fix:

```ts
export function fixNodeEnvAccess(dir: string): void {
	for (const entry of readdirSync(dir)) {
		const fullPath = join(dir, entry);
		if (statSync(fullPath).isDirectory()) {
			fixNodeEnvAccess(fullPath);
			continue;
		}
		if (!entry.endsWith('.ts')) continue;

		let content = readFileSync(fullPath, 'utf8');
		if (!content.includes('process.env.NODE_ENV')) continue;
		content = content.replaceAll(
			'process.env.NODE_ENV',
			"process.env['NODE_ENV']",
		);
		writeFileSync(fullPath, content);
	}
}
```