### PR TITLE
feat: expose identify/parse helpers on generated program plugins

### DIFF
--- a/.changeset/yellow-rice-smoke.md
+++ b/.changeset/yellow-rice-smoke.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-js': minor
+---
+
+Expose `identifyAccount`, `identifyInstruction`, and `parseInstruction` on generated program plugins. When a program has accounts or instructions with discriminators, the plugin object now surfaces the corresponding identifier and parser helpers as `client.myProgram.identifyAccount(...)`, `client.myProgram.identifyInstruction(...)`, and `client.myProgram.parseInstruction(...)`, making it easier to build indexers without re-importing the per-function helpers.

--- a/src/fragments/programPlugin.ts
+++ b/src/fragments/programPlugin.ts
@@ -1,5 +1,6 @@
 import {
     CamelCaseString,
+    getAllInstructionsWithSubs,
     InstructionAccountNode,
     InstructionArgumentNode,
     InstructionNode,
@@ -12,7 +13,7 @@ import { Fragment, fragment, hasAsyncFunction, mergeFragments, RenderScope, use 
 import { getRenamedArgsMap } from './instructionPage';
 
 export function getProgramPluginFragment(
-    scope: Pick<RenderScope, 'asyncResolvers' | 'nameApi'> & { programNode: ProgramNode },
+    scope: Pick<RenderScope, 'asyncResolvers' | 'nameApi' | 'renderParentInstructions'> & { programNode: ProgramNode },
 ): Fragment | undefined {
     if (
         scope.programNode.accounts.length === 0 &&
@@ -28,32 +29,61 @@ export function getProgramPluginFragment(
         )
         .map(i => i.name);
 
+    const extendedScope = { ...scope, asyncInstructions };
     return mergeFragments(
         [
-            getProgramPluginTypeFragment(scope),
+            getProgramPluginTypeFragment(extendedScope),
             getProgramPluginAccountsTypeFragment(scope),
-            getProgramPluginInstructionsTypeFragment({ ...scope, asyncInstructions }),
+            getProgramPluginInstructionsTypeFragment(extendedScope),
             getProgramPluginPdasTypeFragment(scope),
             getProgramPluginRequirementsTypeFragment(scope),
-            getProgramPluginFunctionFragment({ ...scope, asyncInstructions }),
+            getProgramPluginFunctionFragment(extendedScope),
             getMakeOptionalHelperTypeFragment(scope),
         ],
         c => c.join('\n\n'),
     );
 }
 
-function getProgramPluginTypeFragment(scope: Pick<RenderScope, 'nameApi'> & { programNode: ProgramNode }): Fragment {
-    const { programNode, nameApi } = scope;
+function hasAccountIdentifier(programNode: ProgramNode): boolean {
+    return programNode.accounts.some(account => (account.discriminators ?? []).length > 0);
+}
+
+function hasInstructionIdentifier(
+    programNode: ProgramNode,
+    renderParentInstructions: boolean | undefined,
+): boolean {
+    // Mirrors getProgramInstructionsFragment so the plugin tracks whichever
+    // instructions actually flow into identify*/parse* generation.
+    const allInstructions = getAllInstructionsWithSubs(programNode, {
+        leavesOnly: !renderParentInstructions,
+        subInstructionsFirst: true,
+    });
+    return allInstructions.some(instruction => (instruction.discriminators ?? []).length > 0);
+}
+
+function getProgramPluginTypeFragment(
+    scope: Pick<RenderScope, 'nameApi' | 'renderParentInstructions'> & { programNode: ProgramNode },
+): Fragment {
+    const { programNode, nameApi, renderParentInstructions } = scope;
     const programPluginType = nameApi.programPluginType(programNode.name);
     const programPluginAccountsType = nameApi.programPluginAccountsType(programNode.name);
     const programPluginInstructionsType = nameApi.programPluginInstructionsType(programNode.name);
     const programPluginPdasType = nameApi.programPluginPdasType(programNode.name);
+    const accountsIdentifierFunction = nameApi.programAccountsIdentifierFunction(programNode.name);
+    const instructionsIdentifierFunction = nameApi.programInstructionsIdentifierFunction(programNode.name);
+    const instructionsParseFunction = nameApi.programInstructionsParseFunction(programNode.name);
 
     const fields = mergeFragments(
         [
             programNode.accounts.length > 0 ? fragment`accounts: ${programPluginAccountsType};` : undefined,
             programNode.instructions.length > 0 ? fragment`instructions: ${programPluginInstructionsType};` : undefined,
             programNode.pdas.length > 0 ? fragment`pdas: ${programPluginPdasType};` : undefined,
+            hasAccountIdentifier(programNode)
+                ? fragment`identifyAccount: typeof ${accountsIdentifierFunction};`
+                : undefined,
+            hasInstructionIdentifier(programNode, renderParentInstructions)
+                ? fragment`identifyInstruction: typeof ${instructionsIdentifierFunction}; parseInstruction: typeof ${instructionsParseFunction};`
+                : undefined,
         ],
         c => c.join(' '),
     );
@@ -182,20 +212,33 @@ function getProgramPluginRequirementsTypeFragment(
 }
 
 function getProgramPluginFunctionFragment(
-    scope: Pick<RenderScope, 'nameApi'> & { asyncInstructions: CamelCaseString[]; programNode: ProgramNode },
+    scope: Pick<RenderScope, 'nameApi' | 'renderParentInstructions'> & {
+        asyncInstructions: CamelCaseString[];
+        programNode: ProgramNode;
+    },
 ): Fragment {
-    const { programNode, nameApi } = scope;
+    const { programNode, nameApi, renderParentInstructions } = scope;
     const programPluginFunction = nameApi.programPluginFunction(programNode.name);
     const programPluginType = nameApi.programPluginType(programNode.name);
     const programPluginRequirementsType = nameApi.programPluginRequirementsType(programNode.name);
     const programPluginKey = nameApi.programPluginKey(programNode.name);
     const extendClient = use('extendClient', 'solanaPluginCore');
 
+    const accountsIdentifierFunction = nameApi.programAccountsIdentifierFunction(programNode.name);
+    const instructionsIdentifierFunction = nameApi.programInstructionsIdentifierFunction(programNode.name);
+    const instructionsParseFunction = nameApi.programInstructionsParseFunction(programNode.name);
+
     const fields = mergeFragments(
         [
             getProgramPluginAccountsObjectFragment(scope),
             getProgramPluginInstructionsObjectFragment(scope),
             getProgramPluginPdasObjectFragment(scope),
+            hasAccountIdentifier(programNode)
+                ? fragment`identifyAccount: ${accountsIdentifierFunction}`
+                : undefined,
+            hasInstructionIdentifier(programNode, renderParentInstructions)
+                ? fragment`identifyInstruction: ${instructionsIdentifierFunction}, parseInstruction: ${instructionsParseFunction}`
+                : undefined,
         ],
         c => c.join(', '),
     );

--- a/src/fragments/programPlugin.ts
+++ b/src/fragments/programPlugin.ts
@@ -48,10 +48,7 @@ function hasAccountIdentifier(programNode: ProgramNode): boolean {
     return programNode.accounts.some(account => (account.discriminators ?? []).length > 0);
 }
 
-function hasInstructionIdentifier(
-    programNode: ProgramNode,
-    renderParentInstructions: boolean | undefined,
-): boolean {
+function hasInstructionIdentifier(programNode: ProgramNode, renderParentInstructions: boolean | undefined): boolean {
     // Mirrors getProgramInstructionsFragment so the plugin tracks whichever
     // instructions actually flow into identify*/parse* generation.
     const allInstructions = getAllInstructionsWithSubs(programNode, {
@@ -233,9 +230,7 @@ function getProgramPluginFunctionFragment(
             getProgramPluginAccountsObjectFragment(scope),
             getProgramPluginInstructionsObjectFragment(scope),
             getProgramPluginPdasObjectFragment(scope),
-            hasAccountIdentifier(programNode)
-                ? fragment`identifyAccount: ${accountsIdentifierFunction}`
-                : undefined,
+            hasAccountIdentifier(programNode) ? fragment`identifyAccount: ${accountsIdentifierFunction}` : undefined,
             hasInstructionIdentifier(programNode, renderParentInstructions)
                 ? fragment`identifyInstruction: ${instructionsIdentifierFunction}, parseInstruction: ${instructionsParseFunction}`
                 : undefined,

--- a/test/e2e/anchor/src/generated/programs/wenTransferGuard.ts
+++ b/test/e2e/anchor/src/generated/programs/wenTransferGuard.ts
@@ -179,6 +179,9 @@ export function parseWenTransferGuardInstruction<TProgram extends string>(
 export type WenTransferGuardPlugin = {
     accounts: WenTransferGuardPluginAccounts;
     instructions: WenTransferGuardPluginInstructions;
+    identifyAccount: typeof identifyWenTransferGuardAccount;
+    identifyInstruction: typeof identifyWenTransferGuardInstruction;
+    parseInstruction: typeof parseWenTransferGuardInstruction;
 };
 
 export type WenTransferGuardPluginAccounts = {
@@ -224,6 +227,9 @@ export function wenTransferGuardProgram() {
                         ),
                     updateGuard: input => addSelfPlanAndSendFunctions(client, getUpdateGuardInstructionAsync(input)),
                 },
+                identifyAccount: identifyWenTransferGuardAccount,
+                identifyInstruction: identifyWenTransferGuardInstruction,
+                parseInstruction: parseWenTransferGuardInstruction,
             },
         });
     };

--- a/test/e2e/dummy/src/generated/programs/dummy.ts
+++ b/test/e2e/dummy/src/generated/programs/dummy.ts
@@ -157,7 +157,11 @@ export function parseDummyInstruction<TProgram extends string>(
     }
 }
 
-export type DummyPlugin = { instructions: DummyPluginInstructions };
+export type DummyPlugin = {
+    instructions: DummyPluginInstructions;
+    identifyInstruction: typeof identifyDummyInstruction;
+    parseInstruction: typeof parseDummyInstruction;
+};
 
 export type DummyPluginInstructions = {
     instruction1: (
@@ -218,6 +222,8 @@ export function dummyProgram() {
                         ),
                     instruction10: input => addSelfPlanAndSendFunctions(client, getInstruction10Instruction(input)),
                 },
+                identifyInstruction: identifyDummyInstruction,
+                parseInstruction: parseDummyInstruction,
             },
         });
     };

--- a/test/e2e/dummy/test/instructions.test.ts
+++ b/test/e2e/dummy/test/instructions.test.ts
@@ -1,7 +1,14 @@
 import test from 'ava';
 import {
+  DummyInstruction,
   DUMMY_PROGRAM_ADDRESS,
+  dummyProgram,
   getInstruction1Instruction,
+  getInstruction10Instruction,
+  getInstruction3Instruction,
+  identifyDummyInstruction,
+  parseDummyInstruction,
+  type DummyPluginRequirements,
 } from '../src/index.js';
 
 test('it can create instruction 1', (t) => {
@@ -10,4 +17,46 @@ test('it can create instruction 1', (t) => {
 
   // Then we expect the instruction to have the correct program address.
   t.is(instruction.programAddress, DUMMY_PROGRAM_ADDRESS);
+});
+
+test('identifyDummyInstruction recognizes a real instruction built by the generator', (t) => {
+  // Given two instructions built by the generated builders.
+  const ix3 = getInstruction3Instruction();
+  const ix10 = getInstruction10Instruction();
+
+  // Then identifying the encoded data round-trips back to the right variant.
+  t.is(identifyDummyInstruction(ix3), DummyInstruction.Instruction3);
+  t.is(identifyDummyInstruction(ix10), DummyInstruction.Instruction10);
+});
+
+test('parseDummyInstruction returns the matching parsed variant', (t) => {
+  // Given an instruction built by the generator.
+  const ix3 = getInstruction3Instruction();
+
+  // When we parse it.
+  const parsed = parseDummyInstruction(ix3);
+
+  // Then we get the parsed variant tagged with the right enum value.
+  t.is(parsed.instructionType, DummyInstruction.Instruction3);
+  t.is(parsed.programAddress, DUMMY_PROGRAM_ADDRESS);
+});
+
+test('the dummy program plugin re-exposes identifyInstruction and parseInstruction', (t) => {
+  // Given the plugin applied to a stub client. The new identify/parse fields
+  // are bare references that don't read from the client, so a stub is fine.
+  const client = dummyProgram()({} as DummyPluginRequirements);
+
+  // And an instruction built by the generated builder.
+  const instruction = getInstruction3Instruction();
+
+  // Then the plugin's identify/parse helpers behave identically to the
+  // standalone helpers when given the same generator-built instruction.
+  t.is(
+    client.dummy.identifyInstruction(instruction),
+    identifyDummyInstruction(instruction)
+  );
+  t.deepEqual(
+    client.dummy.parseInstruction(instruction),
+    parseDummyInstruction(instruction)
+  );
 });

--- a/test/e2e/system/src/generated/programs/system.ts
+++ b/test/e2e/system/src/generated/programs/system.ts
@@ -267,7 +267,12 @@ export function parseSystemInstruction<TProgram extends string>(
     }
 }
 
-export type SystemPlugin = { accounts: SystemPluginAccounts; instructions: SystemPluginInstructions };
+export type SystemPlugin = {
+    accounts: SystemPluginAccounts;
+    instructions: SystemPluginInstructions;
+    identifyInstruction: typeof identifySystemInstruction;
+    parseInstruction: typeof parseSystemInstruction;
+};
 
 export type SystemPluginAccounts = { nonce: ReturnType<typeof getNonceCodec> & SelfFetchFunctions<NonceArgs, Nonce> };
 
@@ -347,6 +352,8 @@ export function systemProgram() {
                     upgradeNonceAccount: input =>
                         addSelfPlanAndSendFunctions(client, getUpgradeNonceAccountInstruction(input)),
                 },
+                identifyInstruction: identifySystemInstruction,
+                parseInstruction: parseSystemInstruction,
             },
         });
     };

--- a/test/e2e/token/src/generated/programs/associatedToken.ts
+++ b/test/e2e/token/src/generated/programs/associatedToken.ts
@@ -115,6 +115,8 @@ export function parseAssociatedTokenInstruction<TProgram extends string>(
 export type AssociatedTokenPlugin = {
     instructions: AssociatedTokenPluginInstructions;
     pdas: AssociatedTokenPluginPdas;
+    identifyInstruction: typeof identifyAssociatedTokenInstruction;
+    parseInstruction: typeof parseAssociatedTokenInstruction;
 };
 
 export type AssociatedTokenPluginInstructions = {
@@ -159,6 +161,8 @@ export function associatedTokenProgram() {
                         addSelfPlanAndSendFunctions(client, getRecoverNestedAssociatedTokenInstructionAsync(input)),
                 },
                 pdas: { associatedToken: findAssociatedTokenPda },
+                identifyInstruction: identifyAssociatedTokenInstruction,
+                parseInstruction: parseAssociatedTokenInstruction,
             },
         });
     };

--- a/test/e2e/token/src/generated/programs/system.ts
+++ b/test/e2e/token/src/generated/programs/system.ts
@@ -70,7 +70,11 @@ export function parseSystemInstruction<TProgram extends string>(
     }
 }
 
-export type SystemPlugin = { instructions: SystemPluginInstructions };
+export type SystemPlugin = {
+    instructions: SystemPluginInstructions;
+    identifyInstruction: typeof identifySystemInstruction;
+    parseInstruction: typeof parseSystemInstruction;
+};
 
 export type SystemPluginInstructions = {
     createAccount: (
@@ -91,6 +95,8 @@ export function systemProgram() {
                             getCreateAccountInstruction({ ...input, payer: input.payer ?? client.payer }),
                         ),
                 },
+                identifyInstruction: identifySystemInstruction,
+                parseInstruction: parseSystemInstruction,
             },
         });
     };

--- a/test/e2e/token/src/generated/programs/token.ts
+++ b/test/e2e/token/src/generated/programs/token.ts
@@ -459,7 +459,13 @@ export function parseTokenInstruction<TProgram extends string>(
     }
 }
 
-export type TokenPlugin = { accounts: TokenPluginAccounts; instructions: TokenPluginInstructions };
+export type TokenPlugin = {
+    accounts: TokenPluginAccounts;
+    instructions: TokenPluginInstructions;
+    identifyAccount: typeof identifyTokenAccount;
+    identifyInstruction: typeof identifyTokenInstruction;
+    parseInstruction: typeof parseTokenInstruction;
+};
 
 export type TokenPluginAccounts = {
     mint: ReturnType<typeof getMintCodec> & SelfFetchFunctions<MintArgs, Mint>;
@@ -578,6 +584,9 @@ export function tokenProgram() {
                     uiAmountToAmount: input =>
                         addSelfPlanAndSendFunctions(client, getUiAmountToAmountInstruction(input)),
                 },
+                identifyAccount: identifyTokenAccount,
+                identifyInstruction: identifyTokenInstruction,
+                parseInstruction: parseTokenInstruction,
             },
         });
     };

--- a/test/fragments/programPlugin.test.ts
+++ b/test/fragments/programPlugin.test.ts
@@ -1,6 +1,7 @@
 import {
     accountNode,
     accountValueNode,
+    fieldDiscriminatorNode,
     instructionAccountNode,
     instructionArgumentNode,
     instructionNode,
@@ -500,6 +501,65 @@ test('it renders the plugin function with instructions and PDAs but no accounts'
         'instructions: { initializeMint: ( input ) => addSelfPlanAndSendFunctions( client, getInitializeMintInstruction( input ) ) }',
         'pdas: { associatedTokenAccount: findAssociatedTokenAccountPda }',
     ]);
+});
+
+test('it exposes identifyAccount on the plugin when accounts have discriminators', async () => {
+    // Given a program with one account that has a discriminator.
+    const node = programNode({
+        accounts: [accountNode({ discriminators: [fieldDiscriminatorNode('key')], name: 'mint' })],
+        name: 'splToken',
+        publicKey: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    });
+
+    // When we get the program plugin fragment.
+    const fragment = getProgramPluginFragment({ ...getDefaultScope(), programNode: node });
+
+    // Then the plugin type and function expose identifyAccount.
+    await fragmentContains(fragment, [
+        'identifyAccount: typeof identifySplTokenAccount;',
+        'identifyAccount: identifySplTokenAccount',
+    ]);
+});
+
+test('it exposes identifyInstruction and parseInstruction when instructions have discriminators', async () => {
+    // Given a program with an instruction that has a discriminator.
+    const node = programNode({
+        instructions: [
+            instructionNode({
+                discriminators: [fieldDiscriminatorNode('discriminator')],
+                name: 'initializeMint',
+            }),
+        ],
+        name: 'splToken',
+        publicKey: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    });
+
+    // When we get the program plugin fragment.
+    const fragment = getProgramPluginFragment({ ...getDefaultScope(), programNode: node });
+
+    // Then the plugin type and function expose identifyInstruction and parseInstruction.
+    await fragmentContains(fragment, [
+        'identifyInstruction: typeof identifySplTokenInstruction;',
+        'parseInstruction: typeof parseSplTokenInstruction;',
+        'identifyInstruction: identifySplTokenInstruction',
+        'parseInstruction: parseSplTokenInstruction',
+    ]);
+});
+
+test('it omits identify/parse helpers when nodes have no discriminators', async () => {
+    // Given a program with accounts and instructions but no discriminators.
+    const node = programNode({
+        accounts: [accountNode({ name: 'mint' })],
+        instructions: [instructionNode({ name: 'initializeMint' })],
+        name: 'splToken',
+        publicKey: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    });
+
+    // When we get the program plugin fragment.
+    const fragment = getProgramPluginFragment({ ...getDefaultScope(), programNode: node });
+
+    // Then the plugin omits identify/parse keys entirely.
+    await fragmentDoesNotContain(fragment, ['identifyAccount', 'identifyInstruction', 'parseInstruction']);
 });
 
 test('it omits the pdas field when program has no PDAs', async () => {

--- a/test/programsPage.test.ts
+++ b/test/programsPage.test.ts
@@ -16,7 +16,7 @@ import { visit } from '@codama/visitors-core';
 import { expect, test } from 'vitest';
 
 import { getRenderMapVisitor } from '../src';
-import { renderMapContains, renderMapContainsImports } from './_setup';
+import { renderMapContains, renderMapContainsImports, renderMapDoesNotContain } from './_setup';
 
 test('it renders the program address constant', async () => {
     // Given the following program.
@@ -318,6 +318,173 @@ test('it renders a function that parses instructions in a program', async () => 
     await renderMapContainsImports(renderMap, 'programs/splToken.ts', {
         '@solana/kit': ['Instruction', 'InstructionWithData', 'ReadonlyUint8Array'],
     });
+});
+
+test('the program plugin re-exposes identifyAccount, identifyInstruction and parseInstruction when discriminators exist', async () => {
+    // Given a program where one account and one instruction carry discriminators.
+    const node = programNode({
+        accounts: [
+            accountNode({
+                data: structTypeNode([
+                    structFieldTypeNode({
+                        defaultValue: numberValueNode(5),
+                        name: 'key',
+                        type: numberTypeNode('u8'),
+                    }),
+                ]),
+                discriminators: [fieldDiscriminatorNode('key')],
+                name: 'metadata',
+            }),
+        ],
+        instructions: [
+            instructionNode({
+                arguments: [
+                    instructionArgumentNode({
+                        defaultValue: numberValueNode(1),
+                        name: 'discriminator',
+                        type: numberTypeNode('u8'),
+                    }),
+                ],
+                discriminators: [fieldDiscriminatorNode('discriminator')],
+                name: 'mintTokens',
+            }),
+        ],
+        name: 'splToken',
+        publicKey: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    });
+
+    // When we render it.
+    const renderMap = visit(node, getRenderMapVisitor());
+
+    // Then the plugin type wires the helpers as `typeof` references...
+    await renderMapContains(renderMap, 'programs/splToken.ts', [
+        'identifyAccount: typeof identifySplTokenAccount;',
+        'identifyInstruction: typeof identifySplTokenInstruction;',
+        'parseInstruction: typeof parseSplTokenInstruction;',
+    ]);
+
+    // ...and the plugin function exposes them on the extended client.
+    await renderMapContains(renderMap, 'programs/splToken.ts', [
+        'identifyAccount: identifySplTokenAccount',
+        'identifyInstruction: identifySplTokenInstruction',
+        'parseInstruction: parseSplTokenInstruction',
+    ]);
+});
+
+test('the program plugin exposes identifyInstruction/parseInstruction when only a sub-instruction has a discriminator', async () => {
+    // Given a program whose top-level instruction has no discriminator,
+    // but whose sub-instruction does. The leaves-only walk in
+    // getProgramInstructionsFragment still emits identify*/parse*.
+    const node = programNode({
+        instructions: [
+            instructionNode({
+                arguments: [
+                    instructionArgumentNode({
+                        defaultValue: numberValueNode(1),
+                        name: 'subDiscriminator',
+                        type: numberTypeNode('u8'),
+                    }),
+                ],
+                discriminators: [],
+                name: 'mintTokens',
+                subInstructions: [
+                    instructionNode({
+                        arguments: [
+                            instructionArgumentNode({
+                                defaultValue: numberValueNode(1),
+                                name: 'subDiscriminator',
+                                type: numberTypeNode('u8'),
+                            }),
+                        ],
+                        discriminators: [fieldDiscriminatorNode('subDiscriminator')],
+                        name: 'mintTokensV2',
+                    }),
+                ],
+            }),
+        ],
+        name: 'splToken',
+        publicKey: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    });
+
+    // When we render it.
+    const renderMap = visit(node, getRenderMapVisitor());
+
+    // Then the plugin must expose the helpers even though the top-level
+    // instruction itself has no discriminator.
+    await renderMapContains(renderMap, 'programs/splToken.ts', [
+        'identifyInstruction: typeof identifySplTokenInstruction;',
+        'parseInstruction: typeof parseSplTokenInstruction;',
+        'identifyInstruction: identifySplTokenInstruction',
+        'parseInstruction: parseSplTokenInstruction',
+    ]);
+});
+
+test('the program plugin omits identify/parse keys when no node carries a discriminator', async () => {
+    // Given a program with accounts and instructions but no discriminators.
+    const node = programNode({
+        accounts: [accountNode({ discriminators: [], name: 'mint' })],
+        instructions: [instructionNode({ discriminators: [], name: 'mintTokens' })],
+        name: 'splToken',
+        publicKey: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    });
+
+    // When we render it.
+    const renderMap = visit(node, getRenderMapVisitor());
+
+    // Then the program file does not reference any of the new plugin keys.
+    await renderMapDoesNotContain(renderMap, 'programs/splToken.ts', [
+        'identifyAccount',
+        'identifyInstruction',
+        'parseInstruction',
+    ]);
+});
+
+test('the program plugin honors renderParentInstructions when deciding whether to expose identify/parse', async () => {
+    // Given a program whose parent instruction has a discriminator but the
+    // sub-instruction does not. Without renderParentInstructions the parent
+    // is filtered out by the leaves-only walk, so no identifier is emitted.
+    const node = programNode({
+        instructions: [
+            instructionNode({
+                arguments: [
+                    instructionArgumentNode({
+                        defaultValue: numberValueNode(1),
+                        name: 'parentDiscriminator',
+                        type: numberTypeNode('u8'),
+                    }),
+                ],
+                discriminators: [fieldDiscriminatorNode('parentDiscriminator')],
+                name: 'mintTokens',
+                subInstructions: [
+                    instructionNode({
+                        arguments: [
+                            instructionArgumentNode({
+                                defaultValue: numberValueNode(1),
+                                name: 'parentDiscriminator',
+                                type: numberTypeNode('u8'),
+                            }),
+                        ],
+                        discriminators: [],
+                        name: 'mintTokensV1',
+                    }),
+                ],
+            }),
+        ],
+        name: 'splToken',
+        publicKey: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    });
+
+    // When we render with renderParentInstructions: true, the parent is
+    // included in the walk and its discriminator drives identifier emission.
+    const renderMap = visit(node, getRenderMapVisitor({ renderParentInstructions: true }));
+
+    // Then the plugin exposes identifyInstruction/parseInstruction.
+    await renderMapContains(renderMap, 'programs/splToken.ts', [
+        'identifyInstruction: typeof identifySplTokenInstruction;',
+        'parseInstruction: typeof parseSplTokenInstruction;',
+        'identifyInstruction: identifySplTokenInstruction',
+        'parseInstruction: parseSplTokenInstruction',
+    ]);
 });
 
 test('it does not render parse function when no instructions have discriminators', async () => {


### PR DESCRIPTION
## Summary
- Re-expose `identifyAccount`, `identifyInstruction`, and `parseInstruction` on the generated program plugin, so consumers can call `client.myProgram.identifyInstruction(ix)` without importing the per-function helpers.
- Emission mirrors the existing rules for those helpers (account/instruction discriminators, respecting `renderParentInstructions`).
- Adds fragment, page, and e2e (`dummy`) round-trip coverage; e2e fixtures regenerated.

## Test Plan
- `pnpm test:unit`
- `cd test/e2e/dummy && pnpm test`