### PR TITLE
Publish the 1.x line under the release-1.x dist-tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Main
 
 on:
   push:
-    branches: [main, 1.x]
+    branches: [main, '*.x']
   pull_request:
 
 env:

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "dev": "vitest --project node",
         "lint": "eslint . && prettier --check .",
         "lint:fix": "eslint --fix . && prettier --write .",
-        "publish-package": "pnpm build && changeset publish",
+        "publish-package": "pnpm build && changeset publish --tag release-1.x",
         "test": "pnpm test:types && pnpm test:treeshakability && pnpm test:unit && pnpm test:e2e && pnpm test:exports",
         "test:e2e": "./test/e2e/test.sh",
         "test:exports": "node ./test/exports/module.mjs && node ./test/exports/commonjs.cjs",


### PR DESCRIPTION
This PR ensures the `1.x` maintenance line never moves the npm `latest` dist-tag, which belongs to the current major (`2.x`).

`changeset publish` always passes an explicit `--tag` (defaulting to `latest`), which bypasses npm's guardrail against moving `latest` backwards. As a result, publishing a `1.x` release with the default tag clobbers `latest` (as happened with `1.7.1`). The `publish-package` script now publishes under the dedicated `release-1.x` dist-tag instead, so `npm install @codama/renderers-js` keeps resolving to the current major, while `1.x` consumers can opt in via `@codama/renderers-js@release-1.x` or a `^1.7.0` range (semver-range installs never consult dist-tags).

This PR also switches the push trigger to `[main, '*.x']` (the glob the merged `1.x` backport missed), so `main` plus any maintenance line is covered automatically.

No changeset is included because this is a CI/release-infra-only change with no effect on the published package contents.