### PR TITLE
Support `@codama/nodes@1.10` optional array attributes

### DIFF
--- a/.changeset/neat-spiders-bake.md
+++ b/.changeset/neat-spiders-bake.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-js': patch
+---
+
+Support `@codama/nodes@1.10`, whose node array attributes are now optional (`Array<T> | undefined`). Array reads are guarded with `?? []` throughout the renderer, and the new `injectedValueNode` and `accountFieldValueNode` instruction-input default kinds now throw an explicit unsupported-node error rather than being silently mishandled.

--- a/package.json
+++ b/package.json
@@ -50,10 +50,10 @@
         "test:unit": "vitest run"
     },
     "dependencies": {
-        "@codama/errors": "^1.8.0",
-        "@codama/nodes": "^1.8.0",
-        "@codama/renderers-core": "^1.3.9",
-        "@codama/visitors-core": "^1.8.0",
+        "@codama/errors": "^1.10.0",
+        "@codama/nodes": "^1.10.0",
+        "@codama/renderers-core": "^1.3.11",
+        "@codama/visitors-core": "^1.10.0",
         "@solana/codecs-strings": "^7.0.0",
         "prettier": "^3.8.1",
         "semver": "^7.7.3"
@@ -61,7 +61,7 @@
     "devDependencies": {
         "@changesets/changelog-github": "^0.7.0",
         "@changesets/cli": "^2.29.7",
-        "@codama/nodes-from-anchor": "^1.5.1",
+        "@codama/nodes-from-anchor": "^1.5.3",
         "@solana/eslint-config-solana": "^5.0.0",
         "@solana/prettier-config-solana": "0.0.7",
         "@types/node": "^26",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,17 +9,17 @@ importers:
   .:
     dependencies:
       '@codama/errors':
-        specifier: ^1.8.0
-        version: 1.8.0
+        specifier: ^1.10.0
+        version: 1.10.0
       '@codama/nodes':
-        specifier: ^1.8.0
-        version: 1.8.0
+        specifier: ^1.10.0
+        version: 1.10.0
       '@codama/renderers-core':
-        specifier: ^1.3.9
-        version: 1.3.9
+        specifier: ^1.3.11
+        version: 1.3.11
       '@codama/visitors-core':
-        specifier: ^1.8.0
-        version: 1.8.0
+        specifier: ^1.10.0
+        version: 1.10.0
       '@solana/codecs-strings':
         specifier: ^7.0.0
         version: 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -37,8 +37,8 @@ importers:
         specifier: ^2.29.7
         version: 2.31.1(@types/node@26.1.1)
       '@codama/nodes-from-anchor':
-        specifier: ^1.5.1
-        version: 1.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+        specifier: ^1.5.3
+        version: 1.5.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/eslint-config-solana':
         specifier: ^5.0.0
         version: 5.0.0(@eslint/js@9.35.0)(@types/eslint__js@8.42.3)(eslint-plugin-jest@29.0.1(@typescript-eslint/eslint-plugin@8.43.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0)(typescript@5.9.3))(eslint@9.35.0)(typescript@5.9.3))(eslint@9.35.0)(jest@30.1.3(@types/node@26.1.1))(typescript@5.9.3))(eslint-plugin-react-hooks@5.2.0(eslint@9.35.0))(eslint-plugin-simple-import-sort@12.1.1(eslint@9.35.0))(eslint-plugin-sort-keys-fix@1.1.2)(eslint-plugin-typescript-sort-keys@3.3.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0)(typescript@5.9.3))(eslint@9.35.0)(typescript@5.9.3))(eslint@9.35.0)(globals@14.0.0)(jest@30.1.3(@types/node@26.1.1))(typescript-eslint@8.43.0(eslint@9.35.0)(typescript@5.9.3))(typescript@5.9.3)
@@ -305,30 +305,30 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@codama/errors@1.8.0':
-    resolution: {integrity: sha512-A0FNhbfS1PBSK0nS+g65IR8+OKkifuIJCCnLCUBXb+I/OYMGlJMycMpU4pwAEEGS5GAnue7D/llXE+KpUaMi8w==}
+  '@codama/errors@1.10.0':
+    resolution: {integrity: sha512-/qiWQcbPIsyFlP1LrLqJfHt1QNbkY2wtC4UxZyKLnuZtc62YPlgDrN2wp4wcfRuE/DC0n3Y6ZSwYUrDBZyAnvA==}
     hasBin: true
 
-  '@codama/fragments@0.1.1':
-    resolution: {integrity: sha512-+DeC2YklyYf+qjRkoTKeG6HFgwsW7hiQko7er18dgsxF15M316EwYL2W40nKDPWlEhB/iME+sZR5++VQPUO/6w==}
+  '@codama/fragments@0.1.3':
+    resolution: {integrity: sha512-ITa3UYs74AWx7se/6EZN+YXqV1Vu89L3n2v0/irsQNbPcy8wP26p/GKns/1H4a8vGvAKuzWdIGO535dwcauInw==}
 
-  '@codama/node-types@1.8.0':
-    resolution: {integrity: sha512-KE9K9jjEdeFKtDKRrjjm5YwEkg7l+YwoWiH2w1UXJL/x6P5uul6+O5WnGsJn8IFtBVSLN4hbD7YSsZ0/lktJxQ==}
+  '@codama/node-types@1.10.0':
+    resolution: {integrity: sha512-fMoJQ8TgB9A5Pl+GA8ffhDbGK63cV1nrbDrYTgIhPDKeVqBSdkSAoAuAtvWfRd7X2ML73H6RRi6jZRJmo2xfHQ==}
 
-  '@codama/nodes-from-anchor@1.5.1':
-    resolution: {integrity: sha512-AQee53GV/OY+jJE4PsORPoSagFwGMul1cpSBYhKzvxcrJg1xBesiblPqweNDVIW3NyskHB+x1kQpuq6bsJdb+w==}
+  '@codama/nodes-from-anchor@1.5.3':
+    resolution: {integrity: sha512-EcQ2QIty7LK2Vv5vKLprE/qsT13iDBRAvhH79NQauqP+QL6dFD9hCNmu0gfXZK0i7T0vafs55pddExO79qG7Dw==}
 
-  '@codama/nodes@1.8.0':
-    resolution: {integrity: sha512-rl+7BxYatAE6uq5h9b5fEilGLd3YeJaJxqgLDAvdKQ5pspq6ch5ww9NiigkwdvDYli1Yk56PRhMZdLsiZIVgAA==}
+  '@codama/nodes@1.10.0':
+    resolution: {integrity: sha512-P3NXVw6kZq2VDb4wYU6zQ3xFksDqSuDYqp11P6Dpei9XIZZ11NtL2jBjBcqsIudGIx104bMgSo4SZ7Hlej056A==}
 
-  '@codama/renderers-core@1.3.9':
-    resolution: {integrity: sha512-DwMxltM+cldAK+rgtE3jVOmrGZuP7fA/ZLu6vgrsQYBp5dkOXCyiGBdpAz0VlhxaN4lB5TzT2Ia+EVv5G4YdGQ==}
+  '@codama/renderers-core@1.3.11':
+    resolution: {integrity: sha512-VSGrfmwPVv5cRAiHitgIq+rc9ktIN/Q9czbUORaqhZCmM+M3Ux5cd5r90PVTbeIt8vI0Zlw74OUFwdKqdEfSNw==}
 
-  '@codama/visitors-core@1.8.0':
-    resolution: {integrity: sha512-CLO0icVvzAutjI7imuN1Rib0/GIBc7hhwQ5gcE3aVAVBHUNS4M27BzagqYTpL0cMC9I1tL9c6lhpCBV2kKs6Zg==}
+  '@codama/visitors-core@1.10.0':
+    resolution: {integrity: sha512-8koBGs4m/NI4nDLJZx7Q1KzRUKkBy/GAnZq4xOEFGlhTvDCIAzEgo3biAhNFynGY45gzZJSX08QTDWKsPRjnaA==}
 
-  '@codama/visitors@1.8.0':
-    resolution: {integrity: sha512-vQ863YkHBdLWZeaiPKisiRe0bbuBEBe9xDWVcLCCLRsmKCQuS+GB4bKxIwrlTr9cxCOGyQLkI7B/yAqyYEdbmw==}
+  '@codama/visitors@1.10.0':
+    resolution: {integrity: sha512-xAGKosZQnXBo9MiHFipA9Dsec1k9nbpv5UgUyY1j3l85FGEZQT2tHqrNxtBmPrC3LNSLVOfAdiUUMVUXUX5ydA==}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -3590,52 +3590,52 @@ snapshots:
       human-id: 4.2.0
       prettier: 2.8.8
 
-  '@codama/errors@1.8.0':
+  '@codama/errors@1.10.0':
     dependencies:
-      '@codama/node-types': 1.8.0
+      '@codama/node-types': 1.10.0
       commander: 14.0.3
       picocolors: 1.1.1
 
-  '@codama/fragments@0.1.1':
+  '@codama/fragments@0.1.3':
     dependencies:
-      '@codama/errors': 1.8.0
+      '@codama/errors': 1.10.0
 
-  '@codama/node-types@1.8.0': {}
+  '@codama/node-types@1.10.0': {}
 
-  '@codama/nodes-from-anchor@1.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+  '@codama/nodes-from-anchor@1.5.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
-      '@codama/errors': 1.8.0
-      '@codama/nodes': 1.8.0
-      '@codama/visitors': 1.8.0
+      '@codama/errors': 1.10.0
+      '@codama/nodes': 1.10.0
+      '@codama/visitors': 1.10.0
       '@noble/hashes': 2.0.1
       '@solana/codecs': 5.4.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - typescript
 
-  '@codama/nodes@1.8.0':
+  '@codama/nodes@1.10.0':
     dependencies:
-      '@codama/errors': 1.8.0
-      '@codama/node-types': 1.8.0
+      '@codama/errors': 1.10.0
+      '@codama/node-types': 1.10.0
 
-  '@codama/renderers-core@1.3.9':
+  '@codama/renderers-core@1.3.11':
     dependencies:
-      '@codama/errors': 1.8.0
-      '@codama/fragments': 0.1.1
-      '@codama/nodes': 1.8.0
-      '@codama/visitors-core': 1.8.0
+      '@codama/errors': 1.10.0
+      '@codama/fragments': 0.1.3
+      '@codama/nodes': 1.10.0
+      '@codama/visitors-core': 1.10.0
 
-  '@codama/visitors-core@1.8.0':
+  '@codama/visitors-core@1.10.0':
     dependencies:
-      '@codama/errors': 1.8.0
-      '@codama/nodes': 1.8.0
+      '@codama/errors': 1.10.0
+      '@codama/nodes': 1.10.0
       json-stable-stringify: 1.3.0
 
-  '@codama/visitors@1.8.0':
+  '@codama/visitors@1.10.0':
     dependencies:
-      '@codama/errors': 1.8.0
-      '@codama/nodes': 1.8.0
-      '@codama/visitors-core': 1.8.0
+      '@codama/errors': 1.10.0
+      '@codama/nodes': 1.10.0
+      '@codama/visitors-core': 1.10.0
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -4456,8 +4456,8 @@ snapshots:
 
   '@typescript-eslint/project-service@8.43.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.43.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.43.0
+      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.64.0
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:

--- a/src/fragments/accountPage.ts
+++ b/src/fragments/accountPage.ts
@@ -20,7 +20,7 @@ export function getAccountPageFragment(
     }
 
     const typeManifest = visit(node, scope.typeManifestVisitor);
-    const fields = resolveNestedTypeNode(node.data).fields;
+    const fields = resolveNestedTypeNode(node.data).fields ?? [];
     return mergeFragments(
         [
             getDiscriminatorConstantsFragment({

--- a/src/fragments/accountPdaHelpers.ts
+++ b/src/fragments/accountPdaHelpers.ts
@@ -24,7 +24,7 @@ export function getAccountPdaHelpersFragment(
     const importFrom = 'generatedPdas';
     const pdaSeedsType = nameApi.pdaSeedsType(pdaNode.name);
     const findPdaFunction = nameApi.pdaFindFunction(pdaNode.name);
-    const hasVariableSeeds = pdaNode.seeds.filter(isNodeFilter('variablePdaSeedNode')).length > 0;
+    const hasVariableSeeds = (pdaNode.seeds ?? []).filter(isNodeFilter('variablePdaSeedNode')).length > 0;
 
     const fetchFromSeedsFunction = nameApi.accountFetchFromSeedsFunction(accountNode.name);
     const fetchMaybeFromSeedsFunction = nameApi.accountFetchMaybeFromSeedsFunction(accountNode.name);

--- a/src/fragments/discriminatorCondition.ts
+++ b/src/fragments/discriminatorCondition.ts
@@ -89,7 +89,7 @@ function getFieldConditionFragment(
         struct: StructTypeNode;
     },
 ): Fragment {
-    const field = scope.struct.fields.find(f => f.name === discriminator.name);
+    const field = (scope.struct.fields ?? []).find(f => f.name === discriminator.name);
     if (!field || !field.defaultValue) {
         throw new Error(
             `Field discriminator "${discriminator.name}" does not have a matching argument with default value.`,
@@ -98,17 +98,16 @@ function getFieldConditionFragment(
 
     // This handles the case where a field uses an u8 array to represent its discriminator.
     // In this case, we can simplify the generated code by delegating to a constantDiscriminatorNode.
+    const defaultValueItems = isNode(field.defaultValue, 'arrayValueNode') ? (field.defaultValue.items ?? []) : [];
     if (
         isNode(field.type, 'arrayTypeNode') &&
         isNode(field.type.item, 'numberTypeNode') &&
         field.type.item.format === 'u8' &&
         isNode(field.type.count, 'fixedCountNode') &&
         isNode(field.defaultValue, 'arrayValueNode') &&
-        field.defaultValue.items.every(isNodeFilter('numberValueNode'))
+        defaultValueItems.every(isNodeFilter('numberValueNode'))
     ) {
-        const base64Bytes = getBase64Decoder().decode(
-            new Uint8Array(field.defaultValue.items.map(node => node.number)),
-        );
+        const base64Bytes = getBase64Decoder().decode(new Uint8Array(defaultValueItems.map(node => node.number)));
         return getByteConditionFragment(
             constantDiscriminatorNode(constantValueNodeFromBytes('base64', base64Bytes), discriminator.offset),
             scope,

--- a/src/fragments/errorPage.ts
+++ b/src/fragments/errorPage.ts
@@ -18,7 +18,7 @@ export function getErrorPageFragment(scope: Pick<RenderScope, 'nameApi'> & { pro
 function getConstantsFragment(scope: Pick<RenderScope, 'nameApi'> & { programNode: ProgramNode }): Fragment {
     const constantPrefix = scope.nameApi.programErrorConstantPrefix(scope.programNode.name);
     return mergeFragments(
-        [...scope.programNode.errors]
+        [...(scope.programNode.errors ?? [])]
             .sort((a, b) => a.code - b.code)
             .map(error => {
                 const docs = getDocblockFragment(error.docs ?? [], true);
@@ -33,7 +33,7 @@ function getConstantUnionTypeFragment(scope: Pick<RenderScope, 'nameApi'> & { pr
     const constantPrefix = scope.nameApi.programErrorConstantPrefix(scope.programNode.name);
     const typeName = scope.nameApi.programErrorUnion(scope.programNode.name);
     const errorTypes = mergeFragments(
-        [...scope.programNode.errors]
+        [...(scope.programNode.errors ?? [])]
             .sort((a, b) => a.name.localeCompare(b.name))
             .map(error => fragment`typeof ${constantPrefix + scope.nameApi.programErrorConstant(error.name)}`),
         cs => cs.join(' | '),
@@ -47,7 +47,7 @@ function getErrorMessagesFragment(scope: Pick<RenderScope, 'nameApi'> & { progra
     const errorUnionType = scope.nameApi.programErrorUnion(scope.programNode.name);
     const constantPrefix = scope.nameApi.programErrorConstantPrefix(scope.programNode.name);
     const messageEntries = mergeFragments(
-        [...scope.programNode.errors]
+        [...(scope.programNode.errors ?? [])]
             .sort((a, b) => a.name.localeCompare(b.name))
             .map(error => {
                 const constantName = constantPrefix + scope.nameApi.programErrorConstant(error.name);

--- a/src/fragments/instructionData.ts
+++ b/src/fragments/instructionData.ts
@@ -13,14 +13,14 @@ export function getInstructionDataFragment(
 ): Fragment | undefined {
     const { instructionPath, dataArgsManifest, nameApi, customInstructionData } = scope;
     const instructionNode = getLastNodeFromPath(instructionPath);
-    if (instructionNode.arguments.length === 0 || customInstructionData.has(instructionNode.name)) return;
+    if ((instructionNode.arguments ?? []).length === 0 || customInstructionData.has(instructionNode.name)) return;
 
     const instructionDataName = nameApi.instructionDataType(instructionNode.name);
     return getTypeWithCodecFragment({
         manifest: dataArgsManifest,
         name: instructionDataName,
         nameApi,
-        node: structTypeNodeFromInstructionArgumentNodes(instructionNode.arguments),
+        node: structTypeNodeFromInstructionArgumentNodes(instructionNode.arguments ?? []),
         size: scope.size,
     });
 }

--- a/src/fragments/instructionFunction.ts
+++ b/src/fragments/instructionFunction.ts
@@ -46,10 +46,10 @@ export function getInstructionFunctionFragment(
     if (useAsync && !hasAsyncFunction(instructionNode, resolvedInputs, asyncResolvers)) return;
 
     const customData = customInstructionData.get(instructionNode.name);
-    const hasAccounts = instructionNode.accounts.length > 0;
+    const hasAccounts = (instructionNode.accounts ?? []).length > 0;
     const instructionDependencies = getInstructionDependencies(instructionNode, asyncResolvers, useAsync);
     const argDependencies = instructionDependencies.filter(isNodeFilter('argumentValueNode')).map(node => node.name);
-    const hasData = !!customData || instructionNode.arguments.length > 0;
+    const hasData = !!customData || (instructionNode.arguments ?? []).length > 0;
     const argIsNotOmitted = (arg: InstructionArgumentNode) =>
         !(arg.defaultValue && arg.defaultValueStrategy === 'omitted');
     const argIsDependent = (arg: InstructionArgumentNode) => argDependencies.includes(arg.name);
@@ -58,7 +58,7 @@ export function getInstructionFunctionFragment(
         if (useAsync) return true;
         return !isAsyncDefaultValue(arg.defaultValue, asyncResolvers);
     };
-    const hasDataArgs = !!customData || instructionNode.arguments.filter(argIsNotOmitted).length > 0;
+    const hasDataArgs = !!customData || (instructionNode.arguments ?? []).filter(argIsNotOmitted).length > 0;
     const hasExtraArgs =
         (instructionNode.extraArguments ?? []).filter(
             field => argIsNotOmitted(field) && (argIsDependent(field) || argHasDefaultValue(field)),
@@ -121,10 +121,10 @@ const programAddress = config?.programAddress ?? ${programAddressConstant};`;
 }
 
 function getAccountsInitializationFragment(instructionNode: InstructionNode): Fragment | undefined {
-    if (instructionNode.accounts.length === 0) return;
+    if ((instructionNode.accounts ?? []).length === 0) return;
 
     const accounts = mergeFragments(
-        instructionNode.accounts.map(account => {
+        (instructionNode.accounts ?? []).map(account => {
             const name = camelCase(account.name);
             const isWritable = account.isWritable ? 'true' : 'false';
             return fragment`${name}: { value: input.${name} ?? null, isWritable: ${isWritable} }`;
@@ -180,10 +180,10 @@ function getReturnStatementFragment(
 ): Fragment {
     const { instructionNode, hasByteDeltas, hasData, hasDataArgs, hasRemainingAccounts, nameApi } = scope;
     const optionalAccountStrategy = instructionNode.optionalAccountStrategy ?? 'programId';
-    const hasAccounts = instructionNode.accounts.length > 0;
+    const hasAccounts = (instructionNode.accounts ?? []).length > 0;
     const hasLegacyOptionalAccounts =
         instructionNode.optionalAccountStrategy === 'omitted' &&
-        instructionNode.accounts.some(account => account.isOptional);
+        (instructionNode.accounts ?? []).some(account => account.isOptional);
 
     // Account meta helper.
     const getAccountMeta = hasAccounts
@@ -192,7 +192,7 @@ function getReturnStatementFragment(
 
     // Accounts.
     const accountItems = [
-        ...instructionNode.accounts.map(
+        ...(instructionNode.accounts ?? []).map(
             account => `getAccountMeta("${camelCase(account.name)}", accounts.${camelCase(account.name)})`,
         ),
         ...(hasRemainingAccounts ? ['...remainingAccounts'] : []),
@@ -240,7 +240,9 @@ function getReturnTypeFragment(instructionTypeFragment: Fragment, hasByteDeltas:
 function getTypeParamsFragment(instructionNode: InstructionNode, programAddressConstant: Fragment): Fragment {
     return mergeFragments(
         [
-            ...instructionNode.accounts.map(account => fragment`TAccount${pascalCase(account.name)} extends string`),
+            ...(instructionNode.accounts ?? []).map(
+                account => fragment`TAccount${pascalCase(account.name)} extends string`,
+            ),
             fragment`TProgramAddress extends ${use('type Address', 'solanaAddresses')} = typeof ${programAddressConstant}`,
         ],
         cs => `<${cs.join(', ')}>`,
@@ -251,7 +253,7 @@ function getInstructionTypeFragment(scope: { instructionPath: NodePath<Instructi
     const { instructionPath, nameApi } = scope;
     const instructionNode = getLastNodeFromPath(instructionPath);
     const instructionTypeName = nameApi.instructionType(instructionNode.name);
-    const accountTypeParamsFragments = instructionNode.accounts.map(account => {
+    const accountTypeParamsFragments = (instructionNode.accounts ?? []).map(account => {
         const typeParam = fragment`TAccount${pascalCase(account.name)}`;
         const camelName = camelCase(account.name);
 
@@ -285,8 +287,10 @@ function getInputTypeCallFragment(scope: {
     const inputTypeName = useAsync
         ? nameApi.instructionAsyncInputType(instructionNode.name)
         : nameApi.instructionSyncInputType(instructionNode.name);
-    if (instructionNode.accounts.length === 0) return fragment`${inputTypeName}`;
-    const accountTypeParams = instructionNode.accounts.map(account => `TAccount${pascalCase(account.name)}`).join(', ');
+    if ((instructionNode.accounts ?? []).length === 0) return fragment`${inputTypeName}`;
+    const accountTypeParams = (instructionNode.accounts ?? [])
+        .map(account => `TAccount${pascalCase(account.name)}`)
+        .join(', ');
 
     return fragment`${inputTypeName}<${accountTypeParams}>`;
 }

--- a/src/fragments/instructionInputDefault.ts
+++ b/src/fragments/instructionInputDefault.ts
@@ -97,7 +97,7 @@ export function getInstructionInputDefaultFragment(
                 } else if (defaultValue.pda.programId) {
                     pdaProgram = fragment`'${defaultValue.pda.programId}' as ${addressType}<'${defaultValue.pda.programId}'>`;
                 }
-                const pdaSeeds = defaultValue.pda.seeds.flatMap((seed): Fragment[] => {
+                const pdaSeeds = (defaultValue.pda.seeds ?? []).flatMap((seed): Fragment[] => {
                     if (isNode(seed, 'constantPdaSeedNode') && isNode(seed.value, 'programIdValueNode')) {
                         return [fragment`${use('getAddressEncoder', 'solanaAddresses')}().encode(${pdaProgram})`];
                     }
@@ -108,7 +108,7 @@ export function getInstructionInputDefaultFragment(
                     }
                     if (isNode(seed, 'variablePdaSeedNode')) {
                         const typeManifest = visit(seed.type, typeManifestVisitor);
-                        const valueSeed = defaultValue.seeds.find(s => s.name === seed.name)?.value;
+                        const valueSeed = (defaultValue.seeds ?? []).find(s => s.name === seed.name)?.value;
                         if (!valueSeed) return [];
                         if (isNode(valueSeed, 'accountValueNode')) {
                             const name = camelCase(valueSeed.name);
@@ -139,7 +139,7 @@ export function getInstructionInputDefaultFragment(
             // Linked PDA value.
             const pdaFunction = use(nameApi.pdaFindFunction(defaultValue.pda.name), getImportFrom(defaultValue.pda));
             const pdaArgs: Fragment[] = [];
-            const pdaSeeds = defaultValue.seeds.map((seed): Fragment => {
+            const pdaSeeds = (defaultValue.seeds ?? []).map((seed): Fragment => {
                 if (isNode(seed.value, 'accountValueNode')) {
                     const name = camelCase(seed.value.name);
                     return fragment`${seed.name}: ${getAddressFromResolvedInstructionAccount}("${name}", accounts.${name}.value)`;
@@ -263,6 +263,11 @@ export function getInstructionInputDefaultFragment(
                 conditionalFragment,
                 `if (${condition}) {\n${ifTrueRenderer ? ifTrueRenderer.content : ifFalseRenderer?.content}\n}`,
             );
+
+        case 'accountFieldValueNode':
+        case 'injectedValueNode':
+            // These contextual value nodes are not yet supported as instruction input defaults by this renderer.
+            throw new Error(`Unsupported instruction input default value node: [${defaultValue.kind}]`);
 
         default:
             const valueManifest = visit(defaultValue, typeManifestVisitor).value;

--- a/src/fragments/instructionInputType.ts
+++ b/src/fragments/instructionInputType.ts
@@ -45,8 +45,8 @@ export function getInstructionInputTypeFragment(
     const [dataArgumentsFragment, customDataArgumentsFragment] = getDataArgumentsFragments(scope);
 
     let accountTypeParams = '';
-    if (instructionNode.accounts.length > 0) {
-        accountTypeParams = instructionNode.accounts
+    if ((instructionNode.accounts ?? []).length > 0) {
+        accountTypeParams = (instructionNode.accounts ?? [])
             .map(account => `TAccount${pascalCase(account.name)} extends string = string`)
             .join(', ');
         accountTypeParams = `<${accountTypeParams}>`;
@@ -77,7 +77,7 @@ function getAccountsFragment(
     const { instructionPath, resolvedInputs, useAsync, asyncResolvers } = scope;
     const instructionNode = getLastNodeFromPath(instructionPath);
 
-    const fragments = instructionNode.accounts.map(account => {
+    const fragments = (instructionNode.accounts ?? []).map(account => {
         const resolvedAccount = resolvedInputs.find(
             input => input.kind === 'instructionAccountNode' && input.name === account.name,
         ) as ResolvedInstructionAccount;
@@ -132,7 +132,7 @@ function getDataArgumentsFragments(
     const instructionDataName = nameApi.instructionDataType(instructionNode.name);
     const dataArgsType = nameApi.dataArgsType(instructionDataName);
 
-    const fragments = instructionNode.arguments.flatMap(arg => {
+    const fragments = (instructionNode.arguments ?? []).flatMap(arg => {
         const argFragment = getArgumentFragment(arg, dataArgsType, scope.resolvedInputs, scope.renamedArgs);
         return argFragment ? [argFragment] : [];
     });

--- a/src/fragments/instructionPage.ts
+++ b/src/fragments/instructionPage.ts
@@ -49,7 +49,7 @@ export function getInstructionPageFragment(
             getDiscriminatorConstantsFragment({
                 ...childScope,
                 discriminatorNodes: node.discriminators ?? [],
-                fields: node.arguments,
+                fields: node.arguments ?? [],
                 prefix: node.name,
             }),
             getInstructionTypeFragment(childScope),
@@ -65,7 +65,7 @@ export function getInstructionPageFragment(
 
 export function getRenamedArgsMap(instruction: InstructionNode): Map<string, string> {
     const argNames = [
-        ...instruction.arguments.map(a => a.name),
+        ...(instruction.arguments ?? []).map(a => a.name),
         ...(instruction.extraArguments ?? []).map(a => a.name),
     ];
     const duplicateArgs = argNames.filter((e, i, a) => a.indexOf(e) !== i);
@@ -73,7 +73,7 @@ export function getRenamedArgsMap(instruction: InstructionNode): Map<string, str
         throw new Error(`Duplicate args found: [${duplicateArgs.join(', ')}] in instruction [${instruction.name}].`);
     }
 
-    const allNames = [...instruction.accounts.map(account => account.name), ...argNames];
+    const allNames = [...(instruction.accounts ?? []).map(account => account.name), ...argNames];
     const duplicates = allNames.filter((e, i, a) => a.indexOf(e) !== i);
     if (duplicates.length === 0) return new Map();
 

--- a/src/fragments/instructionParseFunction.ts
+++ b/src/fragments/instructionParseFunction.ts
@@ -37,8 +37,8 @@ function getTypeFragment(
     const instructionParsedType = scope.nameApi.instructionParsedType(scope.instructionNode.name);
     const instructionDataName = scope.nameApi.instructionDataType(scope.instructionNode.name);
 
-    const hasData = !!customData || scope.instructionNode.arguments.length > 0;
-    const hasAccounts = scope.instructionNode.accounts.length > 0;
+    const hasData = !!customData || (scope.instructionNode.arguments ?? []).length > 0;
+    const hasAccounts = (scope.instructionNode.accounts ?? []).length > 0;
 
     const typeParamDeclarations = mergeFragments(
         [
@@ -51,7 +51,7 @@ function getTypeFragment(
     );
 
     const accounts = mergeFragments(
-        scope.instructionNode.accounts.map((account, i) => {
+        (scope.instructionNode.accounts ?? []).map((account, i) => {
             const docs = getDocblockFragment(account.docs ?? [], true);
             const name = camelCase(account.name);
             return fragment`${docs}${name}${account.isOptional ? '?' : ''}: TAccountMetas[${i}]${account.isOptional ? ' | undefined' : ''};`;
@@ -82,13 +82,13 @@ function getFunctionFragment(
         ? scope.dataArgsManifest.decoder
         : fragment`${scope.nameApi.decoderFunction(instructionDataName)}()`;
 
-    const hasData = !!customData || scope.instructionNode.arguments.length > 0;
-    const hasAccounts = scope.instructionNode.accounts.length > 0;
-    const hasOptionalAccounts = scope.instructionNode.accounts.some(account => account.isOptional);
+    const hasData = !!customData || (scope.instructionNode.arguments ?? []).length > 0;
+    const hasAccounts = (scope.instructionNode.accounts ?? []).length > 0;
+    const hasOptionalAccounts = (scope.instructionNode.accounts ?? []).some(account => account.isOptional);
     const minimumNumberOfAccounts =
         scope.instructionNode.optionalAccountStrategy === 'omitted'
-            ? scope.instructionNode.accounts.filter(account => !account.isOptional).length
-            : scope.instructionNode.accounts.length;
+            ? (scope.instructionNode.accounts ?? []).filter(account => !account.isOptional).length
+            : (scope.instructionNode.accounts ?? []).length;
 
     const typeParams = ['TProgram', hasAccounts ? 'TAccountMetas' : undefined].filter(Boolean).join(', ');
     const typeParamDeclarations = mergeFragments(
@@ -149,7 +149,7 @@ const getNextOptionalAccount = () => {
     }
 
     const accounts = mergeFragments(
-        scope.instructionNode.accounts.map(account =>
+        (scope.instructionNode.accounts ?? []).map(account =>
             account.isOptional
                 ? fragment`${camelCase(account.name)}: getNextOptionalAccount()`
                 : fragment`${camelCase(account.name)}: getNextAccount()`,

--- a/src/fragments/instructionType.ts
+++ b/src/fragments/instructionType.ts
@@ -14,15 +14,15 @@ export function getInstructionTypeFragment(
     const { instructionPath, nameApi, customInstructionData } = scope;
     const instructionNode = getLastNodeFromPath(instructionPath);
     const programNode = findProgramNodeFromPath(instructionPath)!;
-    const hasAccounts = instructionNode.accounts.length > 0;
+    const hasAccounts = (instructionNode.accounts ?? []).length > 0;
     const customData = customInstructionData.get(instructionNode.name);
-    const hasData = !!customData || instructionNode.arguments.length > 0;
+    const hasData = !!customData || (instructionNode.arguments ?? []).length > 0;
 
     const instructionType = nameApi.instructionType(instructionNode.name);
     const programAddressConstant = use(nameApi.programAddressConstant(programNode.name), 'generatedPrograms');
 
     const accountTypeParams = mergeFragments(
-        instructionNode.accounts.map(account =>
+        (instructionNode.accounts ?? []).map(account =>
             getInstructionAccountTypeParamFragment({
                 ...scope,
                 allowAccountMeta: true,
@@ -38,7 +38,7 @@ export function getInstructionTypeFragment(
 
     const usesLegacyOptionalAccounts = instructionNode.optionalAccountStrategy === 'omitted';
     const accountMetasFragment = mergeFragments(
-        instructionNode.accounts.map(account =>
+        (instructionNode.accounts ?? []).map(account =>
             mapFragmentContent(getInstructionAccountMetaFragment(account), c => {
                 const typeParam = `TAccount${pascalCase(account.name)}`;
                 const isLegacyOptional = account.isOptional && usesLegacyOptionalAccounts;

--- a/src/fragments/pdaFunction.ts
+++ b/src/fragments/pdaFunction.ts
@@ -9,7 +9,7 @@ export function getPdaFunctionFragment(
     },
 ): Fragment {
     const pdaNode = getLastNodeFromPath(scope.pdaPath);
-    const seeds = parsePdaSeedNodes(pdaNode.seeds, scope);
+    const seeds = parsePdaSeedNodes(pdaNode.seeds ?? [], scope);
 
     return mergeFragments([getSeedInputTypeFragment(seeds, scope), getFunctionFragment(seeds, scope)], cs =>
         cs.join('\n\n'),

--- a/src/fragments/programAccounts.ts
+++ b/src/fragments/programAccounts.ts
@@ -8,7 +8,7 @@ export function getProgramAccountsFragment(
         programNode: ProgramNode;
     },
 ): Fragment | undefined {
-    if (scope.programNode.accounts.length === 0) return;
+    if ((scope.programNode.accounts ?? []).length === 0) return;
     return mergeFragments(
         [getProgramAccountsEnumFragment(scope), getProgramAccountsIdentifierFunctionFragment(scope)],
         c => c.join('\n\n'),
@@ -22,7 +22,7 @@ function getProgramAccountsEnumFragment(
 ): Fragment {
     const { programNode, nameApi } = scope;
     const programAccountsEnum = nameApi.programAccountsEnum(programNode.name);
-    const programAccountsEnumVariants = programNode.accounts.map(account =>
+    const programAccountsEnumVariants = (programNode.accounts ?? []).map(account =>
         nameApi.programAccountsEnumVariant(account.name),
     );
     return fragment`export enum ${programAccountsEnum} { ${programAccountsEnumVariants.join(', ')} }`;
@@ -34,7 +34,7 @@ function getProgramAccountsIdentifierFunctionFragment(
     },
 ): Fragment | undefined {
     const { programNode, nameApi } = scope;
-    const accountsWithDiscriminators = programNode.accounts.filter(
+    const accountsWithDiscriminators = (programNode.accounts ?? []).filter(
         account => (account.discriminators ?? []).length > 0,
     );
     const hasAccountDiscriminators = accountsWithDiscriminators.length > 0;

--- a/src/fragments/programInstructions.ts
+++ b/src/fragments/programInstructions.ts
@@ -13,7 +13,7 @@ export function getProgramInstructionsFragment(
         programNode: ProgramNode;
     },
 ): Fragment | undefined {
-    if (scope.programNode.instructions.length === 0) return;
+    if ((scope.programNode.instructions ?? []).length === 0) return;
 
     const allInstructions = getAllInstructionsWithSubs(scope.programNode, {
         leavesOnly: !scope.renderParentInstructions,
@@ -68,7 +68,7 @@ function getProgramInstructionsIdentifierFunctionFragment(
                 dataName: 'data',
                 discriminators: instruction.discriminators ?? [],
                 ifTrue: `return ${programInstructionsEnum}.${variant};`,
-                struct: structTypeNodeFromInstructionArgumentNodes(instruction.arguments),
+                struct: structTypeNodeFromInstructionArgumentNodes(instruction.arguments ?? []),
             });
         }),
         c => c.join('\n'),
@@ -141,7 +141,7 @@ function getProgramInstructionsParseFunctionFragment(
             const parseFunction = use(nameApi.instructionParseFunction(instruction.name), 'generatedInstructions');
             const assertIsInstructionWithAccounts = use('assertIsInstructionWithAccounts', 'solanaInstructions');
             // Only need accounts assertion since data is guaranteed by the input type
-            const hasAccounts = instruction.accounts.length > 0;
+            const hasAccounts = (instruction.accounts ?? []).length > 0;
             const assertionsCode = hasAccounts
                 ? fragment`${assertIsInstructionWithAccounts}(instruction);\n`
                 : fragment``;

--- a/src/fragments/programPlugin.ts
+++ b/src/fragments/programPlugin.ts
@@ -16,14 +16,14 @@ export function getProgramPluginFragment(
     scope: Pick<RenderScope, 'asyncResolvers' | 'nameApi' | 'renderParentInstructions'> & { programNode: ProgramNode },
 ): Fragment | undefined {
     if (
-        scope.programNode.accounts.length === 0 &&
-        scope.programNode.instructions.length === 0 &&
-        scope.programNode.pdas.length === 0
+        (scope.programNode.accounts ?? []).length === 0 &&
+        (scope.programNode.instructions ?? []).length === 0 &&
+        (scope.programNode.pdas ?? []).length === 0
     )
         return;
 
     const resolvedInstructionInputVisitor = getResolvedInstructionInputsVisitor();
-    const asyncInstructions: CamelCaseString[] = scope.programNode.instructions
+    const asyncInstructions: CamelCaseString[] = (scope.programNode.instructions ?? [])
         .filter(instruction =>
             hasAsyncFunction(instruction, visit(instruction, resolvedInstructionInputVisitor), scope.asyncResolvers),
         )
@@ -45,7 +45,7 @@ export function getProgramPluginFragment(
 }
 
 function hasAccountIdentifier(programNode: ProgramNode): boolean {
-    return programNode.accounts.some(account => (account.discriminators ?? []).length > 0);
+    return (programNode.accounts ?? []).some(account => (account.discriminators ?? []).length > 0);
 }
 
 function hasInstructionIdentifier(programNode: ProgramNode, renderParentInstructions: boolean | undefined): boolean {
@@ -72,9 +72,11 @@ function getProgramPluginTypeFragment(
 
     const fields = mergeFragments(
         [
-            programNode.accounts.length > 0 ? fragment`accounts: ${programPluginAccountsType};` : undefined,
-            programNode.instructions.length > 0 ? fragment`instructions: ${programPluginInstructionsType};` : undefined,
-            programNode.pdas.length > 0 ? fragment`pdas: ${programPluginPdasType};` : undefined,
+            (programNode.accounts ?? []).length > 0 ? fragment`accounts: ${programPluginAccountsType};` : undefined,
+            (programNode.instructions ?? []).length > 0
+                ? fragment`instructions: ${programPluginInstructionsType};`
+                : undefined,
+            (programNode.pdas ?? []).length > 0 ? fragment`pdas: ${programPluginPdasType};` : undefined,
             hasAccountIdentifier(programNode)
                 ? fragment`identifyAccount: typeof ${accountsIdentifierFunction};`
                 : undefined,
@@ -92,12 +94,12 @@ function getProgramPluginAccountsTypeFragment(
     scope: Pick<RenderScope, 'nameApi'> & { programNode: ProgramNode },
 ): Fragment | undefined {
     const { programNode, nameApi } = scope;
-    if (programNode.accounts.length === 0) return;
+    if ((programNode.accounts ?? []).length === 0) return;
     const programPluginAccountsType = nameApi.programPluginAccountsType(programNode.name);
     const selfFetchFunctions = use('type SelfFetchFunctions', 'solanaProgramClientCore');
 
     const fields = mergeFragments(
-        programNode.accounts.map(account => {
+        (programNode.accounts ?? []).map(account => {
             const name = nameApi.programPluginAccountKey(account.name);
             const codecFunction = use('type ' + nameApi.codecFunction(account.name), 'generatedAccounts');
             const fromType = use('type ' + nameApi.dataArgsType(account.name), 'generatedAccounts');
@@ -114,12 +116,12 @@ function getProgramPluginInstructionsTypeFragment(
     scope: Pick<RenderScope, 'nameApi'> & { asyncInstructions: CamelCaseString[]; programNode: ProgramNode },
 ): Fragment | undefined {
     const { programNode, asyncInstructions, nameApi } = scope;
-    if (programNode.instructions.length === 0) return;
+    if ((programNode.instructions ?? []).length === 0) return;
     const programPluginInstructionsType = nameApi.programPluginInstructionsType(programNode.name);
     const selfPlanAndSendFunctions = use('type SelfPlanAndSendFunctions', 'solanaProgramClientCore');
 
     const fields = mergeFragments(
-        programNode.instructions.map(instruction => {
+        (programNode.instructions ?? []).map(instruction => {
             const name = nameApi.programPluginInstructionKey(instruction.name);
             const isAsync = asyncInstructions.includes(instruction.name);
             let instructionInputType = isAsync
@@ -147,11 +149,11 @@ function getProgramPluginPdasTypeFragment(
     scope: Pick<RenderScope, 'nameApi'> & { programNode: ProgramNode },
 ): Fragment | undefined {
     const { programNode, nameApi } = scope;
-    if (programNode.pdas.length === 0) return;
+    if ((programNode.pdas ?? []).length === 0) return;
     const programPluginPdasType = nameApi.programPluginPdasType(programNode.name);
 
     const fields = mergeFragments(
-        programNode.pdas.map(pda => {
+        (programNode.pdas ?? []).map(pda => {
             const name = nameApi.programPluginPdaKey(pda.name);
             const pdaFindFunction = use('type ' + nameApi.pdaFindFunction(pda.name), 'generatedPdas');
             return fragment`${name}: typeof ${pdaFindFunction};`;
@@ -166,10 +168,10 @@ function getProgramPluginPdasObjectFragment(
     scope: Pick<RenderScope, 'nameApi'> & { programNode: ProgramNode },
 ): Fragment | undefined {
     const { programNode, nameApi } = scope;
-    if (programNode.pdas.length === 0) return;
+    if ((programNode.pdas ?? []).length === 0) return;
 
     const fields = mergeFragments(
-        programNode.pdas.map(pda => {
+        (programNode.pdas ?? []).map(pda => {
             const name = nameApi.programPluginPdaKey(pda.name);
             const pdaFindFunction = use(nameApi.pdaFindFunction(pda.name), 'generatedPdas');
             return fragment`${name}: ${pdaFindFunction}`;
@@ -189,8 +191,8 @@ function getProgramPluginRequirementsTypeFragment(
     const clientWithPayer = use('type ClientWithPayer', 'solanaPluginInterfaces');
     const clientWithTransactionPlanning = use('type ClientWithTransactionPlanning', 'solanaPluginInterfaces');
     const clientWithTransactionSending = use('type ClientWithTransactionSending', 'solanaPluginInterfaces');
-    const hasAccounts = programNode.accounts.length > 0;
-    const hasInstructions = programNode.instructions.length > 0;
+    const hasAccounts = (programNode.accounts ?? []).length > 0;
+    const hasInstructions = (programNode.instructions ?? []).length > 0;
 
     const requirementList = [
         hasAccounts ? clientWithRpc : undefined,
@@ -250,10 +252,10 @@ function getProgramPluginAccountsObjectFragment(
     scope: Pick<RenderScope, 'nameApi'> & { programNode: ProgramNode },
 ): Fragment | undefined {
     const { programNode, nameApi } = scope;
-    if (programNode.accounts.length === 0) return;
+    if ((programNode.accounts ?? []).length === 0) return;
 
     const fields = mergeFragments(
-        programNode.accounts.map(account => {
+        (programNode.accounts ?? []).map(account => {
             const name = nameApi.programPluginAccountKey(account.name);
             const addSelfFetchFunctions = use('addSelfFetchFunctions', 'solanaProgramClientCore');
             const codecFunction = use(nameApi.codecFunction(account.name), 'generatedAccounts');
@@ -269,10 +271,10 @@ function getProgramPluginInstructionsObjectFragment(
     scope: Pick<RenderScope, 'nameApi'> & { asyncInstructions: CamelCaseString[]; programNode: ProgramNode },
 ): Fragment | undefined {
     const { programNode, nameApi, asyncInstructions } = scope;
-    if (programNode.instructions.length === 0) return;
+    if ((programNode.instructions ?? []).length === 0) return;
 
     const fields = mergeFragments(
-        programNode.instructions.map(instruction => {
+        (programNode.instructions ?? []).map(instruction => {
             const name = nameApi.programPluginInstructionKey(instruction.name);
             const isAsync = asyncInstructions.includes(instruction.name);
             const instructionFunction = isAsync
@@ -307,7 +309,7 @@ function getMakeOptionalHelperTypeFragment(scope: { programNode: ProgramNode }):
 }
 
 function hasPayerDefaultValues(programNode: ProgramNode): boolean {
-    return programNode.instructions.some(instruction => getPayerDefaultValueNodes(instruction).length > 0);
+    return (programNode.instructions ?? []).some(instruction => getPayerDefaultValueNodes(instruction).length > 0);
 }
 
 function getPayerDefaultValues(instructionNode: InstructionNode): { name: string; signer: boolean }[] {
@@ -323,7 +325,7 @@ function getPayerDefaultValueNodes(
     instructionNode: InstructionNode,
 ): (InstructionAccountNode | InstructionArgumentNode)[] {
     return [
-        ...instructionNode.accounts.filter(a => !a.isOptional && isNode(a.defaultValue, 'payerValueNode')),
-        ...instructionNode.arguments.filter(a => isNode(a.defaultValue, 'payerValueNode')),
+        ...(instructionNode.accounts ?? []).filter(a => !a.isOptional && isNode(a.defaultValue, 'payerValueNode')),
+        ...(instructionNode.arguments ?? []).filter(a => isNode(a.defaultValue, 'payerValueNode')),
     ];
 }

--- a/src/fragments/rootIndexPage.ts
+++ b/src/fragments/rootIndexPage.ts
@@ -19,7 +19,7 @@ export function getRootIndexPageFragment(scope: {
         return fragment`export default {};`;
     }
 
-    const programsWithErrorsToExport = scope.programsToExport.filter(p => p.errors.length > 0);
+    const programsWithErrorsToExport = scope.programsToExport.filter(p => (p.errors ?? []).length > 0);
 
     return mergeFragments(
         [

--- a/src/fragments/typeDiscriminatedUnionHelpers.ts
+++ b/src/fragments/typeDiscriminatedUnionHelpers.ts
@@ -18,7 +18,7 @@ export function getTypeDiscriminatedUnionHelpersFragment(
     const getVariantContentType = use('type GetDiscriminatedUnionVariantContent', 'solanaCodecsDataStructures');
     const getVariantType = use('type GetDiscriminatedUnionVariant', 'solanaCodecsDataStructures');
     const variantSignatures = mergeFragments(
-        typeNode.variants.map(variant => {
+        (typeNode.variants ?? []).map(variant => {
             const variantName = nameApi.discriminatedUnionVariant(variant.name);
             if (isNode(variant, 'enumStructVariantTypeNode')) {
                 return fragment`export function ${functionName}(kind: '${variantName}', data: ${getVariantContentType}<${looseName}, '${discriminatorName}', '${variantName}'>): ${getVariantType}<${looseName}, '${discriminatorName}', '${variantName}'>;`;

--- a/src/utils/async.ts
+++ b/src/utils/async.ts
@@ -57,8 +57,8 @@ export function getInstructionDependencies(
 ): (AccountValueNode | ArgumentValueNode)[] {
     if (isNode(input, 'instructionNode')) {
         return deduplicateInstructionDependencies([
-            ...input.accounts.flatMap(x => getInstructionDependencies(x, asyncResolvers, useAsync)),
-            ...input.arguments.flatMap(x => getInstructionDependencies(x, asyncResolvers, useAsync)),
+            ...(input.accounts ?? []).flatMap(x => getInstructionDependencies(x, asyncResolvers, useAsync)),
+            ...(input.arguments ?? []).flatMap(x => getInstructionDependencies(x, asyncResolvers, useAsync)),
             ...(input.extraArguments ?? []).flatMap(x => getInstructionDependencies(x, asyncResolvers, useAsync)),
         ]);
     }
@@ -82,7 +82,7 @@ export function getInstructionDependencies(
 
     if (isNode(input.defaultValue, 'pdaValueNode')) {
         const dependencies = new Map<CamelCaseString, AccountValueNode | ArgumentValueNode>();
-        input.defaultValue.seeds.forEach(seed => {
+        (input.defaultValue.seeds ?? []).forEach(seed => {
             if (isNode(seed.value, ['accountValueNode', 'argumentValueNode'])) {
                 dependencies.set(seed.value.name, { ...seed.value });
             }

--- a/src/utils/customData.ts
+++ b/src/utils/customData.ts
@@ -69,7 +69,7 @@ export const getDefinedTypeNodesToExtract = (
         return [
             definedTypeNode({
                 name: options.extractAs,
-                type: structTypeNodeFromInstructionArgumentNodes(node.arguments),
+                type: structTypeNodeFromInstructionArgumentNodes(node.arguments ?? []),
             }),
         ];
     });

--- a/src/visitors/getRenderMapVisitor.ts
+++ b/src/visitors/getRenderMapVisitor.ts
@@ -139,8 +139,8 @@ export function getRenderMapVisitor(
 
                 visitProgram(node, { self }) {
                     const customDataDefinedType = [
-                        ...getDefinedTypeNodesToExtract(node.accounts, customAccountData),
-                        ...getDefinedTypeNodesToExtract(node.instructions, customInstructionData),
+                        ...getDefinedTypeNodesToExtract(node.accounts ?? [], customAccountData),
+                        ...getDefinedTypeNodesToExtract(node.instructions ?? [], customInstructionData),
                     ];
                     const scope = { ...renderScope, programNode: node };
 
@@ -148,11 +148,11 @@ export function getRenderMapVisitor(
                         createRenderMap({
                             [`programs/${camelCase(node.name)}.ts`]: asPage(getProgramPageFragment(scope)),
                             [`errors/${camelCase(node.name)}.ts`]:
-                                node.errors.length > 0 ? asPage(getErrorPageFragment(scope)) : undefined,
+                                (node.errors ?? []).length > 0 ? asPage(getErrorPageFragment(scope)) : undefined,
                         }),
-                        ...node.pdas.map(p => visit(p, self)),
-                        ...node.accounts.map(a => visit(a, self)),
-                        ...node.definedTypes.map(t => visit(t, self)),
+                        ...(node.pdas ?? []).map(p => visit(p, self)),
+                        ...(node.accounts ?? []).map(a => visit(a, self)),
+                        ...(node.definedTypes ?? []).map(t => visit(t, self)),
                         ...customDataDefinedType.map(t => visit(t, self)),
                         ...getAllInstructionsWithSubs(node, { leavesOnly: !renderScope.renderParentInstructions }).map(
                             i => visit(i, self),
@@ -163,7 +163,7 @@ export function getRenderMapVisitor(
                 visitRoot(node, { self }) {
                     const isNotInternal = (n: { name: CamelCaseString }) => !internalNodes.includes(n.name);
                     const programsToExport = getAllPrograms(node).filter(isNotInternal);
-                    const programsWithErrorsToExport = programsToExport.filter(p => p.errors.length > 0);
+                    const programsWithErrorsToExport = programsToExport.filter(p => (p.errors ?? []).length > 0);
                     const pdasToExport = getAllPdas(node);
                     const accountsToExport = getAllAccounts(node).filter(isNotInternal);
                     const instructionsToExport = getAllInstructionsWithSubs(node, {

--- a/src/visitors/getTypeManifestVisitor.ts
+++ b/src/visitors/getTypeManifestVisitor.ts
@@ -112,7 +112,7 @@ export function getTypeManifestVisitor(input: {
 
                 visitArrayValue(node, { self }) {
                     return mergeTypeManifests(
-                        node.items.map(v => visit(v, self)),
+                        (node.items ?? []).map(v => visit(v, self)),
                         { mergeValues: renders => `[${renders.join(', ')}]` },
                     );
                 },
@@ -295,7 +295,7 @@ export function getTypeManifestVisitor(input: {
                                     'defined type that is a scalar enum through a visitor.',
                             );
                         }
-                        const variantNames = enumType.variants.map(({ name }) => nameApi.enumVariant(name));
+                        const variantNames = (enumType.variants ?? []).map(({ name }) => nameApi.enumVariant(name));
                         return typeManifest({
                             decoder: fragment`${use('getEnumDecoder', 'solanaCodecsDataStructures')}(${currentParentName.strict}${decoderOptionsFragment})`,
                             encoder: fragment`${use('getEnumEncoder', 'solanaCodecsDataStructures')}(${currentParentName.strict}${encoderOptionsFragment})`,
@@ -306,7 +306,7 @@ export function getTypeManifestVisitor(input: {
                     }
 
                     const mergedManifest = mergeTypeManifests(
-                        enumType.variants.map(variant => visit(variant, self)),
+                        (enumType.variants ?? []).map(variant => visit(variant, self)),
                         {
                             mergeCodecs: renders => renders.join(', '),
                             mergeTypes: renders => renders.join(' | '),
@@ -377,7 +377,7 @@ export function getTypeManifestVisitor(input: {
 
                 visitHiddenPrefixType(node, { self }) {
                     const manifest = visit(node.type, self);
-                    const prefixes = node.prefix.map(c => visit(c, self).value);
+                    const prefixes = (node.prefix ?? []).map(c => visit(c, self).value);
                     const prefixEncoders = pipe(
                         mergeFragments(prefixes, cs => cs.map(c => `getConstantEncoder(${c})`).join(', ')),
                         f => addFragmentImports(f, 'solanaCodecsCore', ['getConstantEncoder']),
@@ -396,7 +396,7 @@ export function getTypeManifestVisitor(input: {
 
                 visitHiddenSuffixType(node, { self }) {
                     const manifest = visit(node.type, self);
-                    const suffixes = node.suffix.map(c => visit(c, self).value);
+                    const suffixes = (node.suffix ?? []).map(c => visit(c, self).value);
                     const suffixEncoders = pipe(
                         mergeFragments(suffixes, cs => cs.map(c => `getConstantEncoder(${c})`).join(', ')),
                         f => addFragmentImports(f, 'solanaCodecsCore', ['getConstantEncoder']),
@@ -420,7 +420,7 @@ export function getTypeManifestVisitor(input: {
                         strict: nameApi.dataType(instructionDataName),
                     };
                     const link = customInstructionData.get(instruction.name)?.linkNode;
-                    const struct = structTypeNodeFromInstructionArgumentNodes(instruction.arguments);
+                    const struct = structTypeNodeFromInstructionArgumentNodes(instruction.arguments ?? []);
                     const manifest = link ? visit(link, self) : visit(struct, self);
                     parentName = null;
                     return manifest;
@@ -451,7 +451,7 @@ export function getTypeManifestVisitor(input: {
                 },
 
                 visitMapValue(node, { self }) {
-                    const entryFragments = node.entries.map(entry => visit(entry, self));
+                    const entryFragments = (node.entries ?? []).map(entry => visit(entry, self));
                     return mergeTypeManifests(entryFragments, {
                         mergeValues: renders => `new Map([${renders.join(', ')}])`,
                     });
@@ -645,7 +645,7 @@ export function getTypeManifestVisitor(input: {
 
                 visitSetValue(node, { self }) {
                     return mergeTypeManifests(
-                        node.items.map(v => visit(v, self)),
+                        (node.items ?? []).map(v => visit(v, self)),
                         { mergeValues: renders => `new Set([${renders.join(', ')}])` },
                     );
                 },
@@ -748,11 +748,11 @@ export function getTypeManifestVisitor(input: {
                 },
 
                 visitStructType(structType, { self }) {
-                    const optionalFields = structType.fields.filter(f => !!f.defaultValue);
+                    const optionalFields = (structType.fields ?? []).filter(f => !!f.defaultValue);
 
                     const mergedManifest = pipe(
                         mergeTypeManifests(
-                            structType.fields.map(field => visit(field, self)),
+                            (structType.fields ?? []).map(field => visit(field, self)),
                             {
                                 mergeCodecs: renders => `([${renders.join(', ')}])`,
                                 mergeTypes: renders => `{ ${renders.join('')} }`,
@@ -808,13 +808,13 @@ export function getTypeManifestVisitor(input: {
 
                 visitStructValue(node, { self }) {
                     return mergeTypeManifests(
-                        node.fields.map(field => visit(field, self)),
+                        (node.fields ?? []).map(field => visit(field, self)),
                         { mergeValues: renders => `{ ${renders.join(', ')} }` },
                     );
                 },
 
                 visitTupleType(tupleType, { self }) {
-                    const items = tupleType.items.map(item => visit(item, self));
+                    const items = (tupleType.items ?? []).map(item => visit(item, self));
                     const mergedManifest = mergeTypeManifests(items, {
                         mergeCodecs: codecs => `[${codecs.join(', ')}]`,
                         mergeTypes: types => `readonly [${types.join(', ')}]`,
@@ -829,7 +829,7 @@ export function getTypeManifestVisitor(input: {
 
                 visitTupleValue(node, { self }) {
                     return mergeTypeManifests(
-                        node.items.map(v => visit(v, self)),
+                        (node.items ?? []).map(v => visit(v, self)),
                         { mergeValues: renders => `[${renders.join(', ')}]` },
                     );
                 },


### PR DESCRIPTION
This PR upgrades the `@codama/*` dependencies to 1.10 and adapts the renderer to `@codama/nodes@1.10`, whose node array attributes are now optional (`Array<T> | undefined`). Array reads are guarded with `?? []` throughout, and the new `injectedValueNode` and `accountFieldValueNode` instruction-input default kinds now throw an explicit unsupported-node error rather than being silently mishandled.