### PR TITLE
Add versioned release PR titles and trigger maintenance branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Main
 
 on:
   push:
-    branches: [main]
+    branches: [main, '*.x']
   pull_request:
 
 env:
@@ -10,6 +10,7 @@ env:
   DO_NOT_TRACK: '1'
   NODE_VERSION: 20
   SOLANA_VERSION: 2.1.9
+  RELEASE_VERSION: 2.x
 
 jobs:
   lint:
@@ -103,8 +104,8 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          commit: 'Publish package'
-          title: 'Publish package'
+          commit: '[${{ env.RELEASE_VERSION }}] Publish package'
+          title: '[${{ env.RELEASE_VERSION }}] Publish package'
           publish: pnpm publish-package
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR distinguishes the Changesets release PRs per major line by interpolating a new `RELEASE_VERSION` env into the release job's commit and title, mirroring the `CODAMA_VERSION` pattern used in the codama-idl/codama monorepo. On `main` this resolves to the current major (`2.x`), producing a `[2.x] Publish package` release PR that is visually distinct from the maintenance-line release PRs (e.g. `[1.x] Publish package`).

The push trigger now uses `[main, '*.x']` so that `main` plus any maintenance line (`1.x`, `2.x`, ...) can publish from CI, and future maintenance branches are covered automatically. Note that each branch carries its own copy of this workflow (with its own `RELEASE_VERSION`), since GitHub runs the workflow file from the branch being pushed.

No changeset is included because this is a CI/workflow-only change with no effect on the published package.