### PR TITLE
Restrict release triggers to numeric major branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: Main
 
 on:
   push:
-    branches: ['*.x']
+    branches: ['[0-9]+.x']
   pull_request:
-    branches: ['*.x']
+    branches: ['[0-9]+.x']
 
 concurrency:
   group: main-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This PR tightens the workflow branch filters from `'*.x'` to `'[0-9]+.x'` so that only major branches (`1.x`, `2.x`, …) trigger CI pushes and the release job. The previous glob also matched any slashless branch ending in `.x`, which caused the changesets action to open a release PR against a working branch in the spec repo (codama-idl/spec#103).