### PR TITLE
Kill e2e test validator on exit and wait for startup

### DIFF
--- a/test/e2e/test.sh
+++ b/test/e2e/test.sh
@@ -1,11 +1,42 @@
 #!/usr/bin/env bash
 set -eux
 
-function start_validator() {
-    if ! lsof -t -i:8899; then
-        echo "Starting solana-test-validator"
-        solana-test-validator >/dev/null 2>&1 &
+VALIDATOR_PID=""
+
+function cleanup() {
+    if [ -n "$VALIDATOR_PID" ]; then
+        kill "$VALIDATOR_PID" 2>/dev/null || true
+        wait "$VALIDATOR_PID" 2>/dev/null || true
     fi
+}
+
+trap cleanup EXIT
+
+function check_validator() {
+    curl -s http://127.0.0.1:8899 -X POST \
+        -H "Content-Type: application/json" \
+        -d '{"jsonrpc":"2.0","id":1,"method":"getHealth"}' \
+        2>/dev/null | grep -q '"ok"'
+}
+
+function start_validator() {
+    if check_validator; then
+        echo "Using existing validator on port 8899"
+        return 0
+    fi
+    solana-test-validator --reset >/dev/null 2>&1 &
+    VALIDATOR_PID=$!
+
+    local retries=30
+    while [ $retries -gt 0 ]; do
+        if check_validator; then
+            return 0
+        fi
+        retries=$((retries - 1))
+        sleep 1
+    done
+    echo "Validator failed to start"
+    exit 1
 }
 
 function test_project() {


### PR DESCRIPTION
I noticed after running `pnpm test:e2e` solana-test-validator would never exit. This change will shutdown the test validator if started by the tests. If there is already a test validator running it will re-use it and leave it running.


<img width="754" height="198" alt="Screenshot 2026-04-12 at 9 45 36 AM" src="https://github.com/user-attachments/assets/3ab93bcd-99c6-4fa4-9689-ee70f8614f3d" />
