### PR TITLE
Restore main as the bleeding-edge branch

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,6 +6,6 @@
   ],
   "commit": false,
   "access": "public",
-  "baseBranch": "2.x",
+  "baseBranch": "main",
   "updateInternalDependencies": "patch"
 }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: Main
 
 on:
   push:
-    branches: ['[0-9]+.x']
+    branches: [main, '[0-9]+.x']
   pull_request:
-    branches: ['[0-9]+.x']
+    branches: [main, '[0-9]+.x']
 
 concurrency:
   group: main-${{ github.workflow }}-${{ github.ref }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing
+
+Thanks for your interest in contributing to `@codama/renderers-js`.
+
+## Getting set up
+
+You'll need Node.js and pnpm (see `engines` and `packageManager` in
+`package.json`). Then:
+
+```sh
+pnpm install
+pnpm build
+pnpm test
+pnpm lint
+```
+
+## Declaring release intent
+
+Any PR that ships a change to npm needs a changeset:
+
+```sh
+pnpm changeset
+```
+
+Pick the bump level (`patch` / `minor` / `major`), write a short user-facing
+summary, and commit the resulting `.changeset/*.md` alongside your code.
+
+## Releasing
+
+Patch and minor releases are automated: merging a PR with a changeset into
+`main` makes the release workflow open (or update) a release PR, and merging
+that release PR publishes the package to npm.
+
+Major releases follow the ecosystem-wide process described in the spec
+repository's [RELEASING.md](https://github.com/codama-idl/spec/blob/HEAD/RELEASING.md)
+(branch model, npm dist-tag conventions, release candidates, the bake window,
+and the cross-repo release train).


### PR DESCRIPTION
This PR follows the branch rename back to `main`, reverting the mainless experiment in favour of a permanent `main` branch: `.changeset/config.json` points back at `main` and the workflow triggers accept `main` alongside the numeric major-branch pattern. It also adds the repository's missing `CONTRIBUTING.md`, documenting the day-to-day flow and linking the ecosystem-wide release process.