### PR TITLE
fix: forward program address to linked PDA default values

### DIFF
--- a/.changeset/small-emus-happen.md
+++ b/.changeset/small-emus-happen.md
@@ -1,0 +1,11 @@
+---
+'@codama/renderers-js': minor
+---
+
+Forward the program address to linked PDA default values in async instruction builders
+
+Instruction accounts defaulting to a linked PDA were derived by calling the generated `find*Pda()` function with no config, so the derivation always used the address baked into that function and silently ignored the `programAddress` passed to the instruction builder. Programs deployed at different addresses per cluster produced instructions aimed at the overridden program with PDAs derived from the original one.
+
+Async builders now pass `{ programAddress }` through to the find function when the PDA is derived from the instruction's own program, matching what the generated `fetch*FromSeeds` account helpers already did. PDAs owned by another program, or pinned to an explicit program ID, keep their own address.
+
+This changes generated output for any client with a same-program linked PDA default, so regenerate after upgrading. PDA finders supplied through `linkOverrides.pdas` are called with the same signature as generated ones, so they must accept a trailing `config: { programAddress?: Address }` argument.

--- a/src/fragments/instructionFunction.ts
+++ b/src/fragments/instructionFunction.ts
@@ -29,7 +29,7 @@ import { getInstructionRemainingAccountsFragment } from './instructionRemainingA
 export function getInstructionFunctionFragment(
     scope: Pick<
         RenderScope,
-        'asyncResolvers' | 'customInstructionData' | 'getImportFrom' | 'nameApi' | 'typeManifestVisitor'
+        'asyncResolvers' | 'customInstructionData' | 'getImportFrom' | 'linkables' | 'nameApi' | 'typeManifestVisitor'
     > & {
         dataArgsManifest: TypeManifest;
         extraArgsManifest: TypeManifest;

--- a/src/fragments/instructionInputDefault.ts
+++ b/src/fragments/instructionInputDefault.ts
@@ -1,7 +1,22 @@
 /* eslint-disable no-case-declarations */
-import { camelCase, InstructionInputValueNode, isNode, OptionalAccountStrategy } from '@codama/nodes';
+import {
+    camelCase,
+    InstructionInputValueNode,
+    InstructionNode,
+    isNode,
+    isNodeFilter,
+    OptionalAccountStrategy,
+    PdaNode,
+} from '@codama/nodes';
 import { mapFragmentContent, setFragmentContent } from '@codama/renderers-core';
-import { pipe, ResolvedInstructionInput, visit } from '@codama/visitors-core';
+import {
+    findProgramNodeFromPath,
+    getLastNodeFromPath,
+    NodePath,
+    pipe,
+    ResolvedInstructionInput,
+    visit,
+} from '@codama/visitors-core';
 
 import {
     addFragmentFeatures,
@@ -15,14 +30,24 @@ import {
 } from '../utils';
 
 export function getInstructionInputDefaultFragment(
-    scope: Pick<RenderScope, 'asyncResolvers' | 'getImportFrom' | 'nameApi' | 'typeManifestVisitor'> & {
+    scope: Pick<RenderScope, 'asyncResolvers' | 'getImportFrom' | 'linkables' | 'nameApi' | 'typeManifestVisitor'> & {
         input: ResolvedInstructionInput;
+        instructionPath: NodePath<InstructionNode>;
         optionalAccountStrategy: OptionalAccountStrategy;
         useAsync: boolean;
     },
 ): Fragment {
-    const { input, optionalAccountStrategy, asyncResolvers, useAsync, nameApi, typeManifestVisitor, getImportFrom } =
-        scope;
+    const {
+        input,
+        instructionPath,
+        optionalAccountStrategy,
+        asyncResolvers,
+        useAsync,
+        nameApi,
+        linkables,
+        typeManifestVisitor,
+        getImportFrom,
+    } = scope;
     if (!input.defaultValue) {
         return fragment``;
     }
@@ -138,6 +163,7 @@ export function getInstructionInputDefaultFragment(
 
             // Linked PDA value.
             const pdaFunction = use(nameApi.pdaFindFunction(defaultValue.pda.name), getImportFrom(defaultValue.pda));
+            const pdaPath = linkables.getPath([...instructionPath, defaultValue.pda]);
             const pdaArgs: Fragment[] = [];
             const pdaSeeds = (defaultValue.seeds ?? []).map((seed): Fragment => {
                 if (isNode(seed.value, 'accountValueNode')) {
@@ -156,11 +182,13 @@ export function getInstructionInputDefaultFragment(
                 mergeFragments(pdaSeeds, renders => renders.join(', ')),
                 f => mapFragmentContent(f, c => `{ ${c} }`),
             );
-            if (pdaSeeds.length > 0) {
+            if (pdaSeeds.length > 0 || hasVariablePdaSeeds(pdaPath)) {
                 pdaArgs.push(pdaSeedsFragment);
             }
             if (pdaProgramValue) {
                 pdaArgs.push(fragment`{ programAddress: ${pdaProgramValue} }`);
+            } else if (isPdaDerivedFromInstructionProgram(pdaPath, instructionPath)) {
+                pdaArgs.push(fragment`{ programAddress }`);
             }
             return defaultFragment(fragment`await ${pdaFunction}(${mergeFragments(pdaArgs, c => c.join(', '))})`);
 
@@ -286,4 +314,33 @@ function renderNestedInstructionDefault(
         ...scope,
         input: { ...input, defaultValue },
     });
+}
+
+/**
+ * Whether a linked PDA is derived from the same program as the instruction using it.
+ *
+ * When it is, the generated find function bakes in that program's address as its default,
+ * so the instruction must forward its own — possibly overridden — program address to keep
+ * the derivation in sync with the program the instruction is sent to. PDAs owned by another
+ * program, or pinned to an explicit program ID, keep their own default instead.
+ */
+function isPdaDerivedFromInstructionProgram(
+    pdaPath: NodePath<PdaNode> | undefined,
+    instructionPath: NodePath<InstructionNode>,
+): boolean {
+    if (!pdaPath || getLastNodeFromPath(pdaPath).programId) return false;
+    const pdaProgram = findProgramNodeFromPath(pdaPath);
+    const instructionProgram = findProgramNodeFromPath(instructionPath);
+    return !!pdaProgram && !!instructionProgram && pdaProgram.name === instructionProgram.name;
+}
+
+/**
+ * Whether a linked PDA takes a seeds argument on its generated find function.
+ *
+ * The seeds argument comes first, so it must be rendered — even with no seed values to fill
+ * it — for any following argument to land in the right position.
+ */
+function hasVariablePdaSeeds(pdaPath: NodePath<PdaNode> | undefined): boolean {
+    if (!pdaPath) return false;
+    return (getLastNodeFromPath(pdaPath).seeds ?? []).some(isNodeFilter('variablePdaSeedNode'));
 }

--- a/src/fragments/instructionInputResolved.ts
+++ b/src/fragments/instructionInputResolved.ts
@@ -6,7 +6,7 @@ import { Fragment, fragment, mergeFragments, RenderScope } from '../utils';
 import { getInstructionInputDefaultFragment } from './instructionInputDefault';
 
 export function getInstructionInputResolvedFragment(
-    scope: Pick<RenderScope, 'asyncResolvers' | 'getImportFrom' | 'nameApi' | 'typeManifestVisitor'> & {
+    scope: Pick<RenderScope, 'asyncResolvers' | 'getImportFrom' | 'linkables' | 'nameApi' | 'typeManifestVisitor'> & {
         instructionPath: NodePath<InstructionNode>;
         resolvedInputs: ResolvedInstructionInput[];
         useAsync: boolean;

--- a/test/e2e/anchor/src/generated/instructions/createGuard.ts
+++ b/test/e2e/anchor/src/generated/instructions/createGuard.ts
@@ -248,9 +248,10 @@ export async function getCreateGuardInstructionAsync<
 
     // Resolve default values.
     if (!accounts.guard.value) {
-        accounts.guard.value = await findGuardPda({
-            mint: getAddressFromResolvedInstructionAccount('mint', accounts.mint.value),
-        });
+        accounts.guard.value = await findGuardPda(
+            { mint: getAddressFromResolvedInstructionAccount('mint', accounts.mint.value) },
+            { programAddress },
+        );
     }
     if (!accounts.tokenProgram.value) {
         accounts.tokenProgram.value =

--- a/test/e2e/anchor/src/generated/instructions/execute.ts
+++ b/test/e2e/anchor/src/generated/instructions/execute.ts
@@ -172,9 +172,10 @@ export async function getExecuteInstructionAsync<
 
     // Resolve default values.
     if (!accounts.extraMetasAccount.value) {
-        accounts.extraMetasAccount.value = await findExtraMetasAccountPda({
-            mint: getAddressFromResolvedInstructionAccount('mint', accounts.mint.value),
-        });
+        accounts.extraMetasAccount.value = await findExtraMetasAccountPda(
+            { mint: getAddressFromResolvedInstructionAccount('mint', accounts.mint.value) },
+            { programAddress },
+        );
     }
     if (!accounts.instructionSysvarAccount.value) {
         accounts.instructionSysvarAccount.value =

--- a/test/e2e/anchor/src/generated/instructions/initialize.ts
+++ b/test/e2e/anchor/src/generated/instructions/initialize.ts
@@ -159,9 +159,10 @@ export async function getInitializeInstructionAsync<
 
     // Resolve default values.
     if (!accounts.extraMetasAccount.value) {
-        accounts.extraMetasAccount.value = await findExtraMetasAccountPda({
-            mint: getAddressFromResolvedInstructionAccount('mint', accounts.mint.value),
-        });
+        accounts.extraMetasAccount.value = await findExtraMetasAccountPda(
+            { mint: getAddressFromResolvedInstructionAccount('mint', accounts.mint.value) },
+            { programAddress },
+        );
     }
     if (!accounts.systemProgram.value) {
         accounts.systemProgram.value =

--- a/test/e2e/anchor/src/generated/instructions/updateGuard.ts
+++ b/test/e2e/anchor/src/generated/instructions/updateGuard.ts
@@ -201,9 +201,10 @@ export async function getUpdateGuardInstructionAsync<
 
     // Resolve default values.
     if (!accounts.guard.value) {
-        accounts.guard.value = await findGuardPda({
-            mint: getAddressFromResolvedInstructionAccount('mint', accounts.mint.value),
-        });
+        accounts.guard.value = await findGuardPda(
+            { mint: getAddressFromResolvedInstructionAccount('mint', accounts.mint.value) },
+            { programAddress },
+        );
     }
     if (!accounts.tokenProgram.value) {
         accounts.tokenProgram.value =

--- a/test/e2e/token/src/generated/instructions/createAssociatedToken.ts
+++ b/test/e2e/token/src/generated/instructions/createAssociatedToken.ts
@@ -165,11 +165,14 @@ export async function getCreateAssociatedTokenInstructionAsync<
             'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' as Address<'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'>;
     }
     if (!accounts.ata.value) {
-        accounts.ata.value = await findAssociatedTokenPda({
-            owner: getAddressFromResolvedInstructionAccount('owner', accounts.owner.value),
-            tokenProgram: getAddressFromResolvedInstructionAccount('tokenProgram', accounts.tokenProgram.value),
-            mint: getAddressFromResolvedInstructionAccount('mint', accounts.mint.value),
-        });
+        accounts.ata.value = await findAssociatedTokenPda(
+            {
+                owner: getAddressFromResolvedInstructionAccount('owner', accounts.owner.value),
+                tokenProgram: getAddressFromResolvedInstructionAccount('tokenProgram', accounts.tokenProgram.value),
+                mint: getAddressFromResolvedInstructionAccount('mint', accounts.mint.value),
+            },
+            { programAddress },
+        );
     }
     if (!accounts.systemProgram.value) {
         accounts.systemProgram.value =

--- a/test/e2e/token/src/generated/instructions/createAssociatedTokenIdempotent.ts
+++ b/test/e2e/token/src/generated/instructions/createAssociatedTokenIdempotent.ts
@@ -165,11 +165,14 @@ export async function getCreateAssociatedTokenIdempotentInstructionAsync<
             'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' as Address<'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'>;
     }
     if (!accounts.ata.value) {
-        accounts.ata.value = await findAssociatedTokenPda({
-            owner: getAddressFromResolvedInstructionAccount('owner', accounts.owner.value),
-            tokenProgram: getAddressFromResolvedInstructionAccount('tokenProgram', accounts.tokenProgram.value),
-            mint: getAddressFromResolvedInstructionAccount('mint', accounts.mint.value),
-        });
+        accounts.ata.value = await findAssociatedTokenPda(
+            {
+                owner: getAddressFromResolvedInstructionAccount('owner', accounts.owner.value),
+                tokenProgram: getAddressFromResolvedInstructionAccount('tokenProgram', accounts.tokenProgram.value),
+                mint: getAddressFromResolvedInstructionAccount('mint', accounts.mint.value),
+            },
+            { programAddress },
+        );
     }
     if (!accounts.systemProgram.value) {
         accounts.systemProgram.value =

--- a/test/e2e/token/src/generated/instructions/recoverNestedAssociatedToken.ts
+++ b/test/e2e/token/src/generated/instructions/recoverNestedAssociatedToken.ts
@@ -187,37 +187,46 @@ export async function getRecoverNestedAssociatedTokenInstructionAsync<
             'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' as Address<'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'>;
     }
     if (!accounts.ownerAssociatedAccountAddress.value) {
-        accounts.ownerAssociatedAccountAddress.value = await findAssociatedTokenPda({
-            owner: getAddressFromResolvedInstructionAccount('walletAddress', accounts.walletAddress.value),
-            tokenProgram: getAddressFromResolvedInstructionAccount('tokenProgram', accounts.tokenProgram.value),
-            mint: getAddressFromResolvedInstructionAccount(
-                'ownerTokenMintAddress',
-                accounts.ownerTokenMintAddress.value,
-            ),
-        });
+        accounts.ownerAssociatedAccountAddress.value = await findAssociatedTokenPda(
+            {
+                owner: getAddressFromResolvedInstructionAccount('walletAddress', accounts.walletAddress.value),
+                tokenProgram: getAddressFromResolvedInstructionAccount('tokenProgram', accounts.tokenProgram.value),
+                mint: getAddressFromResolvedInstructionAccount(
+                    'ownerTokenMintAddress',
+                    accounts.ownerTokenMintAddress.value,
+                ),
+            },
+            { programAddress },
+        );
     }
     if (!accounts.nestedAssociatedAccountAddress.value) {
-        accounts.nestedAssociatedAccountAddress.value = await findAssociatedTokenPda({
-            owner: getAddressFromResolvedInstructionAccount(
-                'ownerAssociatedAccountAddress',
-                accounts.ownerAssociatedAccountAddress.value,
-            ),
-            tokenProgram: getAddressFromResolvedInstructionAccount('tokenProgram', accounts.tokenProgram.value),
-            mint: getAddressFromResolvedInstructionAccount(
-                'nestedTokenMintAddress',
-                accounts.nestedTokenMintAddress.value,
-            ),
-        });
+        accounts.nestedAssociatedAccountAddress.value = await findAssociatedTokenPda(
+            {
+                owner: getAddressFromResolvedInstructionAccount(
+                    'ownerAssociatedAccountAddress',
+                    accounts.ownerAssociatedAccountAddress.value,
+                ),
+                tokenProgram: getAddressFromResolvedInstructionAccount('tokenProgram', accounts.tokenProgram.value),
+                mint: getAddressFromResolvedInstructionAccount(
+                    'nestedTokenMintAddress',
+                    accounts.nestedTokenMintAddress.value,
+                ),
+            },
+            { programAddress },
+        );
     }
     if (!accounts.destinationAssociatedAccountAddress.value) {
-        accounts.destinationAssociatedAccountAddress.value = await findAssociatedTokenPda({
-            owner: getAddressFromResolvedInstructionAccount('walletAddress', accounts.walletAddress.value),
-            tokenProgram: getAddressFromResolvedInstructionAccount('tokenProgram', accounts.tokenProgram.value),
-            mint: getAddressFromResolvedInstructionAccount(
-                'nestedTokenMintAddress',
-                accounts.nestedTokenMintAddress.value,
-            ),
-        });
+        accounts.destinationAssociatedAccountAddress.value = await findAssociatedTokenPda(
+            {
+                owner: getAddressFromResolvedInstructionAccount('walletAddress', accounts.walletAddress.value),
+                tokenProgram: getAddressFromResolvedInstructionAccount('tokenProgram', accounts.tokenProgram.value),
+                mint: getAddressFromResolvedInstructionAccount(
+                    'nestedTokenMintAddress',
+                    accounts.nestedTokenMintAddress.value,
+                ),
+            },
+            { programAddress },
+        );
     }
 
     const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');

--- a/test/instructionsPage.test.ts
+++ b/test/instructionsPage.test.ts
@@ -19,12 +19,14 @@ import {
     instructionNode,
     numberTypeNode,
     numberValueNode,
+    pdaLinkNode,
     pdaNode,
     pdaSeedValueNode,
     pdaValueNode,
     programNode,
     publicKeyTypeNode,
     resolverValueNode,
+    rootNode,
     stringTypeNode,
     stringValueNode,
     variablePdaSeedNode,
@@ -208,7 +210,7 @@ test('it renders instruction accounts with linked PDAs as default value', async 
     // Then we expect the following default value to be rendered.
     await renderMapContains(renderMap, 'instructions/increment.ts', [
         'if (!accounts.counter.value) { ' +
-            "accounts.counter.value = await findCounterPda( { authority: getAddressFromResolvedInstructionAccount ( 'authority', accounts.authority.value ) } ); " +
+            "accounts.counter.value = await findCounterPda( { authority: getAddressFromResolvedInstructionAccount ( 'authority', accounts.authority.value ) }, { programAddress } ); " +
             '}',
     ]);
     await renderMapContainsImports(renderMap, 'instructions/increment.ts', { '../pdas': ['findCounterPda'] });
@@ -260,6 +262,138 @@ test('it renders instruction accounts with linked PDA default values that point 
             '}',
     ]);
     await renderMapContainsImports(renderMap, 'instructions/increment.ts', { '../pdas': ['findCounterPda'] });
+});
+
+test('it does not render the program address for linked PDA default values that belong to another program', async () => {
+    // Given the following program with an instruction account using a PDA from another program as default value.
+    const node = rootNode(
+        programNode({
+            instructions: [
+                instructionNode({
+                    accounts: [
+                        instructionAccountNode({
+                            defaultValue: pdaValueNode(pdaLinkNode('counter', 'myOtherProgram')),
+                            isSigner: false,
+                            isWritable: false,
+                            name: 'counter',
+                        }),
+                    ],
+                    name: 'increment',
+                }),
+            ],
+            name: 'myProgram',
+            publicKey: '1111',
+        }),
+        [
+            programNode({
+                name: 'myOtherProgram',
+                pdas: [pdaNode({ name: 'counter', seeds: [] })],
+                publicKey: '2222',
+            }),
+        ],
+    );
+
+    // When we render it.
+    const renderMap = visit(node, getRenderMapVisitor());
+
+    // Then we expect the PDA function to keep its own program address.
+    await renderMapContains(renderMap, 'instructions/increment.ts', [
+        'if (!accounts.counter.value) { accounts.counter.value = await findCounterPda(); }',
+    ]);
+});
+
+test('it does not render the program address for linked PDA default values with an explicit program ID', async () => {
+    // Given the following program with a PDA node pinned to an explicit program ID.
+    const node = programNode({
+        instructions: [
+            instructionNode({
+                accounts: [
+                    instructionAccountNode({
+                        defaultValue: pdaValueNode('counter'),
+                        isSigner: false,
+                        isWritable: false,
+                        name: 'counter',
+                    }),
+                ],
+                name: 'increment',
+            }),
+        ],
+        name: 'counter',
+        pdas: [pdaNode({ name: 'counter', programId: '2222', seeds: [] })],
+        publicKey: '1111',
+    });
+
+    // When we render it.
+    const renderMap = visit(node, getRenderMapVisitor());
+
+    // Then we expect the PDA function to keep its own program address.
+    await renderMapContains(renderMap, 'instructions/increment.ts', [
+        'if (!accounts.counter.value) { accounts.counter.value = await findCounterPda(); }',
+    ]);
+});
+
+test('it renders instruction arguments with linked PDA default values that forward the program address', async () => {
+    // Given the following program with an instruction argument using a PDA as default value.
+    const node = programNode({
+        instructions: [
+            instructionNode({
+                arguments: [
+                    instructionArgumentNode({
+                        defaultValue: pdaValueNode('counter'),
+                        name: 'counterAddress',
+                        type: publicKeyTypeNode(),
+                    }),
+                ],
+                name: 'increment',
+            }),
+        ],
+        name: 'counter',
+        pdas: [pdaNode({ name: 'counter', seeds: [] })],
+        publicKey: '1111',
+    });
+
+    // When we render it.
+    const renderMap = visit(node, getRenderMapVisitor());
+
+    // Then we expect the argument default to use the program address of the instruction.
+    await renderMapContains(renderMap, 'instructions/increment.ts', [
+        'if (!args.counterAddress) { args.counterAddress = await findCounterPda({ programAddress }); }',
+    ]);
+});
+
+test('it renders the seeds argument of linked PDA default values that provide no seed values', async () => {
+    // Given the following program with a PDA node whose seeds are not filled by the default value.
+    const node = programNode({
+        instructions: [
+            instructionNode({
+                accounts: [
+                    instructionAccountNode({
+                        defaultValue: pdaValueNode('counter'),
+                        isSigner: false,
+                        isWritable: false,
+                        name: 'counter',
+                    }),
+                ],
+                name: 'increment',
+            }),
+        ],
+        name: 'counter',
+        pdas: [
+            pdaNode({
+                name: 'counter',
+                seeds: [variablePdaSeedNode('authority', publicKeyTypeNode())],
+            }),
+        ],
+        publicKey: '1111',
+    });
+
+    // When we render it.
+    const renderMap = visit(node, getRenderMapVisitor());
+
+    // Then we expect the seeds argument to keep its position before the program address.
+    await renderMapContains(renderMap, 'instructions/increment.ts', [
+        'if (!accounts.counter.value) { accounts.counter.value = await findCounterPda({}, { programAddress }); }',
+    ]);
 });
 
 test('it renders instruction accounts with inlined PDAs as default value', async () => {

--- a/test/links/pda.test.ts
+++ b/test/links/pda.test.ts
@@ -37,7 +37,7 @@ test('it imports functions from the linked pda', async () => {
     const renderMap = visit(node, getRenderMapVisitor());
 
     // Then we expect the following to be exported.
-    await renderMapContains(renderMap, 'instructions/createCounter.ts', ['await findCounterPda()']);
+    await renderMapContains(renderMap, 'instructions/createCounter.ts', ['await findCounterPda({ programAddress })']);
 
     // And we expect the following imports.
     await renderMapContainsImports(renderMap, 'instructions/createCounter.ts', {
@@ -76,8 +76,10 @@ test('it can override the import of a linked account', async () => {
         }),
     );
 
-    // Then we expect the following to be exported.
-    await renderMapContains(renderMap, 'instructions/createCounter.ts', ['await findCounterPda()']);
+    // Then we expect the following to be exported. Note that overridden PDA finders are called
+    // with the same signature as generated ones, meaning they must accept a trailing
+    // `config: { programAddress?: Address }` argument.
+    await renderMapContains(renderMap, 'instructions/createCounter.ts', ['await findCounterPda({ programAddress })']);
 
     // And we expect the imports to be overridden.
     await renderMapContainsImports(renderMap, 'instructions/createCounter.ts', {


### PR DESCRIPTION
## Problem

Instruction accounts defaulting to a **linked** PDA were rendered as `await findFooPda(seeds)` — no config. Since `findFooPda` bakes in `pdaNode.programId ?? programNode.publicKey`, passing `{ programAddress }` to the instruction builder produced an instruction aimed at the override with PDAs derived from the original address.

Visible in the SPL clients today: `getCreateAssociatedTokenInstructionAsync(input, { programAddress })` derives the ATA under `ATokenGPv…` regardless.

Ref: https://github.com/solana-program/token/blob/f5285693a93135a144e24859c84d26ac20037a3a/clients/js/src/generated/instructions/createAssociatedToken.ts#L160-L173

## Fix

Forward `{ programAddress }` to the find function when the linked PDA is derived from the instruction's own program. PDAs owned by another program, or pinned via an explicit `pdaNode.programId`, keep their own address.

This removes an inconsistency rather than adding behavior — the inlined-PDA branch already defaults to `programAddress`, and `fetch*FromSeeds` already forwards it.

## Notes

- Changes generated output for any client with a same-program linked PDA default; regenerate after upgrading.
- `linkOverrides.pdas` finders must now accept a trailing `config: { programAddress?: Address }`.
- Regenerated `test/e2e/anchor` + `test/e2e/token`.
- Pre-existing on `main`, untouched here: 5 eslint errors in `test/e2e/dummy/test/instructions.test.ts`.