### PR TITLE
Group type-only imports and fix missing type keyword on PDA seeds imports

### DIFF
--- a/.changeset/plenty-papers-sing.md
+++ b/.changeset/plenty-papers-sing.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-js': patch
+---
+
+Group type-only imports as `import type { ... }` statements so that generated code no longer leaves empty side-effect imports in JavaScript emitted under `verbatimModuleSyntax`, and fix a missing `type` keyword on PDA seeds type imports in account PDA helpers. Consumers regenerating clients will see cosmetic `import { type A }` → `import type { A }` diffs.

--- a/src/fragments/accountPdaHelpers.ts
+++ b/src/fragments/accountPdaHelpers.ts
@@ -50,7 +50,12 @@ export async function ${fetchMaybeFromSeedsFunction}(
   const [address] = await ${findPdaFunction}(${hasVariableSeeds ? 'seeds, ' : ''}{ programAddress });
   return await ${fetchMaybeFunction}(rpc, address, fetchConfig);
 }`,
-        f => addFragmentImports(f, importFrom, hasVariableSeeds ? [pdaSeedsType, findPdaFunction] : [findPdaFunction]),
+        f =>
+            addFragmentImports(
+                f,
+                importFrom,
+                hasVariableSeeds ? [`type ${pdaSeedsType}`, findPdaFunction] : [findPdaFunction],
+            ),
         f => addFragmentImports(f, 'solanaAddresses', ['type Address']),
         f =>
             addFragmentImports(f, 'solanaAccounts', [

--- a/src/utils/importMap.ts
+++ b/src/utils/importMap.ts
@@ -147,11 +147,17 @@ export function importMapToString(
             return a.localeCompare(b);
         })
         .map(([module, imports]) => {
-            const innerImports = [...imports.values()]
-                .map(importInfoToString)
+            const importInfos = [...imports.values()];
+            // When every import of a module is type-only, we can use a single
+            // `import type` statement. This ensures the statement is fully erased
+            // from the emitted JavaScript under `verbatimModuleSyntax`, instead of
+            // leaving an empty `import {} from '...'` side-effect statement behind.
+            const isTypeOnlyModule = importInfos.length > 0 && importInfos.every(({ isType }) => isType);
+            const innerImports = importInfos
+                .map(importInfo => importInfoToString(importInfo, isTypeOnlyModule))
                 .sort((a, b) => a.localeCompare(b))
                 .join(', ');
-            return `import { ${innerImports} } from '${module}';`;
+            return `import ${isTypeOnlyModule ? 'type ' : ''}{ ${innerImports} } from '${module}';`;
         })
         .join('\n');
 }
@@ -198,7 +204,10 @@ function resolveImportMapModules(
     );
 }
 
-function importInfoToString({ importedIdentifier, isType, usedIdentifier }: ImportInfo): string {
+function importInfoToString(
+    { importedIdentifier, isType, usedIdentifier }: ImportInfo,
+    omitTypeKeyword: boolean = false,
+): string {
     const alias = importedIdentifier !== usedIdentifier ? ` as ${usedIdentifier}` : '';
-    return `${isType ? 'type ' : ''}${importedIdentifier}${alias}`;
+    return `${isType && !omitTypeKeyword ? 'type ' : ''}${importedIdentifier}${alias}`;
 }

--- a/test/_setup.ts
+++ b/test/_setup.ts
@@ -162,13 +162,13 @@ export function fragmentDoesNotContainImports(
 }
 
 export async function codeContainsImports(actual: string, expectedImports: Record<string, string[]>): Promise<void> {
-    const normalizedActual = await inlineCode(actual);
+    const actualImports = await getImportPairs(actual);
     const importPairs = Object.entries(expectedImports).flatMap(([key, value]) => {
         return value.map(v => [key, v] as const);
     });
 
-    importPairs.forEach(([importFrom, importValue]) => {
-        expect(normalizedActual).toMatch(new RegExp(`import{[^}]*\\b${importValue}\\b[^}]*}from'${importFrom}'`));
+    importPairs.forEach(importPair => {
+        expect(actualImports).toContainEqual(importPair);
     });
 }
 
@@ -176,14 +176,28 @@ export async function codeDoesNotContainImports(
     actual: string,
     expectedImports: Record<string, string[]>,
 ): Promise<void> {
-    const normalizedActual = await inlineCode(actual);
+    const actualImports = await getImportPairs(actual);
     const importPairs = Object.entries(expectedImports).flatMap(([key, value]) => {
         return value.map(v => [key, v] as const);
     });
 
-    importPairs.forEach(([importFrom, importValue]) => {
-        expect(normalizedActual).not.toMatch(new RegExp(`import{[^}]*\\b${importValue}\\b[^}]*}from'${importFrom}'`));
+    importPairs.forEach(importPair => {
+        expect(actualImports).not.toContainEqual(importPair);
     });
+}
+
+async function getImportPairs(code: string): Promise<(readonly [string, string])[]> {
+    const normalizedCode = await inlineCode(code);
+    return [...normalizedCode.matchAll(/import( type)?\{([^}]*)\}from'([^']+)'/g)].flatMap(
+        ([_, typeKeyword, imports, importFrom]) =>
+            imports
+                .split(',')
+                .filter(Boolean)
+                .map(importValue => {
+                    const canonicalImportValue = typeKeyword ? `type ${importValue}` : importValue;
+                    return [importFrom, canonicalImportValue] as const;
+                }),
+    );
 }
 
 export function codeStringAsRegex(code: string): RegExp {

--- a/test/accountsPage.test.ts
+++ b/test/accountsPage.test.ts
@@ -17,6 +17,7 @@ import {
     publicKeyTypeNode,
     structFieldTypeNode,
     structTypeNode,
+    variablePdaSeedNode,
 } from '@codama/nodes';
 import { visit } from '@codama/visitors-core';
 import { test } from 'vitest';
@@ -41,6 +42,27 @@ test('it renders PDA helpers for PDA with no seeds', async () => {
         'export async function fetchFooFromSeeds',
         'export async function fetchMaybeFooFromSeeds',
         'await findBarPda({ programAddress })',
+    ]);
+});
+
+test('it renders PDA helpers for PDA with variable seeds', async () => {
+    // Given the following program with 1 account and 1 pda with a variable seed.
+    const node = programNode({
+        accounts: [accountNode({ name: 'foo', pda: pdaLinkNode('bar') })],
+        name: 'myProgram',
+        pdas: [pdaNode({ name: 'bar', seeds: [variablePdaSeedNode('owner', publicKeyTypeNode())] })],
+        publicKey: '1111',
+    });
+
+    // When we render it.
+    const renderMap = visit(node, getRenderMapVisitor());
+
+    // Then we expect the seeds type to be imported as a type-only import
+    // so that the generated code is compatible with `verbatimModuleSyntax`.
+    await renderMapContains(renderMap, 'accounts/foo.ts', [
+        "import { findBarPda, type BarSeeds } from '../pdas'",
+        'seeds: BarSeeds',
+        'await findBarPda(seeds, { programAddress })',
     ]);
 });
 

--- a/test/e2e/dummy/src/generated/instructions/instruction1.ts
+++ b/test/e2e/dummy/src/generated/instructions/instruction1.ts
@@ -6,7 +6,7 @@
  * @see https://github.com/codama-idl/codama
  */
 
-import { type AccountMeta, type Address, type Instruction, type InstructionWithAccounts } from '@solana/kit';
+import type { AccountMeta, Address, Instruction, InstructionWithAccounts } from '@solana/kit';
 import { DUMMY_PROGRAM_ADDRESS } from '../programs';
 
 export type Instruction1Instruction<

--- a/test/fragments/programPlugin.test.ts
+++ b/test/fragments/programPlugin.test.ts
@@ -68,7 +68,7 @@ test('it renders program plugin account types', async () => {
 
     // And we expect the necessary imports to be included.
     await fragmentContainsImports(fragment, {
-        '@solana/program-client-core': ['SelfFetchFunctions'],
+        '@solana/program-client-core': ['type SelfFetchFunctions'],
     });
 });
 
@@ -92,7 +92,7 @@ test('it renders program plugin instruction types', async () => {
 
     // And we expect the necessary imports to be included.
     await fragmentContainsImports(fragment, {
-        '@solana/program-client-core': ['SelfPlanAndSendFunctions'],
+        '@solana/program-client-core': ['type SelfPlanAndSendFunctions'],
     });
 });
 
@@ -240,7 +240,7 @@ test('it renders the program plugin function', async () => {
     // And we expect the necessary imports to be included.
     await fragmentContainsImports(fragment, {
         '../accounts': ['getMintCodec'],
-        '@solana/kit': ['ExtendedClient', 'extendClient'],
+        '@solana/kit': ['type ExtendedClient', 'extendClient'],
         '@solana/program-client-core': ['addSelfFetchFunctions', 'addSelfPlanAndSendFunctions'],
     });
 });

--- a/test/instructionsPage.test.ts
+++ b/test/instructionsPage.test.ts
@@ -546,7 +546,7 @@ test('it renders instruction accounts with inlined PDAs from another program as 
             '}',
     ]);
     await renderMapContainsImports(renderMap, 'instructions/increment.ts', {
-        '@solana/kit': ['Address', 'getProgramDerivedAddress'],
+        '@solana/kit': ['type Address', 'getProgramDerivedAddress'],
     });
 });
 

--- a/test/links/definedType.test.ts
+++ b/test/links/definedType.test.ts
@@ -51,7 +51,7 @@ test('it imports types and functions from the linked type', async () => {
 
     // And we expect the following imports.
     await renderMapContainsImports(renderMap, 'types/metadata.ts', {
-        '.': ['Symbol', 'SymbolArgs', 'getSymbolEncoder', 'getSymbolDecoder'],
+        '.': ['type Symbol', 'type SymbolArgs', 'getSymbolEncoder', 'getSymbolDecoder'],
     });
 });
 
@@ -94,7 +94,7 @@ test('it can override the import of a linked type', async () => {
 
     // And we expect the imports to be overridden.
     await renderMapContainsImports(renderMap, 'types/metadata.ts', {
-        '../../hooked': ['Symbol', 'SymbolArgs', 'getSymbolEncoder', 'getSymbolDecoder'],
+        '../../hooked': ['type Symbol', 'type SymbolArgs', 'getSymbolEncoder', 'getSymbolDecoder'],
     });
 });
 
@@ -140,7 +140,7 @@ test('it knows if an enum value is a scalar enum using link nodes', async () => 
 
     // And we expect the following imports.
     await renderMapContainsImports(renderMap, 'types/person.ts', {
-        '.': ['Direction', 'DirectionArgs', 'getDirectionEncoder', 'getDirectionDecoder'],
+        '.': ['Direction', 'type DirectionArgs', 'getDirectionEncoder', 'getDirectionDecoder'],
     });
 });
 
@@ -186,6 +186,6 @@ test('it knows if an enum value is a data enum using link nodes', async () => {
 
     // And we expect the following imports.
     await renderMapContainsImports(renderMap, 'types/person.ts', {
-        '.': ['Action', 'ActionArgs', 'getActionEncoder', 'getActionDecoder'],
+        '.': ['type Action', 'type ActionArgs', 'getActionEncoder', 'getActionDecoder'],
     });
 });

--- a/test/programsPage.test.ts
+++ b/test/programsPage.test.ts
@@ -35,7 +35,7 @@ test('it renders the program address constant', async () => {
 
     // And we expect the following imports.
     await renderMapContainsImports(renderMap, 'programs/splToken.ts', {
-        '@solana/kit': ['Address'],
+        '@solana/kit': ['type Address'],
     });
 });
 
@@ -103,7 +103,7 @@ test('it renders an function that identifies accounts in a program', async () =>
     await renderMapContainsImports(renderMap, 'programs/splToken.ts', {
         '@solana/kit': [
             'containsBytes',
-            'ReadonlyUint8Array',
+            'type ReadonlyUint8Array',
             'SolanaError',
             'SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_ACCOUNT',
         ],
@@ -178,7 +178,7 @@ test('it renders an function that identifies instructions in a program', async (
 
     // And we expect the following imports.
     await renderMapContainsImports(renderMap, 'programs/splToken.ts', {
-        '@solana/kit': ['containsBytes', 'ReadonlyUint8Array'],
+        '@solana/kit': ['containsBytes', 'type ReadonlyUint8Array'],
     });
 });
 
@@ -316,7 +316,7 @@ test('it renders a function that parses instructions in a program', async () => 
 
     // And we expect the following imports.
     await renderMapContainsImports(renderMap, 'programs/splToken.ts', {
-        '@solana/kit': ['Instruction', 'InstructionWithData', 'ReadonlyUint8Array'],
+        '@solana/kit': ['type Instruction', 'type InstructionWithData', 'type ReadonlyUint8Array'],
     });
 });
 

--- a/test/types/remainderOption.test.ts
+++ b/test/types/remainderOption.test.ts
@@ -30,8 +30,8 @@ test('it renders remainder option codecs', async () => {
             'getOptionDecoder',
             'getAddressEncoder',
             'getAddressDecoder',
-            'Option',
-            'OptionOrNullable',
+            'type Option',
+            'type OptionOrNullable',
         ],
     });
 });

--- a/test/types/solAmount.test.ts
+++ b/test/types/solAmount.test.ts
@@ -25,6 +25,6 @@ test('it renders size prefix codecs', async () => {
 
     // And we expect the following type and codec imports.
     await renderMapContainsImports(renderMap, 'types/myType.ts', {
-        '@solana/kit': ['Lamports', 'getLamportsEncoder', 'getLamportsDecoder', 'getU64Encoder', 'getU64Decoder'],
+        '@solana/kit': ['type Lamports', 'getLamportsEncoder', 'getLamportsDecoder', 'getU64Encoder', 'getU64Decoder'],
     });
 });

--- a/test/types/zeroableOption.test.ts
+++ b/test/types/zeroableOption.test.ts
@@ -36,8 +36,8 @@ test('it renders zeroable option codecs', async () => {
             'getOptionDecoder',
             'getAddressEncoder',
             'getAddressDecoder',
-            'Option',
-            'OptionOrNullable',
+            'type Option',
+            'type OptionOrNullable',
         ],
     });
 });
@@ -67,8 +67,8 @@ test('it renders zeroable option codecs with custom zero values', async () => {
             'getOptionDecoder',
             'getU16Encoder',
             'getU16Decoder',
-            'Option',
-            'OptionOrNullable',
+            'type Option',
+            'type OptionOrNullable',
         ],
     });
 });

--- a/test/utils/importMap.test.ts
+++ b/test/utils/importMap.test.ts
@@ -287,9 +287,24 @@ describe('importMapToString', () => {
         expect(importMapToString(importMap)).toBe("import { import1, import2, import3 } from 'module-a';");
     });
 
-    test('it supports type-only import statements', () => {
+    test('it preserves empty import statements', () => {
+        const importMap = addToImportMap(createImportMap(), 'module-a', []);
+        expect(importMapToString(importMap)).toBe("import {  } from 'module-a';");
+    });
+
+    test('it groups type-only import statements using the `import type` syntax', () => {
         const importMap = addToImportMap(createImportMap(), 'module-a', ['type import1']);
-        expect(importMapToString(importMap)).toBe("import { type import1 } from 'module-a';");
+        expect(importMapToString(importMap)).toBe("import type { import1 } from 'module-a';");
+    });
+
+    test('it groups multiple type-only imports of the same module using the `import type` syntax', () => {
+        const importMap = addToImportMap(createImportMap(), 'module-a', ['type import1', 'type import2']);
+        expect(importMapToString(importMap)).toBe("import type { import1, import2 } from 'module-a';");
+    });
+
+    test('it keeps inline type markers when a module mixes type-only and value imports', () => {
+        const importMap = addToImportMap(createImportMap(), 'module-a', ['import1', 'type import2']);
+        expect(importMapToString(importMap)).toBe("import { import1, type import2 } from 'module-a';");
     });
 
     test('it supports aliased import statements', () => {
@@ -299,7 +314,12 @@ describe('importMapToString', () => {
 
     test('it supports aliased type-only import statements', () => {
         const importMap = addToImportMap(createImportMap(), 'module-a', ['type import1 as alias1']);
-        expect(importMapToString(importMap)).toBe("import { type import1 as alias1 } from 'module-a';");
+        expect(importMapToString(importMap)).toBe("import type { import1 as alias1 } from 'module-a';");
+    });
+
+    test('it supports aliased type-only imports within a mixed module', () => {
+        const importMap = addToImportMap(createImportMap(), 'module-a', ['import1', 'type import2 as alias2']);
+        expect(importMapToString(importMap)).toBe("import { import1, type import2 as alias2 } from 'module-a';");
     });
 
     test('it orders import items alphabetically', () => {
@@ -341,18 +361,18 @@ describe('importMapToString', () => {
 
     test('it replaces placeholder kit packages with their @solana/kit', () => {
         const importMap = addToImportMap(createImportMap(), 'solanaAddresses', ['type Address']);
-        expect(importMapToString(importMap)).toBe("import { type Address } from '@solana/kit';");
+        expect(importMapToString(importMap)).toBe("import type { Address } from '@solana/kit';");
     });
 
     test('it can use granular packages when replacing placeholder kit packages', () => {
         const importMap = addToImportMap(createImportMap(), 'solanaAddresses', ['type Address']);
-        expect(importMapToString(importMap, {}, 'granular')).toBe("import { type Address } from '@solana/addresses';");
+        expect(importMapToString(importMap, {}, 'granular')).toBe("import type { Address } from '@solana/addresses';");
     });
 
     test('it can override the module of placeholder kit packages', () => {
         const importMap = addToImportMap(createImportMap(), 'solanaAddresses', ['type Address']);
         expect(importMapToString(importMap, { solanaAddresses: '@acme/solana-addresses' })).toBe(
-            "import { type Address } from '@acme/solana-addresses';",
+            "import type { Address } from '@acme/solana-addresses';",
         );
     });
 });

--- a/test/utils/setup.test.ts
+++ b/test/utils/setup.test.ts
@@ -1,0 +1,22 @@
+import { describe, test } from 'vitest';
+
+import { codeContainsImports, codeDoesNotContainImports } from '../_setup';
+
+describe('import assertion helpers', () => {
+    test('`type MyType` requires a type-only import', async () => {
+        const expectedImports = { 'my-module': ['type MyType'] };
+        await codeContainsImports("import { type MyType } from 'my-module';", expectedImports);
+        await codeContainsImports("import type { MyType } from 'my-module';", expectedImports);
+        await codeDoesNotContainImports("import { MyType } from 'my-module';", {
+            'my-module': ['type MyType'],
+        });
+    });
+
+    test('`MyType` requires a value import', async () => {
+        const expectedImports = { 'my-module': ['MyType'] };
+        await codeContainsImports("import { MyType } from 'my-module';", expectedImports);
+        await codeDoesNotContainImports("import type { MyType } from 'my-module';", {
+            'my-module': ['MyType'],
+        });
+    });
+});


### PR DESCRIPTION
Two small fixes that make generated clients cleaner under `verbatimModuleSyntax`, which every e2e fixture tsconfig already enables.

## Group type-only imports

When every identifier a generated file imports from a given module is type-only, the import is now rendered as a single `import type { ... }` statement rather than inlining a `type` marker on each specifier. The two forms are equivalent to the type checker, but they differ in what TypeScript emits: under `verbatimModuleSyntax` the inline form erases the specifiers and leaves an empty `import {} from '...'` side-effect statement behind in the emitted JavaScript, while the grouped form is erased entirely. Modules that mix value and type imports keep the existing inline form, since only a fully type-only group can be hoisted to `import type`.

## Fix the PDA seeds type import

`getAccountPdaHelpersFragment` imported the PDA seeds type (e.g. `BarSeeds`) without a `type` keyword, even though it is only ever referenced in type position on the `seeds` parameter. Any generated client with an account linked to a PDA that has variable seeds therefore failed to compile with TS1484 under `verbatimModuleSyntax`. The identifier is now imported as `type BarSeeds`; `mergeImportMaps` already lets a value import win over a type import, so this stays correct if the same name is also needed as a value.

## Notes for consumers

Regenerating a client will produce cosmetic `import { type A }` → `import type { A }` diffs. No runtime behavior changes.

The checked-in e2e fixtures were regenerated as part of this change to keep CI's clean-working-tree invariant satisfied; the only resulting diff is a single import statement in the dummy client.

## Related work

Part of #180 — running generated clients natively on Node.js 24+ TypeScript (type stripping), with no separate compilation step:

- #176: `import type` grouping and the missing `type` keyword fix (`verbatimModuleSyntax` polish)
- #177: `importExtension` option — explicit `.js`/`.ts` extensions on relative imports
- #178: `erasableSyntax` option — erasable replacements for generated `enum` declarations
- #179: `modern` e2e fixture generated with both options (draft, stacked on #177 and #178)
